### PR TITLE
refactor: clone/restore inherit all resources from snapshot

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -11,9 +11,9 @@ After `cocoon vm clone`, the cloned VM resumes with the **original VM's IP addre
 
 **Mitigation**: run the post-clone guest setup commands printed by `cocoon vm clone` as soon as possible (see [Post-Clone Guest Setup](README.md#post-clone-guest-setup)). For cloudimg VMs this means re-running `cloud-init`; for OCI VMs this means `ip addr flush` + reconfigure with the new IP.
 
-## Clone and restore inherit all resources from the snapshot
+## Clone and restore resources are fixed at snapshot time
 
-Both `cocoon vm clone` and `cocoon vm restore` inherit CPU, memory, storage, and NIC count verbatim from the snapshot. Both hypervisors reconstruct the guest from the snapshot's binary device state, so changing any of these at clone/restore time would not be honored. Use `cocoon vm run` to create a fresh VM with different sizing.
+`cocoon vm clone` inherits CPU, memory, storage, and NIC count from the snapshot — none of them can be grown at clone time. `cocoon vm restore` is more restrictive: CPU, memory, and storage come from the snapshot (the persisted record is realigned to match), and NIC count must already match the target VM (mismatches are rejected, since restore reuses the existing network namespace). Both hypervisors reconstruct the guest from the snapshot's binary device state, so changing any of these would not be honored. Use `cocoon vm run` to create a fresh VM with different sizing.
 
 ## Restore requires a running VM
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -58,21 +58,6 @@ This is by design: clone restores the VM's exact state including all account set
 
 Race window: `cocoon vm run X && cocoon vm exec X -- cmd` may fail with `read CONNECT reply: EOF` if the in-guest agent hasn't started yet. The error includes the hint `(cocoon-agent may still be starting; retry shortly)`. Wait ~5–10s after `vm run` returns.
 
-## Clone/restore CPU and memory cannot grow
-
-`--cpu` and `--memory` on `cocoon vm clone` / `cocoon vm restore` are written into the new VM's `config.json` (cocoon's `patchCHConfig` does its job), but **the guest still sees the snapshot's original vCPU count and memory size**. Cloud Hypervisor's `vm.restore` reconstructs the guest from the binary memory file and saved CPU state — both sized at snapshot time — so a higher value in `config.json` is silently ignored.
-
-| What you set | What `config.json` shows | What the guest sees |
-| --- | --- | --- |
-| `--cpu 4` (snapshot was 2-vCPU) | `boot_vcpus: 4` | `nproc` → 2 |
-| `--memory 2G` (snapshot was 1G) | `memory.size: 2147483648` | `MemTotal` → ~1 GiB |
-
-The disk `num_queues` follows vCPU count and is part of the virtio-blk device state, so it stays at the snapshot's value too. `--disk-queue-size` (ring depth) is software-only and **is** correctly patched on clone/restore.
-
-**Consequence**: clone/restore with grown `--cpu`/`--memory` boots successfully but the new resource ceiling is invisible to the guest kernel. Workloads sized for the requested target will not get the headroom they expect.
-
-**Workaround**: none — this is a CH architectural limitation (no hot-add of vCPU or memory at restore time). Create a fresh VM (`vm run` / `vm create`) with the desired CPU/memory if scaling beyond the snapshot's size is required.
-
 ## Cloud image UEFI boot compatibility
 
 Cocoon uses [rust-hypervisor-firmware](https://github.com/cloud-hypervisor/rust-hypervisor-firmware) (`CLOUDHV.fd`) for cloud image UEFI boot. This firmware implements a minimal EFI specification and does **not** support the `InstallMultipleProtocolInterfaces()` call required by newer distributions.
@@ -197,7 +182,6 @@ Firecracker snapshots store absolute host paths in the vmstate binary (Rust serd
 
 - **Same-host clone/restore**: works without restrictions
 - **Cross-host export/import**: requires the target host to use **identical `root_dir` and `run_dir`** (default: `/var/lib/cocoon` and `/var/lib/cocoon/run`) and have the **same OCI image pulled**
-- **CPU/memory overrides**: not supported on clone/restore — Firecracker cannot change machine config after snapshot/load; `--cpu` and `--memory` flags are rejected if they differ from the snapshot values
 - **Drive path redirect**: Cocoon uses a temporary symlink to redirect the source COW path to the clone's COW during `snapshot/load`. This requires a COW flock to serialize with concurrent operations
 
 This is a fundamental Firecracker design limitation. Cloud Hypervisor snapshots do not have this restriction because CH stores device config in a patchable JSON format (`config.json`).

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -11,9 +11,9 @@ After `cocoon vm clone`, the cloned VM resumes with the **original VM's IP addre
 
 **Mitigation**: run the post-clone guest setup commands printed by `cocoon vm clone` as soon as possible (see [Post-Clone Guest Setup](README.md#post-clone-guest-setup)). For cloudimg VMs this means re-running `cloud-init`; for OCI VMs this means `ip addr flush` + reconfigure with the new IP.
 
-## Clone resource constraints
+## Clone and restore inherit all resources from the snapshot
 
-Clone resources (CPU, memory, storage, NICs) can only be **increased**, never decreased below the snapshot's original values. See [Clone Constraints](README.md#clone-constraints) for details.
+Both `cocoon vm clone` and `cocoon vm restore` inherit CPU, memory, storage, and NIC count verbatim from the snapshot. Both hypervisors reconstruct the guest from the snapshot's binary device state, so changing any of these at clone/restore time would not be honored. Use `cocoon vm run` to create a fresh VM with different sizing.
 
 ## Restore requires a running VM
 

--- a/README.md
+++ b/README.md
@@ -226,9 +226,10 @@ Applies to `cocoon vm restore`:
 | `--from-dir`  | empty   | Restore from a snapshot directory (must contain `snapshot.json`); mutually exclusive with positional `SNAPSHOT` |
 | `--force`     | `false` | Skip the snapshot-belongs-to-VM check (only meaningful with `--from-dir`)                              |
 
-All resources (CPU, memory, storage, NIC count) are inherited from the
-target VM and the snapshot — they must already match. Restore reuses the
-existing network namespace.
+CPU, memory, and storage come from the snapshot (the hypervisor
+reconstructs the guest from snapshot state, so the persisted record is
+realigned to match). NIC count must match the target VM — restore reuses
+its existing network namespace, TAP devices, and IP allocation.
 
 ### Snapshot Flags
 
@@ -744,8 +745,9 @@ Cocoon stages the snapshot into a scratch directory first, then restarts the hyp
 ### Restore Constraints
 
 - **VM must be running.** Restore operates on a live VM by restarting its CH process with snapshot state. For stopped VMs, use `cocoon vm clone` instead.
-- **Snapshot must belong to the VM.** Only snapshots created from the same VM (tracked in `snapshot_ids`) are accepted. Cross-VM restore is not supported; use `cocoon vm clone` for that.
-- **All resources are fixed at snapshot values.** CPU, memory, storage, and NIC count cannot be changed on restore — both hypervisors reconstruct the guest from the snapshot's binary device state.
+- **Snapshot must belong to the VM.** Only snapshots created from the same VM (tracked in `snapshot_ids`) are accepted; pass `--force` with `--from-dir` to opt into a foreign lineage.
+- **CPU, memory, and storage come from the snapshot.** The hypervisor reconstructs the guest from snapshot state, so these are not configurable at restore time; cocoon realigns the persisted record to match.
+- **NIC count must match the target VM.** Restore reuses the VM's existing network namespace, TAP devices, and IP allocation; a mismatched count is rejected.
 
 ## Status Monitoring
 

--- a/README.md
+++ b/README.md
@@ -650,7 +650,7 @@ A snapshot contains the full VM state:
 - **Memory**: complete RAM contents (memory-ranges)
 - **Disks**: COW disk (raw or qcow2), cidata disk (cloudimg)
 - **Config**: Cloud Hypervisor config.json and device state (state.json)
-- **Metadata**: image reference, hypervisor type, network/queue settings
+- **Metadata**: image reference, hypervisor type, network/queue settings, and resource topology (CPU, memory, storage, NIC count) — recorded for inspection and reuse at clone/restore but not overridable on those paths
 
 ### Clone Constraints
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Lightweight MicroVM engine with dual hypervisor backends: [Cloud Hypervisor](htt
 - **Memory balloon** — 25% of memory returned via virtio-balloon (deflate-on-OOM, free-page reporting) when memory >= 256 MiB
 - **Graceful shutdown** — ACPI power-button for UEFI VMs with configurable timeout, fallback to SIGTERM → SIGKILL
 - **Interactive console** — `cocoon vm console` with bidirectional PTY relay, SSH-style escape sequences (`~.` disconnect, `~?` help), configurable escape character, SIGWINCH propagation
-- **Snapshot & clone** — `cocoon snapshot save` captures a running VM's full state (memory, disks, config); `cocoon vm clone` restores it as a new VM with fresh network and identity; CPU/memory inherit from the snapshot, storage and NIC count can be grown
+- **Snapshot & clone** — `cocoon snapshot save` captures a running VM's full state (memory, disks, config); `cocoon vm clone` restores it as a new VM with fresh network and identity; all resources (CPU, memory, storage, NIC count) inherit verbatim from the snapshot
 - **Snapshot export & import** — `cocoon snapshot export` packages a snapshot into a portable `.tar.gz` archive (with sparse-aware pax headers); `cocoon snapshot import` restores it on another host or cluster; supports piping via stdout/stdin for direct host-to-host transfer; `--to-dir` writes a directory form (with `snapshot.json` envelope) for NFS / rsync-friendly handoff
 - **Clone / restore from a directory** — `cocoon vm clone --from-dir DIR` and `cocoon vm restore --from-dir DIR` consume any directory containing a `snapshot.json` envelope without first registering the snapshot in the local DB; the dir is treated as read-only so multi-VM golden-image use cases work without copying
 - **Live status monitoring** — `cocoon vm status` watches VM state changes in real time via fsnotify, with refresh mode (top-like) and event-stream mode (append-only, for scripting and vk-cocoon integration)
@@ -204,14 +204,17 @@ Applies to `cocoon vm clone`:
 | Flag        | Default                  | Description                                             |
 | ----------- | ------------------------ | ------------------------------------------------------- |
 | `--name`    | `cocoon-clone-<id>`      | VM name                                                 |
-| `--storage` | empty (inherit)          | COW disk size (must be >= snapshot value)                |
-| `--nics`    | `0` (inherit)            | Number of NICs (must be >= snapshot value)               |
 | `--queue-size` | `0` (inherit)         | Virtio-net ring depth per queue (0 = inherit from snapshot) |
 | `--disk-queue-size` | `0` (inherit)    | Virtio-blk ring depth per device (0 = inherit from snapshot; CH only) |
 | `--network` | empty (inherit)          | CNI conflist name (empty = inherit from source VM)       |
 | `--bridge`  | empty                    | TAP-on-bridge mode (value is bridge device); mutually exclusive with `--network` |
 | `--no-direct-io` | `false` (inherit)  | Disable O_DIRECT on writable disks (inherit from snapshot if not set) |
 | `--pull`  | `false`              | Auto-pull base image if not found locally (for cross-node clone)      |
+
+CPU, memory, storage, and NIC count all inherit from the snapshot — both
+hypervisors restore the guest from the snapshot's binary device state, so
+those values are fixed at snapshot time. Use `cocoon vm run` to create a
+fresh VM with different resources.
 
 ### Snapshot Flags
 
@@ -619,8 +622,8 @@ cocoon snapshot list
 # 3. Clone a new VM from the snapshot
 cocoon vm clone my-snap
 
-# 4. Clone with a larger COW disk
-cocoon vm clone --name big-clone --storage 20G my-snap
+# 4. Clone with a custom name
+cocoon vm clone --name fresh-clone my-snap
 
 # 5. Delete a snapshot
 cocoon snapshot rm my-snap
@@ -632,12 +635,11 @@ A snapshot contains the full VM state:
 - **Memory**: complete RAM contents (memory-ranges)
 - **Disks**: COW disk (raw or qcow2), cidata disk (cloudimg)
 - **Config**: Cloud Hypervisor config.json and device state (state.json)
-- **Metadata**: image reference, storage/NIC count for resource inheritance
+- **Metadata**: image reference, hypervisor type, network/queue settings
 
 ### Clone Constraints
 
-- **CPU and memory are inherited verbatim from the snapshot.** Both hypervisors reconstruct the guest from the snapshot's binary memory image, so changing them at clone time would not be honored.
-- **Storage and NIC count can be increased, not decreased.** Clone validates them >= the snapshot's original values. Omitting a flag inherits the snapshot value.
+All resources (CPU, memory, storage, NIC count) are fixed at snapshot time. Both hypervisors reconstruct the guest from the snapshot's binary device state, so growing any of them at clone time would not be honored. Clone always uses the snapshot's resource topology; create a fresh VM with `cocoon vm run` if different sizing is needed.
 
 ### Post-Clone Guest Setup
 
@@ -721,9 +723,6 @@ Restore reverts a **running** VM to a previous snapshot's state in-place:
 ```bash
 # Restore a VM to a previous snapshot
 cocoon vm restore my-vm my-snap
-
-# Restore with a larger COW disk (must be >= snapshot value)
-cocoon vm restore --storage 20G my-vm my-snap
 ```
 
 Cocoon stages the snapshot into a scratch directory first, then restarts the hypervisor process only after the full extraction succeeds — a truncated or corrupt snapshot stream errors out with the running VM still intact. Network is fully preserved — same IP, same MAC, same network namespace. No guest-side reconfiguration is needed (unlike clone).
@@ -732,8 +731,7 @@ Cocoon stages the snapshot into a scratch directory first, then restarts the hyp
 
 - **VM must be running.** Restore operates on a live VM by restarting its CH process with snapshot state. For stopped VMs, use `cocoon vm clone` instead.
 - **Snapshot must belong to the VM.** Only snapshots created from the same VM (tracked in `snapshot_ids`) are accepted. Cross-VM restore is not supported; use `cocoon vm clone` for that.
-- **NIC count must match.** The VM's current NIC count must equal the snapshot's (restore reuses the VM's existing network, unlike clone which creates fresh NICs and hot-swaps).
-- **CPU and memory are fixed at snapshot values.** Both hypervisors restore the guest from the snapshot's binary memory image, so growing them on restore would not be honored. Storage can be grown.
+- **All resources are fixed at snapshot values.** CPU, memory, storage, and NIC count cannot be changed on restore — both hypervisors reconstruct the guest from the snapshot's binary device state.
 
 ## Status Monitoring
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,20 @@ hypervisors restore the guest from the snapshot's binary device state, so
 those values are fixed at snapshot time. Use `cocoon vm run` to create a
 fresh VM with different resources.
 
+### Restore Flags
+
+Applies to `cocoon vm restore`:
+
+| Flag          | Default | Description                                                                                            |
+| ------------- | ------- | ------------------------------------------------------------------------------------------------------ |
+| `--on-demand` | `false` | Use UFFD on-demand memory loading for faster restore (CH only; snapshot file must remain on disk)      |
+| `--from-dir`  | empty   | Restore from a snapshot directory (must contain `snapshot.json`); mutually exclusive with positional `SNAPSHOT` |
+| `--force`     | `false` | Skip the snapshot-belongs-to-VM check (only meaningful with `--from-dir`)                              |
+
+All resources (CPU, memory, storage, NIC count) are inherited from the
+target VM and the snapshot — they must already match. Restore reuses the
+existing network namespace.
+
 ### Snapshot Flags
 
 Applies to `cocoon snapshot save`:

--- a/README.md
+++ b/README.md
@@ -209,7 +209,9 @@ Applies to `cocoon vm clone`:
 | `--network` | empty (inherit)          | CNI conflist name (empty = inherit from source VM)       |
 | `--bridge`  | empty                    | TAP-on-bridge mode (value is bridge device); mutually exclusive with `--network` |
 | `--no-direct-io` | `false` (inherit)  | Disable O_DIRECT on writable disks (inherit from snapshot if not set) |
+| `--on-demand` | `false`             | Use UFFD on-demand memory loading for faster clone (CH only; snapshot file must remain on disk) |
 | `--pull`  | `false`              | Auto-pull base image if not found locally (for cross-node clone)      |
+| `--from-dir` | empty                | Clone from a snapshot directory (must contain `snapshot.json`); mutually exclusive with positional `SNAPSHOT` |
 
 CPU, memory, storage, and NIC count all inherit from the snapshot — both
 hypervisors restore the guest from the snapshot's binary device state, so

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Lightweight MicroVM engine with dual hypervisor backends: [Cloud Hypervisor](htt
 - **Memory balloon** — 25% of memory returned via virtio-balloon (deflate-on-OOM, free-page reporting) when memory >= 256 MiB
 - **Graceful shutdown** — ACPI power-button for UEFI VMs with configurable timeout, fallback to SIGTERM → SIGKILL
 - **Interactive console** — `cocoon vm console` with bidirectional PTY relay, SSH-style escape sequences (`~.` disconnect, `~?` help), configurable escape character, SIGWINCH propagation
-- **Snapshot & clone** — `cocoon snapshot save` captures a running VM's full state (memory, disks, config); `cocoon vm clone` restores it as a new VM with fresh network and identity, resource inheritance with validation
+- **Snapshot & clone** — `cocoon snapshot save` captures a running VM's full state (memory, disks, config); `cocoon vm clone` restores it as a new VM with fresh network and identity; CPU/memory inherit from the snapshot, storage and NIC count can be grown
 - **Snapshot export & import** — `cocoon snapshot export` packages a snapshot into a portable `.tar.gz` archive (with sparse-aware pax headers); `cocoon snapshot import` restores it on another host or cluster; supports piping via stdout/stdin for direct host-to-host transfer; `--to-dir` writes a directory form (with `snapshot.json` envelope) for NFS / rsync-friendly handoff
 - **Clone / restore from a directory** — `cocoon vm clone --from-dir DIR` and `cocoon vm restore --from-dir DIR` consume any directory containing a `snapshot.json` envelope without first registering the snapshot in the local DB; the dir is treated as read-only so multi-VM golden-image use cases work without copying
 - **Live status monitoring** — `cocoon vm status` watches VM state changes in real time via fsnotify, with refresh mode (top-like) and event-stream mode (append-only, for scripting and vk-cocoon integration)
@@ -204,8 +204,6 @@ Applies to `cocoon vm clone`:
 | Flag        | Default                  | Description                                             |
 | ----------- | ------------------------ | ------------------------------------------------------- |
 | `--name`    | `cocoon-clone-<id>`      | VM name                                                 |
-| `--cpu`     | `0` (inherit)            | Boot CPUs (must be >= snapshot value)                    |
-| `--memory`  | empty (inherit)          | Memory size (must be >= snapshot value)                  |
 | `--storage` | empty (inherit)          | COW disk size (must be >= snapshot value)                |
 | `--nics`    | `0` (inherit)            | Number of NICs (must be >= snapshot value)               |
 | `--queue-size` | `0` (inherit)         | Virtio-net ring depth per queue (0 = inherit from snapshot) |
@@ -552,7 +550,6 @@ cocoon vm clone my-snap --name clone-vm
 | Cloud images (UEFI boot) | Y | N |
 | Windows guests | Y | N |
 | Snapshot / Clone / Restore | Y | Y |
-| CPU/memory override on clone/restore | Y | N |
 | Multi-queue networking | Y | N |
 | Memory balloon | Y | Y |
 | qcow2 storage | Y | N |
@@ -566,7 +563,6 @@ cocoon vm clone my-snap --name clone-vm
 - **OCI images only**: `--fc` is mutually exclusive with `--windows` and rejects cloudimg (UEFI boot) images
 - **Raw disks only**: Firecracker uses raw virtio-blk without serial support; disks are referenced by device path (`/dev/vdX`)
 - **Single-queue networking**: `NetworkConfig.NumQueues` is ignored
-- **No CPU/memory override on clone/restore**: Firecracker cannot change machine config after snapshot/load
 - **Snapshot portability requires same directory layout**: FC snapshots store absolute paths in the vmstate binary (not patchable); cross-host export/import requires the target host to use the same `root_dir`/`run_dir` and have the same OCI image pulled
 - **Console via PTY relay**: a background relay process bridges FC's serial (stdin/stdout) to `console.sock`
 
@@ -623,8 +619,8 @@ cocoon snapshot list
 # 3. Clone a new VM from the snapshot
 cocoon vm clone my-snap
 
-# 4. Clone with more resources
-cocoon vm clone --name big-clone --cpu 4 --memory 4G my-snap
+# 4. Clone with a larger COW disk
+cocoon vm clone --name big-clone --storage 20G my-snap
 
 # 5. Delete a snapshot
 cocoon snapshot rm my-snap
@@ -636,11 +632,12 @@ A snapshot contains the full VM state:
 - **Memory**: complete RAM contents (memory-ranges)
 - **Disks**: COW disk (raw or qcow2), cidata disk (cloudimg)
 - **Config**: Cloud Hypervisor config.json and device state (state.json)
-- **Metadata**: image reference, CPU/memory/storage/NIC count for resource inheritance
+- **Metadata**: image reference, storage/NIC count for resource inheritance
 
 ### Clone Constraints
 
-**Resources can be increased, not decreased.** Clone validates that CPU, memory, storage, and NIC count are >= the snapshot's original values. Omitting a flag (or passing 0) inherits the snapshot value.
+- **CPU and memory are inherited verbatim from the snapshot.** Both hypervisors reconstruct the guest from the snapshot's binary memory image, so changing them at clone time would not be honored.
+- **Storage and NIC count can be increased, not decreased.** Clone validates them >= the snapshot's original values. Omitting a flag inherits the snapshot value.
 
 ### Post-Clone Guest Setup
 
@@ -725,8 +722,8 @@ Restore reverts a **running** VM to a previous snapshot's state in-place:
 # Restore a VM to a previous snapshot
 cocoon vm restore my-vm my-snap
 
-# Restore with more resources (must be >= snapshot values)
-cocoon vm restore --cpu 4 --memory 4G my-vm my-snap
+# Restore with a larger COW disk (must be >= snapshot value)
+cocoon vm restore --storage 20G my-vm my-snap
 ```
 
 Cocoon stages the snapshot into a scratch directory first, then restarts the hypervisor process only after the full extraction succeeds — a truncated or corrupt snapshot stream errors out with the running VM still intact. Network is fully preserved — same IP, same MAC, same network namespace. No guest-side reconfiguration is needed (unlike clone).
@@ -736,7 +733,7 @@ Cocoon stages the snapshot into a scratch directory first, then restarts the hyp
 - **VM must be running.** Restore operates on a live VM by restarting its CH process with snapshot state. For stopped VMs, use `cocoon vm clone` instead.
 - **Snapshot must belong to the VM.** Only snapshots created from the same VM (tracked in `snapshot_ids`) are accepted. Cross-VM restore is not supported; use `cocoon vm clone` for that.
 - **NIC count must match.** The VM's current NIC count must equal the snapshot's (restore reuses the VM's existing network, unlike clone which creates fresh NICs and hot-swaps).
-- **Resources can be increased, not decreased.** CPU, memory, and storage must be >= the snapshot's original values. Omitting a flag keeps the VM's current value.
+- **CPU and memory are fixed at snapshot values.** Both hypervisors restore the guest from the snapshot's binary memory image, so growing them on restore would not be honored. Storage can be grown.
 
 ## Status Monitoring
 

--- a/cmd/core/helpers.go
+++ b/cmd/core/helpers.go
@@ -404,18 +404,21 @@ func CloneVMConfigFromFlags(cmd *cobra.Command, snapCfg types.SnapshotConfig) (*
 	return cfg, nil
 }
 
-// RestoreVMConfigFromFlags builds VMConfig for restore. Resources come from
-// the snapshot (the hypervisor reconstructs the guest from snapshot state, so
-// the persisted record must match), VM identity stays, --from-dir / --force
-// foreign lineages are gated by the NIC-count check.
+// RestoreVMConfigFromFlags builds VMConfig for restore. Guest-state fields
+// come from the snapshot so the persisted record matches what the hypervisor
+// reconstructs; VM-bound fields (Name, Network) stay because the CNI
+// namespace, TAPs and IPs were allocated at create time and survive restore.
+// --from-dir / --force foreign lineages are gated by the NIC-count check.
 func RestoreVMConfigFromFlags(cmd *cobra.Command, vm *types.VM, snapCfg types.SnapshotConfig) (*types.VMConfig, error) {
 	if snapCfg.NICs != len(vm.NetworkConfigs) {
 		return nil, fmt.Errorf("NIC count mismatch: vm has %d, snapshot has %d",
 			len(vm.NetworkConfigs), snapCfg.NICs)
 	}
+	cfg := snapCfg.Config
+	cfg.Network = vm.Config.Network
 	onDemand, _ := cmd.Flags().GetBool("on-demand")
 	return &types.VMConfig{
-		Config:   snapCfg.Config,
+		Config:   cfg,
 		Name:     vm.Config.Name,
 		OnDemand: onDemand,
 	}, nil

--- a/cmd/core/helpers.go
+++ b/cmd/core/helpers.go
@@ -380,8 +380,7 @@ func CloneVMConfigFromFlags(cmd *cobra.Command, snapCfg types.SnapshotConfig) (*
 
 	onDemand, _ := cmd.Flags().GetBool("on-demand")
 
-	// Validate is deferred to prepareClone, which fills the default
-	// "cocoon-clone-<id>" name once vmID has been generated.
+	// Validate runs in prepareClone, after the default name is filled in.
 	return &types.VMConfig{
 		Name: vmName,
 		Config: types.Config{
@@ -402,11 +401,8 @@ func CloneVMConfigFromFlags(cmd *cobra.Command, snapCfg types.SnapshotConfig) (*
 	}, nil
 }
 
-// RestoreVMConfigFromFlags builds VMConfig for restore. Guest-state fields
-// come from the snapshot so the persisted record matches what the hypervisor
-// reconstructs; VM-bound fields (Name, Network) stay because the CNI
-// namespace, TAPs and IPs were allocated at create time and survive restore.
-// --from-dir / --force foreign lineages are gated by the NIC-count check.
+// RestoreVMConfigFromFlags builds VMConfig for restore: resources from the
+// snapshot, Name/Network from the VM (CNI namespace survives restore).
 func RestoreVMConfigFromFlags(cmd *cobra.Command, vm *types.VM, snapCfg types.SnapshotConfig) (*types.VMConfig, error) {
 	if snapCfg.NICs != len(vm.NetworkConfigs) {
 		return nil, fmt.Errorf("NIC count mismatch: vm has %d, snapshot has %d",
@@ -420,8 +416,7 @@ func RestoreVMConfigFromFlags(cmd *cobra.Command, vm *types.VM, snapCfg types.Sn
 		Name:     vm.Config.Name,
 		OnDemand: onDemand,
 	}
-	// Reject tampered / malformed snapshot envelopes (--from-dir --force) before
-	// the bad values reach FinalizeRestore and overwrite the VM record.
+	// Guard against tampered --from-dir --force envelopes.
 	if err := result.Validate(); err != nil {
 		return nil, fmt.Errorf("snapshot config: %w", err)
 	}

--- a/cmd/core/helpers.go
+++ b/cmd/core/helpers.go
@@ -417,11 +417,17 @@ func RestoreVMConfigFromFlags(cmd *cobra.Command, vm *types.VM, snapCfg types.Sn
 	cfg := snapCfg.Config
 	cfg.Network = vm.Config.Network
 	onDemand, _ := cmd.Flags().GetBool("on-demand")
-	return &types.VMConfig{
+	result := &types.VMConfig{
 		Config:   cfg,
 		Name:     vm.Config.Name,
 		OnDemand: onDemand,
-	}, nil
+	}
+	// Reject tampered / malformed snapshot envelopes (--from-dir --force) before
+	// the bad values reach FinalizeRestore and overwrite the VM record.
+	if err := result.Validate(); err != nil {
+		return nil, fmt.Errorf("snapshot config: %w", err)
+	}
+	return result, nil
 }
 
 func EnsureFirmwarePath(conf *config.Config, bootCfg *types.BootConfig) {

--- a/cmd/core/helpers.go
+++ b/cmd/core/helpers.go
@@ -378,11 +378,6 @@ func CloneVMConfigFromFlags(cmd *cobra.Command, snapCfg types.SnapshotConfig) (*
 		noDirectIO, _ = cmd.Flags().GetBool("no-direct-io")
 	}
 
-	storage, err := mergeStorageFlag(cmd, snapCfg.Storage, snapCfg)
-	if err != nil {
-		return nil, err
-	}
-
 	onDemand, _ := cmd.Flags().GetBool("on-demand")
 
 	cfg := &types.VMConfig{
@@ -390,7 +385,7 @@ func CloneVMConfigFromFlags(cmd *cobra.Command, snapCfg types.SnapshotConfig) (*
 		Config: types.Config{
 			CPU:           snapCfg.CPU,
 			Memory:        snapCfg.Memory,
-			Storage:       storage,
+			Storage:       snapCfg.Storage,
 			QueueSize:     queueSize,
 			DiskQueueSize: diskQueueSize,
 			Image:         snapCfg.Image,
@@ -409,19 +404,16 @@ func CloneVMConfigFromFlags(cmd *cobra.Command, snapCfg types.SnapshotConfig) (*
 	return cfg, nil
 }
 
-// RestoreVMConfigFromFlags builds VMConfig for restore (only storage is overridable).
+// RestoreVMConfigFromFlags builds VMConfig for restore. Resources are
+// inherited verbatim from the VM; the snapshot's NIC count must match.
 func RestoreVMConfigFromFlags(cmd *cobra.Command, vm *types.VM, snapCfg types.SnapshotConfig) (*types.VMConfig, error) {
-	result := vm.Config // value copy — keep current VM values
-
-	storage, err := mergeStorageFlag(cmd, result.Storage, snapCfg)
-	if err != nil {
-		return nil, err
+	if snapCfg.NICs != len(vm.NetworkConfigs) {
+		return nil, fmt.Errorf("NIC count mismatch: vm has %d, snapshot has %d",
+			len(vm.NetworkConfigs), snapCfg.NICs)
 	}
-	result.Storage = storage
-
+	result := vm.Config
 	onDemand, _ := cmd.Flags().GetBool("on-demand")
 	result.OnDemand = onDemand
-
 	return &result, nil
 }
 
@@ -566,23 +558,6 @@ func sanitizeVMName(image string) string {
 		n = n[:63]
 	}
 	return n
-}
-
-// mergeStorageFlag resolves --storage for clone/restore: empty keeps current,
-// explicit must be >= snapshot's COW size.
-func mergeStorageFlag(cmd *cobra.Command, storage int64, snapCfg types.SnapshotConfig) (int64, error) {
-	storStr, _ := cmd.Flags().GetString("storage")
-	if storStr != "" {
-		v, err := units.RAMInBytes(storStr)
-		if err != nil {
-			return 0, fmt.Errorf("invalid --storage %q: %w", storStr, err)
-		}
-		storage = v
-	}
-	if storage < snapCfg.Storage {
-		return 0, fmt.Errorf("--storage %s below snapshot minimum %s", FormatSize(storage), FormatSize(snapCfg.Storage))
-	}
-	return storage, nil
 }
 
 // parseDataDiskFlags parses --data-disk values, normalizes defaults, and

--- a/cmd/core/helpers.go
+++ b/cmd/core/helpers.go
@@ -378,7 +378,7 @@ func CloneVMConfigFromFlags(cmd *cobra.Command, snapCfg types.SnapshotConfig) (*
 		noDirectIO, _ = cmd.Flags().GetBool("no-direct-io")
 	}
 
-	cpu, memBytes, storBytes, err := mergeResourceFlags(cmd, snapCfg.CPU, snapCfg.Memory, snapCfg.Storage, snapCfg)
+	storage, err := mergeStorageFlag(cmd, snapCfg.Storage, snapCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -388,9 +388,9 @@ func CloneVMConfigFromFlags(cmd *cobra.Command, snapCfg types.SnapshotConfig) (*
 	cfg := &types.VMConfig{
 		Name: vmName,
 		Config: types.Config{
-			CPU:           cpu,
-			Memory:        memBytes,
-			Storage:       storBytes,
+			CPU:           snapCfg.CPU,
+			Memory:        snapCfg.Memory,
+			Storage:       storage,
 			QueueSize:     queueSize,
 			DiskQueueSize: diskQueueSize,
 			Image:         snapCfg.Image,
@@ -409,17 +409,15 @@ func CloneVMConfigFromFlags(cmd *cobra.Command, snapCfg types.SnapshotConfig) (*
 	return cfg, nil
 }
 
-// RestoreVMConfigFromFlags builds VMConfig for restore (allows overrides).
+// RestoreVMConfigFromFlags builds VMConfig for restore (only storage is overridable).
 func RestoreVMConfigFromFlags(cmd *cobra.Command, vm *types.VM, snapCfg types.SnapshotConfig) (*types.VMConfig, error) {
 	result := vm.Config // value copy — keep current VM values
 
-	cpu, memBytes, storBytes, err := mergeResourceFlags(cmd, result.CPU, result.Memory, result.Storage, snapCfg)
+	storage, err := mergeStorageFlag(cmd, result.Storage, snapCfg)
 	if err != nil {
 		return nil, err
 	}
-	result.CPU = cpu
-	result.Memory = memBytes
-	result.Storage = storBytes
+	result.Storage = storage
 
 	onDemand, _ := cmd.Flags().GetBool("on-demand")
 	result.OnDemand = onDemand
@@ -570,39 +568,21 @@ func sanitizeVMName(image string) string {
 	return n
 }
 
-func mergeResourceFlags(cmd *cobra.Command, cpu int, memory, storage int64, snapCfg types.SnapshotConfig) (int, int64, int64, error) {
-	cpuFlag, _ := cmd.Flags().GetInt("cpu")
-	memStr, _ := cmd.Flags().GetString("memory")
+// mergeStorageFlag resolves --storage for clone/restore: empty keeps current,
+// explicit must be >= snapshot's COW size.
+func mergeStorageFlag(cmd *cobra.Command, storage int64, snapCfg types.SnapshotConfig) (int64, error) {
 	storStr, _ := cmd.Flags().GetString("storage")
-
-	if cpuFlag > 0 {
-		cpu = cpuFlag
-	}
-	if memStr != "" {
-		v, err := units.RAMInBytes(memStr)
-		if err != nil {
-			return 0, 0, 0, fmt.Errorf("invalid --memory %q: %w", memStr, err)
-		}
-		memory = v
-	}
 	if storStr != "" {
 		v, err := units.RAMInBytes(storStr)
 		if err != nil {
-			return 0, 0, 0, fmt.Errorf("invalid --storage %q: %w", storStr, err)
+			return 0, fmt.Errorf("invalid --storage %q: %w", storStr, err)
 		}
 		storage = v
 	}
-
-	if cpu < snapCfg.CPU {
-		return 0, 0, 0, fmt.Errorf("--cpu %d below snapshot minimum %d", cpu, snapCfg.CPU)
-	}
-	if memory < snapCfg.Memory {
-		return 0, 0, 0, fmt.Errorf("--memory %s below snapshot minimum %s", FormatSize(memory), FormatSize(snapCfg.Memory))
-	}
 	if storage < snapCfg.Storage {
-		return 0, 0, 0, fmt.Errorf("--storage %s below snapshot minimum %s", FormatSize(storage), FormatSize(snapCfg.Storage))
+		return 0, fmt.Errorf("--storage %s below snapshot minimum %s", FormatSize(storage), FormatSize(snapCfg.Storage))
 	}
-	return cpu, memory, storage, nil
+	return storage, nil
 }
 
 // parseDataDiskFlags parses --data-disk values, normalizes defaults, and

--- a/cmd/core/helpers.go
+++ b/cmd/core/helpers.go
@@ -404,17 +404,21 @@ func CloneVMConfigFromFlags(cmd *cobra.Command, snapCfg types.SnapshotConfig) (*
 	return cfg, nil
 }
 
-// RestoreVMConfigFromFlags builds VMConfig for restore. Resources are
-// inherited verbatim from the VM; the snapshot's NIC count must match.
+// RestoreVMConfigFromFlags builds VMConfig for restore. Resources come from
+// the snapshot (the hypervisor reconstructs the guest from snapshot state, so
+// the persisted record must match), VM identity stays, --from-dir / --force
+// foreign lineages are gated by the NIC-count check.
 func RestoreVMConfigFromFlags(cmd *cobra.Command, vm *types.VM, snapCfg types.SnapshotConfig) (*types.VMConfig, error) {
 	if snapCfg.NICs != len(vm.NetworkConfigs) {
 		return nil, fmt.Errorf("NIC count mismatch: vm has %d, snapshot has %d",
 			len(vm.NetworkConfigs), snapCfg.NICs)
 	}
-	result := vm.Config
 	onDemand, _ := cmd.Flags().GetBool("on-demand")
-	result.OnDemand = onDemand
-	return &result, nil
+	return &types.VMConfig{
+		Config:   snapCfg.Config,
+		Name:     vm.Config.Name,
+		OnDemand: onDemand,
+	}, nil
 }
 
 func EnsureFirmwarePath(conf *config.Config, bootCfg *types.BootConfig) {

--- a/cmd/core/helpers.go
+++ b/cmd/core/helpers.go
@@ -380,7 +380,9 @@ func CloneVMConfigFromFlags(cmd *cobra.Command, snapCfg types.SnapshotConfig) (*
 
 	onDemand, _ := cmd.Flags().GetBool("on-demand")
 
-	cfg := &types.VMConfig{
+	// Validate is deferred to prepareClone, which fills the default
+	// "cocoon-clone-<id>" name once vmID has been generated.
+	return &types.VMConfig{
 		Name: vmName,
 		Config: types.Config{
 			CPU:           snapCfg.CPU,
@@ -397,11 +399,7 @@ func CloneVMConfigFromFlags(cmd *cobra.Command, snapCfg types.SnapshotConfig) (*
 			SharedMemory:  snapCfg.SharedMemory,
 		},
 		OnDemand: onDemand,
-	}
-	if err := cfg.Validate(); err != nil {
-		return nil, err
-	}
-	return cfg, nil
+	}, nil
 }
 
 // RestoreVMConfigFromFlags builds VMConfig for restore. Guest-state fields

--- a/cmd/vm/commands.go
+++ b/cmd/vm/commands.go
@@ -135,7 +135,6 @@ func Command(h Actions) *cobra.Command {
 		},
 		RunE: h.Restore,
 	}
-	restoreCmd.Flags().String("storage", "", "COW disk size (empty = keep current)")
 	restoreCmd.Flags().Bool("on-demand", false, "use UFFD on-demand memory loading for faster restore (CH only; snapshot file must remain on disk)")
 	restoreCmd.Flags().String("from-dir", "", "restore from a snapshot directory (must contain snapshot.json) instead of the local snapshot DB; mutually exclusive with positional SNAPSHOT")
 	restoreCmd.Flags().Bool("force", false, "skip the snapshot-belongs-to-VM check (only meaningful with --from-dir; risk of restoring to an unrelated lineage)")
@@ -268,8 +267,6 @@ func addVMFlags(cmd *cobra.Command) {
 
 func addCloneFlags(cmd *cobra.Command) {
 	cmd.Flags().String("name", "", "VM name (default: cocoon-clone-<id>)")
-	cmd.Flags().String("storage", "", "COW disk size (empty = inherit from snapshot)")
-	cmd.Flags().Int("nics", 0, "number of NICs (0 = inherit from snapshot)")
 	cmd.Flags().Int("queue-size", 0, "virtio-net ring depth per queue (0 = inherit from snapshot)")       //nolint:mnd
 	cmd.Flags().Int("disk-queue-size", 0, "virtio-blk ring depth per device (0 = inherit from snapshot)") //nolint:mnd
 	cmd.Flags().String("network", "", "CNI conflist name (empty = inherit from source VM)")

--- a/cmd/vm/commands.go
+++ b/cmd/vm/commands.go
@@ -135,8 +135,6 @@ func Command(h Actions) *cobra.Command {
 		},
 		RunE: h.Restore,
 	}
-	restoreCmd.Flags().Int("cpu", 0, "boot CPUs (0 = keep current)")
-	restoreCmd.Flags().String("memory", "", "memory size (empty = keep current)")
 	restoreCmd.Flags().String("storage", "", "COW disk size (empty = keep current)")
 	restoreCmd.Flags().Bool("on-demand", false, "use UFFD on-demand memory loading for faster restore (CH only; snapshot file must remain on disk)")
 	restoreCmd.Flags().String("from-dir", "", "restore from a snapshot directory (must contain snapshot.json) instead of the local snapshot DB; mutually exclusive with positional SNAPSHOT")
@@ -270,8 +268,6 @@ func addVMFlags(cmd *cobra.Command) {
 
 func addCloneFlags(cmd *cobra.Command) {
 	cmd.Flags().String("name", "", "VM name (default: cocoon-clone-<id>)")
-	cmd.Flags().Int("cpu", 0, "boot CPUs (0 = inherit from snapshot)")
-	cmd.Flags().String("memory", "", "memory size (empty = inherit from snapshot)")
 	cmd.Flags().String("storage", "", "COW disk size (empty = inherit from snapshot)")
 	cmd.Flags().Int("nics", 0, "number of NICs (0 = inherit from snapshot)")
 	cmd.Flags().Int("queue-size", 0, "virtio-net ring depth per queue (0 = inherit from snapshot)")       //nolint:mnd

--- a/cmd/vm/run.go
+++ b/cmd/vm/run.go
@@ -1,7 +1,6 @@
 package vm
 
 import (
-	"cmp"
 	"context"
 	"fmt"
 	"slices"
@@ -181,11 +180,6 @@ func (h Handler) Restore(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("snapshot %s does not belong to VM %s", snapRef, vmRef)
 	}
 
-	if snapInfo.NICs != len(vm.NetworkConfigs) {
-		return fmt.Errorf("NIC count mismatch: vm has %d, snapshot has %d",
-			len(vm.NetworkConfigs), snapInfo.NICs)
-	}
-
 	vmCfg, err := cmdcore.RestoreVMConfigFromFlags(cmd, vm, snapInfo.SnapshotConfig)
 	if err != nil {
 		return err
@@ -247,10 +241,6 @@ func (h Handler) restoreFromDir(ctx context.Context, cmd *cobra.Command, conf *c
 			return fmt.Errorf("snapshot envelope id %s does not belong to VM %s; pass --force to override", cfg.ID, vmRef)
 		}
 		logger.Warnf(ctx, "snapshot envelope id %s does not belong to VM %s; --force in effect", cfg.ID, vmRef)
-	}
-	if cfg.NICs != len(vm.NetworkConfigs) {
-		return fmt.Errorf("NIC count mismatch: vm has %d, snapshot has %d",
-			len(vm.NetworkConfigs), cfg.NICs)
 	}
 	vmCfg, err := cmdcore.RestoreVMConfigFromFlags(cmd, vm, cfg)
 	if err != nil {
@@ -357,22 +347,8 @@ func (h Handler) prepareClone(ctx context.Context, cmd *cobra.Command, conf *con
 		cmdcore.EnsureImage(ctx, backends, vmCfg)
 	}
 
-	// FC snapshot/load cannot change CPU, memory, or NIC count.
-	// Reject overrides early before creating network/dirs.
-	if conf.UseFirecracker {
-		if validateErr := validateFCCloneOverrides(cmd, cfg); validateErr != nil {
-			return nil, "", nil, nil, validateErr
-		}
-	}
-
-	nicsFlag, _ := cmd.Flags().GetInt("nics")
-	nics := cmp.Or(nicsFlag, cfg.NICs)
-	if nics < cfg.NICs {
-		return nil, "", nil, nil, fmt.Errorf("--nics %d below snapshot minimum %d", nics, cfg.NICs)
-	}
-
 	bridgeDev, _ := cmd.Flags().GetString("bridge")
-	netProvider, networkConfigs, err := initNetwork(ctx, conf, vmID, nics, vmCfg, tapQueues(vmCfg.CPU, conf.UseFirecracker), bridgeDev)
+	netProvider, networkConfigs, err := initNetwork(ctx, conf, vmID, cfg.NICs, vmCfg, tapQueues(vmCfg.CPU, conf.UseFirecracker), bridgeDev)
 	if err != nil {
 		return nil, "", nil, nil, err
 	}
@@ -630,19 +606,6 @@ func printOCINetworkHints(vm *types.VM, networkConfigs []*types.NetworkConfig) {
 	}
 
 	fmt.Println("  systemctl restart systemd-networkd")
-}
-
-func validateFCCloneOverrides(cmd *cobra.Command, cfg types.SnapshotConfig) error {
-	if cpuFlag, _ := cmd.Flags().GetInt("cpu"); cpuFlag > 0 && cpuFlag != cfg.CPU {
-		return fmt.Errorf("--cpu %d not supported: Firecracker cannot change CPU after snapshot/load (snapshot has %d)", cpuFlag, cfg.CPU)
-	}
-	if memStr, _ := cmd.Flags().GetString("memory"); memStr != "" {
-		return fmt.Errorf("--memory not supported: Firecracker cannot change memory after snapshot/load")
-	}
-	if nics, _ := cmd.Flags().GetInt("nics"); nics > 0 && nics != cfg.NICs {
-		return fmt.Errorf("--nics %d not supported: Firecracker cannot change NIC count after snapshot/load (snapshot has %d)", nics, cfg.NICs)
-	}
-	return nil
 }
 
 func printBashArray(name string, nics []nicHint, field func(nicHint) string) {

--- a/cmd/vm/run.go
+++ b/cmd/vm/run.go
@@ -337,6 +337,9 @@ func (h Handler) prepareClone(ctx context.Context, cmd *cobra.Command, conf *con
 	if vmCfg.Name == "" {
 		vmCfg.Name = "cocoon-clone-" + network.VMIDPrefix(vmID)
 	}
+	if err = vmCfg.Validate(); err != nil {
+		return nil, "", nil, nil, err
+	}
 
 	// Auto-pull base image if --pull is set (cross-node clone).
 	if pull, _ := cmd.Flags().GetBool("pull"); pull && vmCfg.Image != "" && vmCfg.ImageType != "" {

--- a/hypervisor/backend.go
+++ b/hypervisor/backend.go
@@ -75,26 +75,24 @@ type LaunchSpec struct {
 
 // RestoreSpec carries the backend-specific hooks for Backend.RestoreSequence.
 type RestoreSpec struct {
-	VMCfg         *types.VMConfig
-	Snapshot      io.Reader
-	OverrideCheck func(rec *VMRecord, vmCfg *types.VMConfig) error
-	Preflight     func(stagingDir string, rec *VMRecord) error
-	Kill          func(ctx context.Context, vmID string, rec *VMRecord) error
-	Wrap          func(rec *VMRecord, fn func() error) error // optional disk lock around merge+afterExtract
-	BeforeMerge   func(rec *VMRecord) error                  // e.g. FC removes stale COW
-	AfterExtract  func(ctx context.Context, vmID string, vmCfg *types.VMConfig, rec *VMRecord) (*types.VM, error)
+	VMCfg        *types.VMConfig
+	Snapshot     io.Reader
+	Preflight    func(stagingDir string, rec *VMRecord) error
+	Kill         func(ctx context.Context, vmID string, rec *VMRecord) error
+	Wrap         func(rec *VMRecord, fn func() error) error // optional disk lock around merge+afterExtract
+	BeforeMerge  func(rec *VMRecord) error                  // e.g. FC removes stale COW
+	AfterExtract func(ctx context.Context, vmID string, vmCfg *types.VMConfig, rec *VMRecord) (*types.VM, error)
 }
 
 // DirectRestoreSpec is RestoreSpec for a local srcDir rather than a tar; Populate replaces staging+merge.
 type DirectRestoreSpec struct {
-	VMCfg         *types.VMConfig
-	SrcDir        string
-	OverrideCheck func(rec *VMRecord, vmCfg *types.VMConfig) error
-	Preflight     func(srcDir string, rec *VMRecord) error
-	Kill          func(ctx context.Context, vmID string, rec *VMRecord) error
-	Wrap          func(rec *VMRecord, fn func() error) error
-	Populate      func(rec *VMRecord, srcDir string) error
-	AfterExtract  func(ctx context.Context, vmID string, vmCfg *types.VMConfig, rec *VMRecord) (*types.VM, error)
+	VMCfg        *types.VMConfig
+	SrcDir       string
+	Preflight    func(srcDir string, rec *VMRecord) error
+	Kill         func(ctx context.Context, vmID string, rec *VMRecord) error
+	Wrap         func(rec *VMRecord, fn func() error) error
+	Populate     func(rec *VMRecord, srcDir string) error
+	AfterExtract func(ctx context.Context, vmID string, vmCfg *types.VMConfig, rec *VMRecord) (*types.VM, error)
 }
 
 // CreateSpec carries the inputs to CreateSequence. Prepare returns the

--- a/hypervisor/cloudhypervisor/clone.go
+++ b/hypervisor/cloudhypervisor/clone.go
@@ -69,11 +69,6 @@ func (ch *CloudHypervisor) cloneAfterExtract(ctx context.Context, vmID string, v
 	if err = hypervisor.VerifyBaseFiles(storageConfigs, bootCfg); err != nil {
 		return nil, fmt.Errorf("verify base files: %w", err)
 	}
-	if vmCfg.Storage > 0 {
-		if err = qemuExpandImage(ctx, cowPath, vmCfg.Storage, directBoot); err != nil {
-			return nil, fmt.Errorf("resize COW: %w", err)
-		}
-	}
 
 	stateReplacements := buildStateReplacements(chCfg, storageConfigs)
 

--- a/hypervisor/cloudhypervisor/clone.go
+++ b/hypervisor/cloudhypervisor/clone.go
@@ -40,7 +40,7 @@ func (ch *CloudHypervisor) cloneAfterExtract(ctx context.Context, vmID string, v
 	logger := log.WithFunc("cloudhypervisor.Clone")
 
 	chConfigPath := filepath.Join(runDir, "config.json")
-	chCfg, chConfigRaw, err := parseCHConfig(chConfigPath)
+	chCfg, err := parseCHConfig(chConfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("parse CH config: %w", err)
 	}
@@ -93,12 +93,9 @@ func (ch *CloudHypervisor) cloneAfterExtract(ctx context.Context, vmID string, v
 		consoleSock:    consoleSock,
 		vsockSock:      hypervisor.VsockSockPath(runDir),
 		directBoot:     directBoot,
-		windows:        vmCfg.Windows,
-		cpu:            vmCfg.CPU,
-		memory:         vmCfg.Memory,
 		diskQueueSize:  vmCfg.DiskQueueSize,
 		noDirectIO:     vmCfg.NoDirectIO,
-	}, chCfg, chConfigRaw); err != nil {
+	}); err != nil {
 		return nil, fmt.Errorf("patch CH config: %w", err)
 	}
 
@@ -215,16 +212,16 @@ func (ch *CloudHypervisor) ensureCloneCidata(vmID string, vmCfg *types.VMConfig,
 	return storageConfigs, nil
 }
 
-func parseCHConfig(path string) (*chVMConfig, []byte, error) {
+func parseCHConfig(path string) (*chVMConfig, error) {
 	data, err := os.ReadFile(path) //nolint:gosec
 	if err != nil {
-		return nil, nil, fmt.Errorf("read %s: %w", path, err)
+		return nil, fmt.Errorf("read %s: %w", path, err)
 	}
 	var cfg chVMConfig
 	if err := json.Unmarshal(data, &cfg); err != nil {
-		return nil, nil, fmt.Errorf("decode %s: %w", path, err)
+		return nil, fmt.Errorf("decode %s: %w", path, err)
 	}
-	return &cfg, data, nil
+	return &cfg, nil
 }
 
 func rebuildBootConfig(cfg *chVMConfig) *types.BootConfig {

--- a/hypervisor/cloudhypervisor/clone_test.go
+++ b/hypervisor/cloudhypervisor/clone_test.go
@@ -135,7 +135,7 @@ func TestPatchCHConfig_PreservesUnknownFields(t *testing.T) {
 	dir := t.TempDir()
 	path := writeCHConfig(t, dir, baseCHConfig())
 
-	if err := patchCHConfig(path, basePatchOpts(), nil, nil); err != nil {
+	if err := patchCHConfig(path, basePatchOpts()); err != nil {
 		t.Fatalf("patchCHConfig: %v", err)
 	}
 
@@ -196,7 +196,7 @@ func TestPatchCHConfig_UpdatesDiskPaths(t *testing.T) {
 	path := writeCHConfig(t, dir, baseCHConfig())
 
 	opts := basePatchOpts()
-	if err := patchCHConfig(path, opts, nil, nil); err != nil {
+	if err := patchCHConfig(path, opts); err != nil {
 		t.Fatal(err)
 	}
 
@@ -226,7 +226,7 @@ func TestPatchCHConfig_SerialConsole(t *testing.T) {
 
 		opts := basePatchOpts()
 		opts.directBoot = true
-		if err := patchCHConfig(path, opts, nil, nil); err != nil {
+		if err := patchCHConfig(path, opts); err != nil {
 			t.Fatal(err)
 		}
 
@@ -250,7 +250,7 @@ func TestPatchCHConfig_SerialConsole(t *testing.T) {
 		opts := basePatchOpts()
 		opts.directBoot = false
 		opts.consoleSock = "/new/console.sock"
-		if err := patchCHConfig(path, opts, nil, nil); err != nil {
+		if err := patchCHConfig(path, opts); err != nil {
 			t.Fatal(err)
 		}
 
@@ -269,132 +269,6 @@ func TestPatchCHConfig_SerialConsole(t *testing.T) {
 	})
 }
 
-func TestPatchCHConfig_CPUMemoryBalloon(t *testing.T) {
-	dir := t.TempDir()
-	path := writeCHConfig(t, dir, baseCHConfig())
-
-	opts := basePatchOpts()
-	opts.cpu = 4
-	opts.memory = 2 << 30 // 2 GiB
-	if err := patchCHConfig(path, opts, nil, nil); err != nil {
-		t.Fatal(err)
-	}
-
-	result := readRawJSON(t, path)
-
-	cpus := result["cpus"].(map[string]any)
-	if cpus["boot_vcpus"] != float64(4) {
-		t.Errorf("boot_vcpus: got %v, want 4", cpus["boot_vcpus"])
-	}
-	// max_phys_bits preserved.
-	if cpus["max_phys_bits"] != float64(46) {
-		t.Errorf("max_phys_bits lost: got %v", cpus["max_phys_bits"])
-	}
-
-	mem := result["memory"].(map[string]any)
-	if mem["size"] != float64(2<<30) {
-		t.Errorf("memory.size: got %v, want %v", mem["size"], float64(2<<30))
-	}
-	// shared preserved.
-	if _, ok := mem["shared"]; !ok {
-		t.Error("memory.shared lost")
-	}
-
-	balloon := result["balloon"].(map[string]any)
-	expectedSize := float64(2 << 30 / 4)
-	if balloon["size"] != expectedSize {
-		t.Errorf("balloon.size: got %v, want %v", balloon["size"], expectedSize)
-	}
-	// Balloon device id preserved.
-	if balloon["id"] != "_balloon0" {
-		t.Errorf("balloon.id lost: got %v", balloon["id"])
-	}
-}
-
-func TestPatchCHConfig_BalloonRemoved(t *testing.T) {
-	dir := t.TempDir()
-	path := writeCHConfig(t, dir, baseCHConfig())
-
-	opts := basePatchOpts()
-	opts.memory = 128 << 20 // 128 MiB, below minBalloonMemory
-	if err := patchCHConfig(path, opts, nil, nil); err != nil {
-		t.Fatal(err)
-	}
-
-	result := readRawJSON(t, path)
-	if _, ok := result["balloon"]; ok {
-		t.Error("balloon should be removed for memory < 256 MiB")
-	}
-}
-
-func TestPatchCHConfig_BalloonCreated(t *testing.T) {
-	dir := t.TempDir()
-	cfg := baseCHConfig()
-	delete(cfg, "balloon") // no balloon initially
-	path := writeCHConfig(t, dir, cfg)
-
-	opts := basePatchOpts()
-	opts.memory = 1 << 30 // 1 GiB
-	if err := patchCHConfig(path, opts, nil, nil); err != nil {
-		t.Fatal(err)
-	}
-
-	result := readRawJSON(t, path)
-	balloon, ok := result["balloon"].(map[string]any)
-	if !ok {
-		t.Fatal("balloon should be created for memory >= 256 MiB")
-	}
-	expectedSize := float64(1 << 30 / 4)
-	if balloon["size"] != expectedSize {
-		t.Errorf("balloon.size: got %v, want %v", balloon["size"], expectedSize)
-	}
-	if balloon["deflate_on_oom"] != true {
-		t.Error("deflate_on_oom should be true")
-	}
-}
-
-func TestPatchCHConfig_WindowsBalloonRemoved(t *testing.T) {
-	dir := t.TempDir()
-	cfg := baseCHConfig()
-	cfg["balloon"] = nil
-	path := writeCHConfig(t, dir, cfg)
-
-	opts := basePatchOpts()
-	opts.windows = true
-	opts.memory = 4 << 30
-	if err := patchCHConfig(path, opts, nil, nil); err != nil {
-		t.Fatal(err)
-	}
-
-	result := readRawJSON(t, path)
-	if _, ok := result["balloon"]; ok {
-		t.Fatal("balloon should be removed for Windows")
-	}
-}
-
-func TestPatchCHConfig_BalloonNullCreated(t *testing.T) {
-	dir := t.TempDir()
-	cfg := baseCHConfig()
-	cfg["balloon"] = nil
-	path := writeCHConfig(t, dir, cfg)
-
-	opts := basePatchOpts()
-	opts.memory = 1 << 30
-	if err := patchCHConfig(path, opts, nil, nil); err != nil {
-		t.Fatal(err)
-	}
-
-	result := readRawJSON(t, path)
-	balloon, ok := result["balloon"].(map[string]any)
-	if !ok {
-		t.Fatal("balloon should be created when raw balloon is null")
-	}
-	expectedSize := float64(1 << 30 / 4)
-	if balloon["size"] != expectedSize {
-		t.Errorf("balloon.size: got %v, want %v", balloon["size"], expectedSize)
-	}
-}
-
 func TestPatchCHConfig_DiskCountMismatch(t *testing.T) {
 	dir := t.TempDir()
 	path := writeCHConfig(t, dir, baseCHConfig())
@@ -402,7 +276,7 @@ func TestPatchCHConfig_DiskCountMismatch(t *testing.T) {
 	opts := basePatchOpts()
 	// 3 storage configs vs 2 disks in config.
 	opts.storageConfigs = append(opts.storageConfigs, &types.StorageConfig{Path: "/extra"})
-	err := patchCHConfig(path, opts, nil, nil)
+	err := patchCHConfig(path, opts)
 	if err == nil {
 		t.Fatal("expected error for disk count mismatch")
 	}

--- a/hypervisor/cloudhypervisor/direct.go
+++ b/hypervisor/cloudhypervisor/direct.go
@@ -33,7 +33,7 @@ func (ch *CloudHypervisor) DirectRestore(ctx context.Context, vmRef string, vmCf
 }
 
 func cloneSnapshotFiles(dstDir, srcDir string) error {
-	chCfg, _, err := parseCHConfig(filepath.Join(srcDir, "config.json"))
+	chCfg, err := parseCHConfig(filepath.Join(srcDir, "config.json"))
 	if err != nil {
 		return fmt.Errorf("parse source config: %w", err)
 	}

--- a/hypervisor/cloudhypervisor/direct.go
+++ b/hypervisor/cloudhypervisor/direct.go
@@ -27,7 +27,7 @@ func (ch *CloudHypervisor) DirectRestore(ctx context.Context, vmRef string, vmCf
 		},
 		AfterExtract: func(ctx context.Context, vmID string, vmCfg *types.VMConfig, rec *hypervisor.VMRecord) (*types.VM, error) {
 			directBoot := isDirectBoot(rec.BootConfig)
-			return ch.restoreAfterExtract(ctx, vmID, vmCfg, rec, directBoot, ch.cowPath(vmID, directBoot))
+			return ch.restoreAfterExtract(ctx, vmID, vmCfg, rec, directBoot)
 		},
 	})
 }

--- a/hypervisor/cloudhypervisor/helper.go
+++ b/hypervisor/cloudhypervisor/helper.go
@@ -46,7 +46,7 @@ func validateSnapshotIntegrity(srcDir string, sidecar []*types.StorageConfig) er
 	if err := hypervisor.ValidateSnapshotIntegrity(srcDir, sidecar); err != nil {
 		return err
 	}
-	chCfg, _, err := parseCHConfig(filepath.Join(srcDir, "config.json"))
+	chCfg, err := parseCHConfig(filepath.Join(srcDir, "config.json"))
 	if err != nil {
 		return fmt.Errorf("parse snapshot config: %w", err)
 	}

--- a/hypervisor/cloudhypervisor/patch.go
+++ b/hypervisor/cloudhypervisor/patch.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/cocoonstack/cocoon/hypervisor"
 	"github.com/cocoonstack/cocoon/types"
 	"github.com/cocoonstack/cocoon/utils"
 )
@@ -16,25 +15,17 @@ type patchOptions struct {
 	consoleSock    string
 	vsockSock      string
 	directBoot     bool
-	windows        bool
-	cpu            int
-	memory         int64
 	diskQueueSize  int
 	noDirectIO     bool
 }
 
 // patchCHConfig patches specific fields in config.json while preserving all
 // unknown fields that CH adds internally (platform, cpus.topology, etc.).
-// If chCfg and rawData are provided, the file is not re-read.
-func patchCHConfig(path string, opts *patchOptions, chCfg *chVMConfig, rawData []byte) error {
-	var err error
-	if rawData == nil {
-		rawData, err = os.ReadFile(path) //nolint:gosec
-		if err != nil {
-			return fmt.Errorf("read %s: %w", path, err)
-		}
+func patchCHConfig(path string, opts *patchOptions) error {
+	rawData, err := os.ReadFile(path) //nolint:gosec
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
 	}
-
 	var raw map[string]json.RawMessage
 	if e := json.Unmarshal(rawData, &raw); e != nil {
 		return fmt.Errorf("decode raw %s: %w", path, e)
@@ -74,24 +65,6 @@ func patchCHConfig(path string, opts *patchOptions, chCfg *chVMConfig, rawData [
 		}
 	}
 
-	if opts.cpu > 0 {
-		if cpuRaw, ok := raw["cpus"]; ok {
-			patched, patchErr := patchRawObject(cpuRaw, func(obj map[string]json.RawMessage) error {
-				return setField(obj, "boot_vcpus", opts.cpu)
-			})
-			if patchErr != nil {
-				return fmt.Errorf("patch cpus: %w", patchErr)
-			}
-			raw["cpus"] = patched
-		}
-	}
-
-	if opts.memory > 0 {
-		if memErr := patchMemoryAndBalloon(raw, chCfg, opts.memory, opts.windows); memErr != nil {
-			return memErr
-		}
-	}
-
 	return utils.AtomicWriteJSON(path, raw)
 }
 
@@ -116,52 +89,6 @@ func patchDisks(diskRaw json.RawMessage, opts *patchOptions) (json.RawMessage, e
 			directIO = !sc.RO && !opts.noDirectIO
 		}
 		return setField(elem, "direct", directIO)
-	})
-}
-
-func patchMemoryAndBalloon(raw map[string]json.RawMessage, chCfg *chVMConfig, memory int64, windows bool) error {
-	if memRaw, ok := raw["memory"]; ok {
-		patched, err := patchRawObject(memRaw, func(obj map[string]json.RawMessage) error {
-			return setField(obj, "size", memory)
-		})
-		if err != nil {
-			return fmt.Errorf("patch memory: %w", err)
-		}
-		raw["memory"] = patched
-	}
-	newSize, enabled := hypervisor.BalloonSize(memory, windows)
-	if !enabled {
-		delete(raw, "balloon")
-		return nil
-	}
-	hasBalloon := chCfg != nil && chCfg.Balloon != nil
-	if !hasBalloon {
-		balloonRaw, ok := raw["balloon"]
-		hasBalloon = ok && rawObjectPresent(balloonRaw)
-	}
-	if err := patchBalloonRaw(raw, hasBalloon, newSize); err != nil {
-		return fmt.Errorf("patch balloon: %w", err)
-	}
-	return nil
-}
-
-func patchBalloonRaw(raw map[string]json.RawMessage, hasBalloon bool, newSize int64) error {
-	if hasBalloon {
-		if balloonRaw, ok := raw["balloon"]; ok {
-			patched, err := patchRawObject(balloonRaw, func(obj map[string]json.RawMessage) error {
-				return setField(obj, "size", newSize)
-			})
-			if err != nil {
-				return fmt.Errorf("patch balloon size: %w", err)
-			}
-			raw["balloon"] = patched
-			return nil
-		}
-	}
-	return setField(raw, "balloon", &chBalloon{
-		Size:              newSize,
-		DeflateOnOOM:      true,
-		FreePageReporting: true,
 	})
 }
 

--- a/hypervisor/cloudhypervisor/restore.go
+++ b/hypervisor/cloudhypervisor/restore.go
@@ -21,7 +21,7 @@ func (ch *CloudHypervisor) Restore(ctx context.Context, vmRef string, vmCfg *typ
 		Kill:      ch.killForRestore,
 		AfterExtract: func(ctx context.Context, vmID string, vmCfg *types.VMConfig, rec *hypervisor.VMRecord) (*types.VM, error) {
 			directBoot := isDirectBoot(rec.BootConfig)
-			return ch.restoreAfterExtract(ctx, vmID, vmCfg, rec, directBoot, ch.cowPath(vmID, directBoot))
+			return ch.restoreAfterExtract(ctx, vmID, vmCfg, rec, directBoot)
 		},
 	})
 }
@@ -37,7 +37,7 @@ func (ch *CloudHypervisor) killForRestore(ctx context.Context, vmID string, rec 
 	}, runtimeFiles)
 }
 
-func (ch *CloudHypervisor) restoreAfterExtract(ctx context.Context, vmID string, vmCfg *types.VMConfig, rec *hypervisor.VMRecord, directBoot bool, cowPath string) (_ *types.VM, err error) {
+func (ch *CloudHypervisor) restoreAfterExtract(ctx context.Context, vmID string, vmCfg *types.VMConfig, rec *hypervisor.VMRecord, directBoot bool) (_ *types.VM, err error) {
 	logger := log.WithFunc("cloudhypervisor.Restore")
 
 	defer func() {
@@ -66,12 +66,6 @@ func (ch *CloudHypervisor) restoreAfterExtract(ctx context.Context, vmID string,
 		noDirectIO:     vmCfg.NoDirectIO,
 	}); err != nil {
 		return nil, fmt.Errorf("patch config: %w", err)
-	}
-
-	if vmCfg.Storage > 0 {
-		if err = qemuExpandImage(ctx, cowPath, vmCfg.Storage, directBoot); err != nil {
-			return nil, fmt.Errorf("resize COW: %w", err)
-		}
 	}
 
 	sockPath := hypervisor.SocketPath(rec.RunDir)

--- a/hypervisor/cloudhypervisor/restore.go
+++ b/hypervisor/cloudhypervisor/restore.go
@@ -62,12 +62,9 @@ func (ch *CloudHypervisor) restoreAfterExtract(ctx context.Context, vmID string,
 		consoleSock:    hypervisor.ConsoleSockPath(rec.RunDir),
 		vsockSock:      hypervisor.VsockSockPath(rec.RunDir),
 		directBoot:     directBoot,
-		windows:        vmCfg.Windows,
-		cpu:            vmCfg.CPU,
-		memory:         vmCfg.Memory,
 		diskQueueSize:  vmCfg.DiskQueueSize,
 		noDirectIO:     vmCfg.NoDirectIO,
-	}, nil, nil); err != nil {
+	}); err != nil {
 		return nil, fmt.Errorf("patch config: %w", err)
 	}
 

--- a/hypervisor/cloudhypervisor/snapshot.go
+++ b/hypervisor/cloudhypervisor/snapshot.go
@@ -50,7 +50,7 @@ func (ch *CloudHypervisor) Snapshot(ctx context.Context, ref string) (*types.Sna
 // diverge for cloudimg post-FirstBooted but pre-restart: CH still holds cidata,
 // activeDisks would skip it.
 func buildSnapshotMeta(rec *hypervisor.VMRecord, tmpDir string) (*hypervisor.SnapshotMeta, error) {
-	chCfg, _, err := parseCHConfig(filepath.Join(tmpDir, "config.json"))
+	chCfg, err := parseCHConfig(filepath.Join(tmpDir, "config.json"))
 	if err != nil {
 		return nil, fmt.Errorf("parse snapshot config: %w", err)
 	}

--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -35,14 +35,6 @@ func (fc *Firecracker) cloneAfterExtract(ctx context.Context, vmID string, vmCfg
 		return nil, fmt.Errorf("load snapshot metadata: %w", err)
 	}
 
-	// FC cannot update CPU/memory after snapshot/load.
-	if meta.CPU > 0 && vmCfg.CPU != meta.CPU {
-		return nil, fmt.Errorf("--cpu %d not supported: Firecracker cannot change CPU after snapshot/load (snapshot has %d)", vmCfg.CPU, meta.CPU)
-	}
-	if meta.Memory > 0 && vmCfg.Memory != meta.Memory {
-		return nil, fmt.Errorf("--memory not supported: Firecracker cannot change memory after snapshot/load")
-	}
-
 	cowPath := fc.conf.COWRawPath(vmID)
 	snapshotCOW := filepath.Join(runDir, cowFileName)
 	if renameErr := os.Rename(snapshotCOW, cowPath); renameErr != nil {

--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -61,11 +61,6 @@ func (fc *Firecracker) cloneAfterExtract(ctx context.Context, vmID string, vmCfg
 	if verifyErr := hypervisor.VerifyBaseFiles(storageConfigs, bootCfg); verifyErr != nil {
 		return nil, fmt.Errorf("verify base files: %w", verifyErr)
 	}
-	if vmCfg.Storage > 0 {
-		if expandErr := hypervisor.ExpandRawImage(cowPath, vmCfg.Storage); expandErr != nil {
-			return nil, fmt.Errorf("resize COW: %w", expandErr)
-		}
-	}
 	if bootCfg != nil {
 		dns, dnsErr := fc.conf.DNSServers()
 		if dnsErr != nil {

--- a/hypervisor/firecracker/direct.go
+++ b/hypervisor/firecracker/direct.go
@@ -16,11 +16,10 @@ func (fc *Firecracker) DirectClone(ctx context.Context, vmID string, vmCfg *type
 
 func (fc *Firecracker) DirectRestore(ctx context.Context, vmRef string, vmCfg *types.VMConfig, srcDir string) (*types.VM, error) {
 	return fc.DirectRestoreSequence(ctx, vmRef, hypervisor.DirectRestoreSpec{
-		VMCfg:         vmCfg,
-		SrcDir:        srcDir,
-		OverrideCheck: validateRestoreOverrides,
-		Preflight:     fc.preflightRestore,
-		Kill:          fc.killForRestore,
+		VMCfg:     vmCfg,
+		SrcDir:    srcDir,
+		Preflight: fc.preflightRestore,
+		Kill:      fc.killForRestore,
 		// Lock writable disks so recoverStaleBackup heals stale data-*.raw.cocoon-clone-backup
 		// before restore overwrites them; otherwise a future clone renames backup over restored data.
 		Wrap: func(rec *hypervisor.VMRecord, inner func() error) error {

--- a/hypervisor/firecracker/restore.go
+++ b/hypervisor/firecracker/restore.go
@@ -60,12 +60,6 @@ func (fc *Firecracker) restoreAfterExtract(ctx context.Context, vmID string, vmC
 		}
 	}
 
-	if vmCfg.Storage > 0 {
-		if err = hypervisor.ExpandRawImage(cowPath, vmCfg.Storage); err != nil {
-			return nil, fmt.Errorf("resize COW: %w", err)
-		}
-	}
-
 	sockPath := hypervisor.SocketPath(rec.RunDir)
 
 	withNetwork := len(rec.NetworkConfigs) > 0

--- a/hypervisor/firecracker/restore.go
+++ b/hypervisor/firecracker/restore.go
@@ -16,11 +16,10 @@ import (
 
 func (fc *Firecracker) Restore(ctx context.Context, vmRef string, vmCfg *types.VMConfig, snapshot io.Reader) (*types.VM, error) {
 	return fc.RestoreSequence(ctx, vmRef, hypervisor.RestoreSpec{
-		VMCfg:         vmCfg,
-		Snapshot:      snapshot,
-		OverrideCheck: validateRestoreOverrides,
-		Preflight:     fc.preflightRestore,
-		Kill:          fc.killForRestore,
+		VMCfg:     vmCfg,
+		Snapshot:  snapshot,
+		Preflight: fc.preflightRestore,
+		Kill:      fc.killForRestore,
 		// Lock writable disks so recoverStaleBackup heals stale data-*.raw.cocoon-clone-backup
 		// before restore overwrites them; otherwise a future clone renames backup over restored data.
 		Wrap: func(rec *hypervisor.VMRecord, inner func() error) error {
@@ -93,15 +92,4 @@ func (fc *Firecracker) restoreAfterExtract(ctx context.Context, vmID string, vmC
 
 	logger.Infof(ctx, "VM %s restored from snapshot", vmID)
 	return fc.FinalizeRestore(ctx, vmID, vmCfg, rec, pid)
-}
-
-// validateRestoreOverrides rejects CPU/memory changes FC cannot apply post-load.
-func validateRestoreOverrides(rec *hypervisor.VMRecord, vmCfg *types.VMConfig) error {
-	if vmCfg.CPU != rec.Config.CPU {
-		return fmt.Errorf("--cpu %d not supported: Firecracker cannot change CPU after snapshot/load (VM has %d)", vmCfg.CPU, rec.Config.CPU)
-	}
-	if vmCfg.Memory != rec.Config.Memory {
-		return fmt.Errorf("--memory not supported: Firecracker cannot change memory after snapshot/load")
-	}
-	return nil
 }

--- a/hypervisor/restore.go
+++ b/hypervisor/restore.go
@@ -77,11 +77,6 @@ func (b *Backend) RestoreSequence(ctx context.Context, vmRef string, spec Restor
 	if err != nil {
 		return nil, err
 	}
-	if spec.OverrideCheck != nil {
-		if checkErr := spec.OverrideCheck(rec, spec.VMCfg); checkErr != nil {
-			return nil, checkErr
-		}
-	}
 
 	stagingDir, cleanupStaging, err := PrepareStagingDir(rec.RunDir, spec.Snapshot)
 	if err != nil {
@@ -130,11 +125,6 @@ func (b *Backend) DirectRestoreSequence(ctx context.Context, vmRef string, spec 
 	vmID, rec, err := b.ResolveForRestore(ctx, vmRef)
 	if err != nil {
 		return nil, err
-	}
-	if spec.OverrideCheck != nil {
-		if checkErr := spec.OverrideCheck(rec, spec.VMCfg); checkErr != nil {
-			return nil, checkErr
-		}
 	}
 
 	if preflightErr := spec.Preflight(spec.SrcDir, rec); preflightErr != nil {


### PR DESCRIPTION
## Summary

Removes `--cpu`, `--memory`, `--storage`, and `--nics` from `cocoon vm clone` and `cocoon vm restore`. Both hypervisors reconstruct the guest from the snapshot's binary device state, so none of these can actually be grown — the previous flag layer was Potemkin validation.

The hot-swap NIC logic stays: clone still removes the snapshot's NICs and adds fresh ones at the same count, because the binary state binds the old MACs/TAPs to the source VM.

## What changed

**CLI**
- `addCloneFlags` and `restoreCmd` lose `--cpu`, `--memory`, `--storage`, `--nics`.
- `mergeResourceFlags` → `mergeStorageFlag` → deleted (fully dead).
- `CloneVMConfigFromFlags` inherits CPU/memory/storage from snapshot, NIC count from `cfg.NICs`.
- `RestoreVMConfigFromFlags` builds the persisted record from `snapCfg.Config` (so the record matches what the hypervisor reconstructs) **except** for `Network`, which stays from `vm.Config`: the CNI namespace, TAPs, and IPs were allocated at create time and survive restore. NIC count must match the target VM (gated inside the helper, eliminating duplicate checks in run.go).
- `validateFCCloneOverrides` deleted (fully dead).

**Cloud Hypervisor**
- `patchOptions` drops `cpu`, `memory`, `windows` fields.
- `patchCHConfig` no longer patches CPU/memory; signature simplified.
- `patchMemoryAndBalloon` and `patchBalloonRaw` deleted.
- `parseCHConfig` returns `(*chVMConfig, error)` instead of `(*chVMConfig, []byte, error)`.
- `qemuExpandImage` calls in clone/restore are gone (storage strictly inherits).
- `restoreAfterExtract` loses an unused `cowPath` parameter.

**Firecracker**
- `validateRestoreOverrides`, the CPU/memory checks in `cloneAfterExtract`, and the `ExpandRawImage` calls in clone/restore are all gone.
- `RestoreSpec.OverrideCheck` and `DirectRestoreSpec.OverrideCheck` fields removed.

**Docs**
- README clone-flag table reduced to non-resource knobs; restore section gets its own flag table; `What Gets Captured` made explicit that snapshot metadata still records the full resource topology.
- KNOWN_ISSUES updated.

## Persisted record after restore

| Field | Source after restore | Why |
| --- | --- | --- |
| CPU, Memory, Storage | snapshot | guest is reconstructed from snapshot binary state |
| Image, ImageDigest, ImageType | snapshot | rootfs lineage matches the snapshot's |
| Windows, SharedMemory | snapshot | baked into the snapshot's config |
| QueueSize, DiskQueueSize, NoDirectIO | snapshot | virtio device shape baked in; future cold boots read from patched config.json |
| **Network** | **target VM** | CNI namespace, TAPs, IPs were allocated at create time and survive restore |
| Name | target VM | VM identity is preserved |

## Net diff

```
17 files, +80 / -446
```

## Test plan

- [x] `make lint` clean on darwin + linux
- [x] `go test ./...` all pass
- [x] /code senior review walkthrough
- [x] /simplify three-agent review (round 1) + combined review (round 2)
- [x] Testbed E2E (35.240.182.52)
  - [x] `vm clone` / `vm restore` reject `--cpu`, `--memory`, `--storage`, `--nics` as `unknown flag`
  - [x] `vm run --help` still has the four resource flags
  - [x] Clone with no flags inherits CPU/memory/storage/NICs verbatim from snapshot
  - [x] Restore: post-restore `vm inspect` shows snapshot's resources; running guest matches; Network field preserved
  - [x] NIC hot-swap still produces correct fresh MACs on clone

## Why drop `--storage` too

Same root cause as CPU/memory. Host file resizes (qemu-img reports new size), but virtio-blk on `vm.restore` is reconstructed from the snapshot's binary device state with original capacity baked in. Plus `--storage` was ambiguous in multi-data-disk setups (only addressed COW). Dropping the illusion is the cleaner contract.