### PR TITLE
Replace bridge with TC redirect for VM networking

### DIFF
--- a/hypervisor/cloudhypervisor/console.go
+++ b/hypervisor/cloudhypervisor/console.go
@@ -14,14 +14,14 @@ import (
 // For direct-boot VMs (OCI):    opens the virtio-console PTY allocated by CH.
 //
 // The endpoint is stored in VM.ConsolePath at start time.
-// The caller is responsible for closing the returned ReadCloser.
-func (ch *CloudHypervisor) Console(ctx context.Context, ref string) (io.ReadCloser, error) {
+// The caller is responsible for closing the returned ReadWriteCloser.
+func (ch *CloudHypervisor) Console(ctx context.Context, ref string) (io.ReadWriteCloser, error) {
 	info, err := ch.Inspect(ctx, ref)
 	if err != nil {
 		return nil, err
 	}
 
-	var conn io.ReadCloser
+	var conn io.ReadWriteCloser
 	if err := ch.withRunningVM(info.ID, func(_ int) error {
 		path := info.ConsolePath
 		if path == "" {

--- a/hypervisor/hypervisor.go
+++ b/hypervisor/hypervisor.go
@@ -26,7 +26,7 @@ type Hypervisor interface {
 	Inspect(ctx context.Context, ref string) (*types.VM, error)
 	List(context.Context) ([]*types.VM, error)
 	Delete(ctx context.Context, refs []string, force bool) ([]string, error)
-	Console(ctx context.Context, ref string) (io.ReadCloser, error)
+	Console(ctx context.Context, ref string) (io.ReadWriteCloser, error)
 
 	// TODO SNAPSHOT
 	// TODO RESTORE

--- a/network/cni/config_darwin.go
+++ b/network/cni/config_darwin.go
@@ -12,6 +12,6 @@ func deleteNetns(_ string) error {
 	return errNotSupported
 }
 
-func setupTCRedirect(_, _, _ string) error {
-	return errNotSupported
+func setupTCRedirect(_, _, _ string) (string, error) {
+	return "", errNotSupported
 }


### PR DESCRIPTION
## Summary

Replace the per-NIC Linux bridge (`eth0 → br0 → tap0`) with TC ingress mirred redirect (`eth0 ↔ tap0`), following the industry-standard pattern used by [awslabs/tc-redirect-tap](https://github.com/awslabs/tc-redirect-tap) and Kata Containers.

## What changed

### Network data plane: bridge → TC redirect

**Before:** Each NIC created 3 kernel objects (eth0, br0, tap0) with a MAC learning disable hack to prevent ARP reply misrouting.

**After:** Each NIC creates 2 kernel objects (eth0, tap0) wired by TC ingress qdisc + U32 catch-all filter + mirred `EGRESS_REDIR` action with `TC_ACT_STOLEN`. Bidirectional: eth0 ingress → tap0 egress, tap0 ingress → eth0 egress.

### MAC address alignment

Replaced `utils.GenerateMAC()` (random MAC) with capturing `eth0`'s actual HardwareAddr from CNI and passing it to Cloud Hypervisor's `--net mac=` parameter. This ensures the guest virtio-net MAC matches the CNI veth MAC — required for anti-spoofing CNI plugins (Cilium eBPF, Calico eBPF, AWS VPC ENI CNIs).

### TAP device hardening

- `IFF_VNET_HDR`: Allows kernel to parse virtio_net headers for checksum offload and GSO/GRO.
- `IFF_ONE_QUEUE`: Prevents packet drops on older kernels when the send buffer is full.
- MTU sync: TAP device MTU is explicitly set to match the CNI veth MTU, preventing silent large-packet drops with overlay networks (MTU 1450) or jumbo frames (MTU 9000).

### Console interface fix

Changed `Hypervisor.Console()` return type from `io.ReadCloser` to `io.ReadWriteCloser` to match actual usage (`net.Conn` and `*os.File` are both ReadWriteCloser).

## Files changed

| File | Change |
|------|--------|
| `network/cni/config_linux.go` | `bridgeTapInNS` → `tcRedirectInNS` + `addTCRedirect` helper |
| `network/cni/config.go` | Remove `brName`, use MAC from `setupTCRedirect` instead of `GenerateMAC` |
| `network/cni/config_darwin.go` | Signature sync |
| `hypervisor/hypervisor.go` | `Console` → `io.ReadWriteCloser` |
| `hypervisor/cloudhypervisor/console.go` | Implementation sync |

## Verification

```bash
# No bridge device, only eth0 + tap0
ip netns exec $NS ip link show

# TC ingress qdisc on both
ip netns exec $NS tc qdisc show

# Bidirectional mirred redirect filters
ip netns exec $NS tc filter show dev eth0 ingress
ip netns exec $NS tc filter show dev tap0 ingress

# MTU aligned
ip netns exec $NS ip link show eth0 | grep mtu
ip netns exec $NS ip link show tap0 | grep mtu

# TAP flags: 0x5802 = TAP + ONE_QUEUE + VNET_HDR (+ CH adds MULTI_QUEUE, NO_PI)
ip netns exec $NS cat /sys/class/net/tap0/tun_flags

# MAC aligned: eth0 MAC = CH --net mac=
ip netns exec $NS cat /sys/class/net/eth0/address
ps -ef | grep cloud-hyp | grep -o 'mac=[^,]*'

# Guest connectivity
ping -c3 <gateway>
ping -c3 8.8.8.8
```

All verified on Ubuntu 24.04 host with Cloud Hypervisor v51.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)