### PR TITLE
fix(snapshot): fall back to non-sparse tar when segment map exceeds PAX cap

### DIFF
--- a/utils/tar_sparse_linux.go
+++ b/utils/tar_sparse_linux.go
@@ -11,6 +11,9 @@ import (
 	"strconv"
 )
 
+// Sparse-map JSON cap (margin under tar's 1MB PAX block); var so tests can override.
+var maxSparseMapJSONSize = 800 * 1024
+
 // tarFileMaybeSparse writes a file to tw using our custom COCOON.sparse PAX
 // format when the file has holes (detected via SEEK_HOLE/SEEK_DATA).
 //
@@ -21,6 +24,7 @@ import (
 //   - the file is empty or very small
 //   - SEEK_HOLE/SEEK_DATA fails (unsupported filesystem)
 //   - the file has no holes (not actually sparse)
+//   - the segment-map JSON would exceed tar's 1MB PAX cap
 func tarFileMaybeSparse(tw *tar.Writer, path, nameInTar string) error {
 	f, err := os.Open(path) //nolint:gosec
 	if err != nil {
@@ -41,10 +45,7 @@ func tarFileMaybeSparse(tw *tar.Writer, path, nameInTar string) error {
 	segments, err := scanDataSegments(int(f.Fd()), size)
 	if err != nil {
 		// SEEK_HOLE/SEEK_DATA unsupported (e.g. tmpfs, NFS). Fall back.
-		if _, seekErr := f.Seek(0, io.SeekStart); seekErr != nil {
-			return fmt.Errorf("seek %s: %w", path, seekErr)
-		}
-		return tarFileFrom(tw, f, fi, nameInTar)
+		return rewindAndTarFull(tw, f, fi, path, nameInTar)
 	}
 
 	var dataSize int64
@@ -52,15 +53,17 @@ func tarFileMaybeSparse(tw *tar.Writer, path, nameInTar string) error {
 		dataSize += seg.Length
 	}
 	if dataSize == size {
-		if _, seekErr := f.Seek(0, io.SeekStart); seekErr != nil {
-			return fmt.Errorf("seek %s: %w", path, seekErr)
-		}
-		return tarFileFrom(tw, f, fi, nameInTar)
+		return rewindAndTarFull(tw, f, fi, path, nameInTar)
 	}
 
 	mapJSON, err := json.Marshal(segments)
 	if err != nil {
 		return fmt.Errorf("marshal sparse map for %s: %w", path, err)
+	}
+
+	// Segment-map JSON exceeds tar's 1MB PAX cap. Fall back to non-sparse.
+	if len(mapJSON) > maxSparseMapJSONSize {
+		return rewindAndTarFull(tw, f, fi, path, nameInTar)
 	}
 
 	hdr, err := tar.FileInfoHeader(fi, "")
@@ -88,4 +91,12 @@ func tarFileMaybeSparse(tw *tar.Writer, path, nameInTar string) error {
 	}
 
 	return nil
+}
+
+// rewindAndTarFull seeks f to the start and writes it as a non-sparse tar entry.
+func rewindAndTarFull(tw *tar.Writer, f *os.File, fi os.FileInfo, path, nameInTar string) error {
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("seek %s: %w", path, err)
+	}
+	return tarFileFrom(tw, f, fi, nameInTar)
 }

--- a/utils/tar_sparse_linux_test.go
+++ b/utils/tar_sparse_linux_test.go
@@ -1,0 +1,142 @@
+//go:build linux
+
+package utils
+
+import (
+	"archive/tar"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeSparseFile alternates numSegments data regions of blockSize with equal-sized holes.
+func writeSparseFile(t *testing.T, path string, numSegments, blockSize int) int64 {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close() //nolint:errcheck
+	for i := range numSegments {
+		offset := int64(i) * int64(blockSize) * 2
+		data := bytes.Repeat([]byte{byte((i % 250) + 1)}, blockSize)
+		if _, err := f.WriteAt(data, offset); err != nil {
+			t.Fatal(err)
+		}
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fi.Size()
+}
+
+// Segment-map JSON over the cap → tarFileMaybeSparse falls back to non-sparse.
+func TestTarFileMaybeSparse_FallsBackOnLargeMap(t *testing.T) {
+	orig := maxSparseMapJSONSize
+	maxSparseMapJSONSize = 4 * 1024
+	t.Cleanup(func() { maxSparseMapJSONSize = orig })
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "memory-ranges")
+	logicalSize := writeSparseFile(t, path, 200, 4096)
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := tarFileMaybeSparse(tw, path, "memory-ranges"); err != nil {
+		t.Fatalf("tarFileMaybeSparse: %v (expected fallback to succeed)", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	tr := tar.NewReader(&buf)
+	hdr, err := tr.Next()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hdr.Name != "memory-ranges" {
+		t.Fatalf("name = %q, want memory-ranges", hdr.Name)
+	}
+	if _, ok := hdr.PAXRecords[paxSparseMap]; ok {
+		t.Errorf("PAX %s present, expected non-sparse fallback", paxSparseMap)
+	}
+	if hdr.Size != logicalSize {
+		t.Errorf("hdr.Size = %d, want logical size %d", hdr.Size, logicalSize)
+	}
+}
+
+// Fallback round-trip: extracted file matches the original byte-for-byte (holes serialised as zeros).
+func TestTarFileMaybeSparse_FallbackRoundTrip(t *testing.T) {
+	orig := maxSparseMapJSONSize
+	maxSparseMapJSONSize = 4 * 1024
+	t.Cleanup(func() { maxSparseMapJSONSize = orig })
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "memory-ranges")
+	writeSparseFile(t, path, 200, 4096)
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := tarFileMaybeSparse(tw, path, "memory-ranges"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := t.TempDir()
+	if err := ExtractTar(dst, &buf); err != nil {
+		t.Fatalf("ExtractTar: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dst, "memory-ranges"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("extracted content differs (len got=%d want=%d)", len(got), len(want))
+	}
+}
+
+// Small fragmentation still takes the sparse path; fallback only on PAX overflow.
+func TestTarFileMaybeSparse_PreservesSparsePathForSmallMaps(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "small-sparse")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteAt(bytes.Repeat([]byte{0xAA}, 4096), 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteAt(bytes.Repeat([]byte{0xBB}, 4096), 1<<20); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := tarFileMaybeSparse(tw, path, "small-sparse"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	tr := tar.NewReader(&buf)
+	hdr, err := tr.Next()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := hdr.PAXRecords[paxSparseMap]; !ok {
+		t.Errorf("expected sparse PAX record for small fragmentation, got none")
+	}
+}


### PR DESCRIPTION
Fixes #24.

## Summary

`cocoon snapshot export` fails with `archive/tar: header field too long` when `memory-ranges` is highly fragmented. The cause is Go's `archive/tar` 1MB cap (`maxSpecialFileSize = 1<<20`, see `archive/tar/format.go`) on the encoded PAX block — our sparse encoding packs the whole segment list into a single `COCOON.sparse.map` PAX record, and a sufficiently fragmented file produces a JSON that overflows it.

This fix detects the overflow up front (mapJSON > ~800KB, well under the 1MB cap) and falls back to writing the file as a regular non-sparse tar entry. Memory-ranges can be GB-scale, so we lose the sparse-export size advantage on the affected file, but a larger successful push beats an indefinite hung loop. Reader path is unchanged — the fallback emits a standard tar entry that existing extract logic handles via the non-sparse path.

## Repro

Run a cocoon Windows VM with simular-pro-agent-runtime 1.8.0 (an Electron app with a live Firebase WebSocket). The agent's V8 heap + IPC buffers + WebSocket pools fragment the guest memory enough that memory-ranges yields tens of thousands of sparse segments; the JSON exceeds 1MB.

```
$ sudo cocoon snapshot save --name probe-realjwt <vmid>
INF snapshotting VM <vmid> ...
INF saving snapshot data ...
INF snapshot saved: <id>
$ sudo cocoon snapshot export probe-realjwt -o /tmp/probe.tar
INF exporting to /tmp/probe.tar ...
Error: write archive: write header memory-ranges: archive/tar: header field too long
```

vk-cocoon then loops the push indefinitely (only the metadata blobs reach epoch; the memory layer is never PUT), so vm-service hibernate never observes phase=Suspended and the API caller times out. With this fix, export emits a non-sparse memory-ranges entry and the push completes normally.

Empirical Go-tar limit measured before/after this change:

| segments | mapJSON size | result |
|---|---|---|
| 30,000 | ~736 KB | OK (sparse path) |
| 50,000 | ~1.2 MB | `header field too long` (without fix) → fallback (with fix) |

## Test plan

- [x] `TestTarFileMaybeSparse_FallsBackOnLargeMap` — verifies the fallback triggers when the map exceeds the cap and no PAX sparse records are written.
- [x] `TestTarFileMaybeSparse_FallbackRoundTrip` — extract of a fallback-encoded file matches the original byte-for-byte (including the holes that get serialised as zeros).
- [x] `TestTarFileMaybeSparse_PreservesSparsePathForSmallMaps` — sanity that ordinary fragmentation still uses the sparse encoding.
- [x] Full `utils` package suite passes on linux/amd64 (verified by running the cross-compiled test binary on a cocoon node).

🤖 Generated with [Claude Code](https://claude.com/claude-code)