### PR TITLE
refactor: SKILL audit + os-image cocoon-agent/sshd unification

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -228,3 +228,21 @@ Attaches via `cocoon vm fs attach` and `cocoon vm device attach` are runtime-onl
 ## virtiofsd is a single-shot daemon
 
 Upstream virtiofsd serves exactly one vhost-user client and exits when that client disconnects. Consequence: after `cocoon vm fs detach`, the daemon is gone — a follow-up `cocoon vm fs attach` against the same socket path will hang or time out until a fresh `virtiofsd` instance is launched. The same applies after `cocoon vm stop` (CH closes the socket on shutdown). Scripts that cycle attach/detach should respawn virtiofsd between calls. This is a virtiofsd behavior, not a cocoon limitation.
+
+## Official OS images ship with default `root:cocoon` and `PermitRootLogin yes`
+
+Every Ubuntu image under `os-image/` enables `openssh-server` with `PermitRootLogin yes` and the default `root:cocoon` credentials baked in. This is convenient for development and matches the existing OCI-image behavior, but it is **not** safe for production exposure.
+
+Mitigations for production users:
+
+- Rotate the root password (`passwd root`) and/or disable password auth (`PasswordAuthentication no`) inside the guest before exposing it.
+- Add a non-root sudo user, then flip `PermitRootLogin` back to `no`.
+- Or fork the Dockerfile and adjust the `install-agent.sh` invocation to skip the SSH config step.
+
+Control-plane traffic from cocoon-managed hosts (vk-cocoon, `cocoon vm exec`) goes through cocoon-agent over vsock and never depends on SSH credentials.
+
+## Android cocoon-agent service may be blocked by SELinux
+
+`os-image/android/{14.0,15.0}` install the cocoon-agent binary at `/system/bin/cocoon-agent` and register it via `/system/etc/init/cocoon-agent.rc`. Android's SELinux policies don't ship with a domain for cocoon-agent, so the service may run in `init`'s domain or be denied outright depending on the redroid build.
+
+If `cocoon vm exec` against an Android VM returns `dial agent: ...`, check `logcat | grep -i avc` inside the guest. The fix is build-time — adjust the Android sepolicy to grant the new binary network/socket permissions — and is out of scope for the Dockerfile.

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ $ cocoon vm exec -e FOO=bar myvm -- sh -c 'echo $FOO'
 bar
 ```
 
-Requires cocoon-agent to be running inside the guest (already baked into the official `ghcr.io/cocoonstack/cocoon/ubuntu:24.04` image and started via systemd). Windows guests are not yet supported.
+Requires cocoon-agent to be running inside the guest. All official `ghcr.io/cocoonstack/cocoon/ubuntu:*` and `ghcr.io/cocoonstack/cocoon/android:*` images now bake the binary and enable it on boot (systemd unit on Ubuntu, init.rc service on Android). Windows guests are not yet supported.
 
 ### Logs Flags
 
@@ -418,7 +418,7 @@ Cloudimg VMs receive a NoCloud cidata disk (FAT12 with `CIDATA` volume label) co
 
 The cidata disk is **automatically excluded on subsequent boots** — after the first successful start, the VM record is marked as `first_booted` and the cidata disk is no longer attached, preventing cloud-init from re-running.
 
-Note: `--user`/`--password` only apply to **cloudimg** VMs (cloud-init). OCI VM images bake credentials at build time. Host-to-guest control plane operations (kubectl exec, kubectl logs) go through cocoon-agent over vsock, not SSH. Only `os-image/ubuntu/24.04-picoclaw` ships sshd; its credentials are documented via `LABEL cocoon.ssh.username` / `cocoon.ssh.password` in the Dockerfile so glance and other SSH-aware tooling can populate their own credential stores.
+Note: `--user`/`--password` only apply to **cloudimg** VMs (cloud-init). OCI VM images bake credentials at build time — every official `os-image/ubuntu/*` image ships `openssh-server` enabled with `PermitRootLogin yes` and the default `root:cocoon` credentials. Host-to-guest control plane operations (kubectl exec, kubectl logs) prefer cocoon-agent over vsock; SSH stays available as the human-on-keyboard path.
 
 ## Data Disks
 
@@ -807,7 +807,7 @@ cocoon image pull ghcr.io/cocoonstack/cocoon/ubuntu:24.04
 cocoon image pull ghcr.io/cocoonstack/cocoon/ubuntu:22.04
 ```
 
-These images include kernel, initramfs, and a systemd-based rootfs with an overlayfs boot script.
+These images include kernel, initramfs, and a systemd-based rootfs with an overlayfs boot script. Every official OS image (Ubuntu + Android) bakes `cocoon-agent` (vsock exec) with auto-start; Ubuntu images additionally enable `sshd` with `PermitRootLogin yes` so `ssh root@<vm>` works out of the box (default `root:cocoon`).
 
 ## Shell Completion
 

--- a/cmd/images/handler.go
+++ b/cmd/images/handler.go
@@ -2,6 +2,11 @@ package images
 
 import cmdcore "github.com/cocoonstack/cocoon/cmd/core"
 
+// imageType identifies the content type detected from a stream.
+type imageType int
+
+type importSourceKind int
+
 const (
 	// digestDisplayLen = len("sha256:") + 12 hex digits for compact display.
 	digestDisplayLen = 19
@@ -17,11 +22,6 @@ const (
 type Handler struct {
 	cmdcore.BaseHandler
 }
-
-// imageType identifies the content type detected from a stream.
-type imageType int
-
-type importSourceKind int
 
 type importLocalPlan struct {
 	kind  importSourceKind

--- a/hypervisor/cloudhypervisor/config.go
+++ b/hypervisor/cloudhypervisor/config.go
@@ -19,7 +19,7 @@ func NewConfig(conf *config.Config) *Config {
 
 func (c *Config) BinaryName() string { return filepath.Base(c.CHBinary) }
 
-func (c *Config) PIDFileName() string { return "ch.pid" }
+func (c *Config) PIDFileName() string { return pidFileName }
 
 func (c *Config) COWRawPath(vmID string) string {
 	return filepath.Join(c.VMRunDir(vmID), "cow.raw")

--- a/hypervisor/cloudhypervisor/helper.go
+++ b/hypervisor/cloudhypervisor/helper.go
@@ -20,6 +20,7 @@ import (
 type chMemoryRestoreMode string
 
 const (
+	pidFileName     = "ch.pid"
 	cmdlineFileName = "cmdline"
 
 	// chMemoryRestoreOnDemand uses userfaultfd (UFFD) to lazily page in
@@ -27,7 +28,7 @@ const (
 	chMemoryRestoreOnDemand chMemoryRestoreMode = "OnDemand"
 )
 
-var runtimeFiles = []string{hypervisor.APISocketName, "ch.pid", hypervisor.ConsoleSockName, cmdlineFileName, hypervisor.VsockSockName}
+var runtimeFiles = []string{hypervisor.APISocketName, pidFileName, hypervisor.ConsoleSockName, cmdlineFileName, hypervisor.VsockSockName}
 
 type chRestoreConfig struct {
 	SourceURL         string              `json:"source_url"`

--- a/hypervisor/cloudhypervisor/helper.go
+++ b/hypervisor/cloudhypervisor/helper.go
@@ -16,6 +16,9 @@ import (
 	"github.com/cocoonstack/cocoon/utils"
 )
 
+// chMemoryRestoreMode controls how CH restores guest memory from a snapshot.
+type chMemoryRestoreMode string
+
 const (
 	cmdlineFileName = "cmdline"
 
@@ -25,9 +28,6 @@ const (
 )
 
 var runtimeFiles = []string{hypervisor.APISocketName, "ch.pid", hypervisor.ConsoleSockName, cmdlineFileName, hypervisor.VsockSockName}
-
-// chMemoryRestoreMode controls how CH restores guest memory from a snapshot.
-type chMemoryRestoreMode string
 
 type chRestoreConfig struct {
 	SourceURL         string              `json:"source_url"`

--- a/hypervisor/utils.go
+++ b/hypervisor/utils.go
@@ -22,6 +22,9 @@ import (
 	"github.com/cocoonstack/cocoon/utils"
 )
 
+// SnapshotFileKind classifies a snapshot file for CloneSnapshotFiles.
+type SnapshotFileKind int
+
 const (
 	// SnapshotFileMemory is a read-only memory/state file (hard link or symlink).
 	SnapshotFileMemory SnapshotFileKind = iota
@@ -40,9 +43,6 @@ const (
 	// usually appears within a few ms after process start.
 	socketReadyPollInterval = 1 * time.Millisecond
 )
-
-// SnapshotFileKind classifies a snapshot file for CloneSnapshotFiles.
-type SnapshotFileKind int
 
 func RemoveVMDirs(runDir, logDir string) error {
 	return errors.Join(

--- a/images/oci/commit.go
+++ b/images/oci/commit.go
@@ -94,16 +94,16 @@ func commitAndRecord(conf *Config, idx *imageIndex, ref string, manifestDigest i
 		}
 		totalSize += size
 	}
-	if size, err := validFileSize(conf.KernelPath(kernelLayer.Hex())); err != nil {
+	size, err := validFileSize(conf.KernelPath(kernelLayer.Hex()))
+	if err != nil {
 		return fmt.Errorf("kernel missing for %s (concurrent GC?)", kernelLayer)
-	} else {
-		totalSize += size
 	}
-	if size, err := validFileSize(conf.InitrdPath(initrdLayer.Hex())); err != nil {
+	totalSize += size
+	size, err = validFileSize(conf.InitrdPath(initrdLayer.Hex()))
+	if err != nil {
 		return fmt.Errorf("initrd missing for %s (concurrent GC?)", initrdLayer)
-	} else {
-		totalSize += size
 	}
+	totalSize += size
 
 	idx.Images[ref] = &imageEntry{
 		Ref:            ref,

--- a/network/bridge/bridge_other.go
+++ b/network/bridge/bridge_other.go
@@ -19,7 +19,7 @@ type Bridge struct{}
 
 // New returns an error on non-Linux.
 func New(_ *config.Config, _ string) (*Bridge, error) {
-	return nil, fmt.Errorf("bridge TAP networking requires Linux (running on %s)", runtime.GOOS)
+	return nil, errUnsupported
 }
 
 // Type returns the provider identifier.

--- a/os-image/README.md
+++ b/os-image/README.md
@@ -68,6 +68,15 @@ IMAGE_NAME="ghcr.io/cocoonstack/cocoon/ubuntu:24.04" bash start.sh
 IMAGE_NAME="ghcr.io/cocoonstack/cocoon/android:14.0" bash start.sh
 ```
 
+## In-VM Services
+
+Every official OS image bakes the following on top of its base distro:
+
+- **cocoon-agent** (vsock exec) — pinned binary from [cocoonstack/cocoon-agent](https://github.com/cocoonstack/cocoon-agent), auto-started on boot. Backs `cocoon vm exec` (kubectl-style stdin/stdout/stderr/exit, no SSH/network dependency). Ubuntu uses a systemd unit; Android uses `/system/etc/init/cocoon-agent.rc`.
+- **sshd** *(Ubuntu only)* — `openssh-server` enabled with `PermitRootLogin yes`. Default credentials are `root:cocoon`. SSH covers the human-on-keyboard case while cocoon-agent handles control-plane traffic.
+
+Default credentials apply to fresh VMs. If you fork an image you should rotate the root password and (if you keep sshd) flip `PermitRootLogin` back to `no` once you have a non-root sudoer.
+
 ## DHCP and VM Cloning
 
 All Ubuntu images configure systemd-networkd with `ClientIdentifier=mac` in their DHCP settings. This ensures that when a VM is cloned from a snapshot, each clone uses its unique MAC address as the DHCP client identifier instead of the machine-id-derived DUID. Without this, clones from the same snapshot share an identical DUID and dnsmasq treats them as a single client, causing IP conflicts.

--- a/os-image/android/14.0/Dockerfile
+++ b/os-image/android/14.0/Dockerfile
@@ -16,17 +16,21 @@ FROM ubuntu:24.04 AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+ARG COCOON_AGENT_VERSION=0.1.0
+
 RUN --mount=type=secret,id=cocoon_overlay \
     --mount=type=secret,id=cocoon_network \
     --mount=type=secret,id=cocoon_init_wrapper \
     --mount=type=secret,id=cocoon_network_rc \
     --mount=type=secret,id=cocoon_omx_fix_rc \
     --mount=type=secret,id=cocoon_disable_bt_rc \
+    --mount=type=secret,id=cocoon_agent_rc \
     # --- Install kernel + initramfs tooling ---
     apt-get update && apt-get install -y --no-install-recommends \
     linux-image-generic \
     initramfs-tools \
     busybox-static \
+    ca-certificates curl \
     && \
     apt-get install -y --no-install-recommends \
         linux-modules-extra-$(ls /lib/modules/ | head -1) \
@@ -38,6 +42,7 @@ RUN --mount=type=secret,id=cocoon_overlay \
     { \
       echo erofs; echo overlay; echo ext4; \
       echo virtio_blk; echo virtio_pci; echo virtio_ring; echo virtio_net; \
+      echo vsock; echo vmw_vsock_virtio_transport; \
       echo binder_linux; echo loop; \
     } >> /etc/initramfs-tools/modules && \
     # netfilter: Android netd requires iptables tables.
@@ -68,6 +73,11 @@ RUN --mount=type=secret,id=cocoon_overlay \
     cp /run/secrets/cocoon_network_rc /output/system/etc/init/cocoon-network.rc && \
     cp /run/secrets/cocoon_omx_fix_rc /output/system/etc/init/cocoon-omx-fix.rc && \
     cp /run/secrets/cocoon_disable_bt_rc /output/system/etc/init/cocoon-disable-bt.rc && \
+    # --- cocoon-agent (vsock exec) — Android amd64 only ---
+    cp /run/secrets/cocoon_agent_rc /output/system/etc/init/cocoon-agent.rc && \
+    curl -fsSL "https://github.com/cocoonstack/cocoon-agent/releases/download/v${COCOON_AGENT_VERSION}/cocoon-agent_${COCOON_AGENT_VERSION}_Linux_x86_64.tar.gz" \
+        | tar -xz -C /output/system/bin/ cocoon-agent && \
+    chmod 0755 /output/system/bin/cocoon-agent && \
     rm -rf /var/lib/apt/lists/*
 
 # ---- Stage 2: Android rootfs + single cocoon layer ----

--- a/os-image/android/15.0/Dockerfile
+++ b/os-image/android/15.0/Dockerfile
@@ -16,17 +16,21 @@ FROM ubuntu:24.04 AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+ARG COCOON_AGENT_VERSION=0.1.0
+
 RUN --mount=type=secret,id=cocoon_overlay \
     --mount=type=secret,id=cocoon_network \
     --mount=type=secret,id=cocoon_init_wrapper \
     --mount=type=secret,id=cocoon_network_rc \
     --mount=type=secret,id=cocoon_omx_fix_rc \
     --mount=type=secret,id=cocoon_disable_bt_rc \
+    --mount=type=secret,id=cocoon_agent_rc \
     # --- Install kernel + initramfs tooling ---
     apt-get update && apt-get install -y --no-install-recommends \
     linux-image-generic \
     initramfs-tools \
     busybox-static \
+    ca-certificates curl \
     && \
     apt-get install -y --no-install-recommends \
         linux-modules-extra-$(ls /lib/modules/ | head -1) \
@@ -38,6 +42,7 @@ RUN --mount=type=secret,id=cocoon_overlay \
     { \
       echo erofs; echo overlay; echo ext4; \
       echo virtio_blk; echo virtio_pci; echo virtio_ring; echo virtio_net; \
+      echo vsock; echo vmw_vsock_virtio_transport; \
       echo binder_linux; echo loop; \
     } >> /etc/initramfs-tools/modules && \
     # netfilter: Android netd requires iptables tables.
@@ -68,6 +73,11 @@ RUN --mount=type=secret,id=cocoon_overlay \
     cp /run/secrets/cocoon_network_rc /output/system/etc/init/cocoon-network.rc && \
     cp /run/secrets/cocoon_omx_fix_rc /output/system/etc/init/cocoon-omx-fix.rc && \
     cp /run/secrets/cocoon_disable_bt_rc /output/system/etc/init/cocoon-disable-bt.rc && \
+    # --- cocoon-agent (vsock exec) — Android amd64 only ---
+    cp /run/secrets/cocoon_agent_rc /output/system/etc/init/cocoon-agent.rc && \
+    curl -fsSL "https://github.com/cocoonstack/cocoon-agent/releases/download/v${COCOON_AGENT_VERSION}/cocoon-agent_${COCOON_AGENT_VERSION}_Linux_x86_64.tar.gz" \
+        | tar -xz -C /output/system/bin/ cocoon-agent && \
+    chmod 0755 /output/system/bin/cocoon-agent && \
     rm -rf /var/lib/apt/lists/*
 
 # ---- Stage 2: Android rootfs + single cocoon layer ----

--- a/os-image/android/agent.rc
+++ b/os-image/android/agent.rc
@@ -1,0 +1,12 @@
+# /system/etc/init/cocoon-agent.rc
+#
+# Cocoon vsock exec agent (host-side `cocoon vm exec` listens on AF_VSOCK).
+# Persistent service: init restarts the binary if it exits.
+
+service cocoon-agent /system/bin/cocoon-agent serve
+    class core
+    user root
+    group root
+
+on boot
+    start cocoon-agent

--- a/os-image/ubuntu/22.04/Dockerfile
+++ b/os-image/ubuntu/22.04/Dockerfile
@@ -1,12 +1,14 @@
 # Use the latest Ubuntu 22.04 (Jammy) LTS
 FROM ubuntu:22.04
 
+ARG TARGETARCH
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Combined System Setup (Single Layer)
 # Install packages first so /etc/initramfs-tools/scripts/ exists, then inject the hook.
 RUN --mount=type=secret,id=cocoon_overlay \
     --mount=type=secret,id=cocoon_network \
+    --mount=type=secret,id=cocoon_install_agent \
     apt-get update && apt-get install -y --no-install-recommends \
         linux-image-virtual \
         initramfs-tools \
@@ -16,13 +18,15 @@ RUN --mount=type=secret,id=cocoon_overlay \
         udev \
         kmod \
         iproute2 \
+        openssh-server \
+        ca-certificates curl \
     && \
     cp /run/secrets/cocoon_overlay /etc/initramfs-tools/scripts/cocoon-overlay && \
     chmod 0755 /etc/initramfs-tools/scripts/cocoon-overlay && \
     cp /run/secrets/cocoon_network /etc/initramfs-tools/scripts/init-bottom/cocoon-network && \
     chmod 0755 /etc/initramfs-tools/scripts/init-bottom/cocoon-network && \
     # [Kernel Config]
-    printf "erofs\noverlay\next4\nvirtio_blk\nvirtio_pci\nvirtio_ring\nvirtio_net\n" >> /etc/initramfs-tools/modules && \
+    printf "erofs\noverlay\next4\nvirtio_blk\nvirtio_pci\nvirtio_ring\nvirtio_net\nvsock\nvmw_vsock_virtio_transport\n" >> /etc/initramfs-tools/modules && \
     sed -i 's/^COMPRESS=.*/COMPRESS=gzip/' /etc/initramfs-tools/initramfs.conf && \
     # [Networking] IP=off prevents initramfs from running DHCP during boot.
     # Kernel ip= parameters (when present) override this and still trigger ipconfig.
@@ -36,6 +40,8 @@ RUN --mount=type=secret,id=cocoon_overlay \
     systemctl enable systemd-networkd systemd-resolved systemd-timesyncd && \
     mkdir -p /etc/systemd/network && \
     printf "[Match]\nName=e* v*\n[Network]\nDHCP=yes\n\n[DHCPv4]\nClientIdentifier=mac\n" > /etc/systemd/network/20-wired.network && \
+    # [Cocoon agent + sshd] vsock exec daemon and SSH access.
+    sh /run/secrets/cocoon_install_agent && \
     # [Final Touches]
     echo 'root:cocoon' | chpasswd && \
     rm -rf /var/lib/apt/lists/*

--- a/os-image/ubuntu/24.04-chrome/Dockerfile
+++ b/os-image/ubuntu/24.04-chrome/Dockerfile
@@ -5,6 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN --mount=type=secret,id=cocoon_overlay \
     --mount=type=secret,id=cocoon_network \
+    --mount=type=secret,id=cocoon_install_agent \
     apt-get update && apt-get install -y --no-install-recommends \
     linux-image-virtual \
     initramfs-tools \
@@ -13,6 +14,7 @@ RUN --mount=type=secret,id=cocoon_overlay \
     software-properties-common htop ncdu nload net-tools \
     openbox \
     xserver-xorg-core dbus-x11 xrdp xorgxrdp \
+    openssh-server ca-certificates \
     && \
     ARCH=${TARGETARCH:-$(dpkg --print-architecture)}; \
     if [ "$ARCH" = "amd64" ]; then \
@@ -32,7 +34,7 @@ RUN --mount=type=secret,id=cocoon_overlay \
     chmod 0755 /etc/initramfs-tools/scripts/cocoon-overlay && \
     cp /run/secrets/cocoon_network /etc/initramfs-tools/scripts/init-bottom/cocoon-network && \
     chmod 0755 /etc/initramfs-tools/scripts/init-bottom/cocoon-network && \
-    printf "erofs\nlz4\nlz4_compress\nzstd\nzstd_compress\noverlay\next4\nvirtio_blk\nvirtio_pci\nvirtio_ring\nvirtio_net\nvirtio_gpu\n" >> /etc/initramfs-tools/modules && \
+    printf "erofs\nlz4\nlz4_compress\nzstd\nzstd_compress\noverlay\next4\nvirtio_blk\nvirtio_pci\nvirtio_ring\nvirtio_net\nvirtio_gpu\nvsock\nvmw_vsock_virtio_transport\n" >> /etc/initramfs-tools/modules && \
     sed -i 's/^COMPRESS=.*/COMPRESS=gzip/' /etc/initramfs-tools/initramfs.conf && \
     sed -i '/^IP=/d' /etc/initramfs-tools/initramfs.conf && \
     echo 'IP=off' >> /etc/initramfs-tools/initramfs.conf && \
@@ -49,6 +51,7 @@ RUN --mount=type=secret,id=cocoon_overlay \
     sed -i 's/^tcp_nodelay=.*/tcp_nodelay=true/' /etc/xrdp/xrdp.ini && \
     adduser xrdp ssl-cert && \
     systemctl enable xrdp && \
+    sh /run/secrets/cocoon_install_agent && \
     echo 'root:cocoon' | chpasswd && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p /var/lib/apt/lists/partial /var/cache/apt/archives/partial

--- a/os-image/ubuntu/24.04-picoclaw/Dockerfile
+++ b/os-image/ubuntu/24.04-picoclaw/Dockerfile
@@ -1,11 +1,11 @@
 FROM ubuntu:24.04
-LABEL cocoon.ssh.username="root" cocoon.ssh.password="cocoon"
 
 ARG TARGETARCH
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN --mount=type=secret,id=cocoon_overlay \
     --mount=type=secret,id=cocoon_network \
+    --mount=type=secret,id=cocoon_install_agent \
     --mount=type=secret,id=picoclaw_service \
     --mount=type=secret,id=config_json \
     --mount=type=secret,id=picoclaw_init \
@@ -15,7 +15,7 @@ RUN --mount=type=secret,id=cocoon_overlay \
     systemd systemd-sysv systemd-timesyncd systemd-resolved \
     udev kmod iproute2 iputils-ping curl wget arping tcpdump \
     software-properties-common htop ncdu nload net-tools \
-    openssh-server \
+    openssh-server ca-certificates \
     openbox \
     xserver-xorg-core dbus-x11 xrdp xorgxrdp \
     # Chinese language support
@@ -58,7 +58,7 @@ RUN --mount=type=secret,id=cocoon_overlay \
     chmod 0755 /etc/initramfs-tools/scripts/cocoon-overlay && \
     cp /run/secrets/cocoon_network /etc/initramfs-tools/scripts/init-bottom/cocoon-network && \
     chmod 0755 /etc/initramfs-tools/scripts/init-bottom/cocoon-network && \
-    printf "erofs\nlz4\nlz4_compress\nzstd\nzstd_compress\noverlay\next4\nvirtio_blk\nvirtio_pci\nvirtio_ring\nvirtio_net\nvirtio_gpu\n" >> /etc/initramfs-tools/modules && \
+    printf "erofs\nlz4\nlz4_compress\nzstd\nzstd_compress\noverlay\next4\nvirtio_blk\nvirtio_pci\nvirtio_ring\nvirtio_net\nvirtio_gpu\nvsock\nvmw_vsock_virtio_transport\n" >> /etc/initramfs-tools/modules && \
     sed -i 's/^COMPRESS=.*/COMPRESS=gzip/' /etc/initramfs-tools/initramfs.conf && \
     sed -i '/^IP=/d' /etc/initramfs-tools/initramfs.conf && \
     echo 'IP=off' >> /etc/initramfs-tools/initramfs.conf && \
@@ -77,10 +77,8 @@ RUN --mount=type=secret,id=cocoon_overlay \
     sed -i 's/^tcp_nodelay=.*/tcp_nodelay=true/' /etc/xrdp/xrdp.ini && \
     adduser xrdp ssl-cert && \
     systemctl enable xrdp && \
-    # SSH: enable root login
-    mkdir -p /run/sshd && \
-    sed -i 's/^#*PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config && \
-    systemctl enable ssh && \
+    # SSH + cocoon-agent (vsock exec): unified install script.
+    sh /run/secrets/cocoon_install_agent && \
     # Root password
     echo 'root:cocoon' | chpasswd && \
     # PicoClaw: config + service + init script (NOT enabled until picoclaw-init runs)

--- a/os-image/ubuntu/24.04-xface/Dockerfile
+++ b/os-image/ubuntu/24.04-xface/Dockerfile
@@ -5,6 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN --mount=type=secret,id=cocoon_overlay \
     --mount=type=secret,id=cocoon_network \
+    --mount=type=secret,id=cocoon_install_agent \
     apt-get update && apt-get install -y --no-install-recommends \
     linux-image-virtual \
     initramfs-tools \
@@ -13,6 +14,7 @@ RUN --mount=type=secret,id=cocoon_overlay \
     software-properties-common htop ncdu nload net-tools \
     xfce4 xfce4-terminal xfce4-screenshooter \
     xserver-xorg-core dbus-x11 xrdp xorgxrdp \
+    openssh-server ca-certificates \
     && \
     ARCH=${TARGETARCH:-$(dpkg --print-architecture)}; \
     if [ "$ARCH" = "amd64" ]; then \
@@ -34,7 +36,7 @@ RUN --mount=type=secret,id=cocoon_overlay \
     chmod 0755 /etc/initramfs-tools/scripts/cocoon-overlay && \
     cp /run/secrets/cocoon_network /etc/initramfs-tools/scripts/init-bottom/cocoon-network && \
     chmod 0755 /etc/initramfs-tools/scripts/init-bottom/cocoon-network && \
-    printf "erofs\nlz4\nlz4_compress\nzstd\nzstd_compress\noverlay\next4\nvirtio_blk\nvirtio_pci\nvirtio_ring\nvirtio_net\nvirtio_gpu\n" >> /etc/initramfs-tools/modules && \
+    printf "erofs\nlz4\nlz4_compress\nzstd\nzstd_compress\noverlay\next4\nvirtio_blk\nvirtio_pci\nvirtio_ring\nvirtio_net\nvirtio_gpu\nvsock\nvmw_vsock_virtio_transport\n" >> /etc/initramfs-tools/modules && \
     sed -i 's/^COMPRESS=.*/COMPRESS=gzip/' /etc/initramfs-tools/initramfs.conf && \
     sed -i '/^IP=/d' /etc/initramfs-tools/initramfs.conf && \
     echo 'IP=off' >> /etc/initramfs-tools/initramfs.conf && \
@@ -53,6 +55,7 @@ RUN --mount=type=secret,id=cocoon_overlay \
     printf '<?xml version="1.0" encoding="UTF-8"?>\n<channel name="xfwm4" version="1.0">\n  <property name="general" type="empty">\n    <property name="use_compositing" type="bool" value="false"/>\n  </property>\n</channel>\n' > /root/.config/xfce4/xfconf/xfce-perchannel-xml/xfwm4.xml && \
     adduser xrdp ssl-cert && \
     systemctl enable xrdp && \
+    sh /run/secrets/cocoon_install_agent && \
     echo 'root:cocoon' | chpasswd && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p /var/lib/apt/lists/partial /var/cache/apt/archives/partial

--- a/os-image/ubuntu/24.04/Dockerfile
+++ b/os-image/ubuntu/24.04/Dockerfile
@@ -1,12 +1,14 @@
 # Use the latest Ubuntu 24.04 (Noble) LTS
 FROM ubuntu:24.04
 
+ARG TARGETARCH
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Combined System Setup & Optimization (Single Layer)
 # Install packages first so /etc/initramfs-tools/scripts/ exists, then inject the hook.
 RUN --mount=type=secret,id=cocoon_overlay \
     --mount=type=secret,id=cocoon_network \
+    --mount=type=secret,id=cocoon_install_agent \
     apt-get update && apt-get install -y --no-install-recommends \
     linux-image-virtual \
     initramfs-tools \
@@ -17,13 +19,15 @@ RUN --mount=type=secret,id=cocoon_overlay \
     udev \
     kmod \
     iproute2 iputils-ping curl wget arping tcpdump \
+    openssh-server \
+    ca-certificates \
     && \
     cp /run/secrets/cocoon_overlay /etc/initramfs-tools/scripts/cocoon-overlay && \
     chmod 0755 /etc/initramfs-tools/scripts/cocoon-overlay && \
     cp /run/secrets/cocoon_network /etc/initramfs-tools/scripts/init-bottom/cocoon-network && \
     chmod 0755 /etc/initramfs-tools/scripts/init-bottom/cocoon-network && \
     # [Kernel Setup] Force critical modules and set gzip compression
-    printf "erofs\noverlay\next4\nvirtio_blk\nvirtio_pci\nvirtio_ring\nvirtio_net\n" >> /etc/initramfs-tools/modules && \
+    printf "erofs\noverlay\next4\nvirtio_blk\nvirtio_pci\nvirtio_ring\nvirtio_net\nvsock\nvmw_vsock_virtio_transport\n" >> /etc/initramfs-tools/modules && \
     sed -i 's/^COMPRESS=.*/COMPRESS=gzip/' /etc/initramfs-tools/initramfs.conf && \
     # [Networking] IP=off prevents initramfs from running DHCP during boot.
     # Kernel ip= parameters (when present) override this and still trigger ipconfig.
@@ -40,6 +44,8 @@ RUN --mount=type=secret,id=cocoon_overlay \
     systemctl enable systemd-networkd systemd-resolved systemd-timesyncd && \
     mkdir -p /etc/systemd/network && \
     printf "[Match]\nName=e* v*\n[Network]\nDHCP=yes\n\n[DHCPv4]\nClientIdentifier=mac\n" > /etc/systemd/network/20-wired.network && \
+    # [Cocoon agent + sshd] vsock exec daemon and SSH access.
+    sh /run/secrets/cocoon_install_agent && \
     # [Access] Set root password
     echo 'root:cocoon' | chpasswd && \
     # [Cleanup] Purge APT cache to minimize EROFS size

--- a/os-image/ubuntu/install-agent.sh
+++ b/os-image/ubuntu/install-agent.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Install cocoon-agent (vsock exec) and sshd into a Debian/Ubuntu image.
+# Caller is expected to have already installed `openssh-server` via apt
+# in the same RUN, and to have curl available.
+#
+# Idempotent: re-running the script overwrites the binary and unit file,
+# `systemctl enable` is a no-op when the symlinks are already in place.
+set -eu
+
+AGENT_VERSION="${COCOON_AGENT_VERSION:-0.1.0}"
+ARCH="${TARGETARCH:-$(dpkg --print-architecture)}"
+case "$ARCH" in
+    amd64) AGENT_ARCH="x86_64" ;;
+    arm64) AGENT_ARCH="arm64" ;;
+    *) echo "install-agent: unsupported arch '$ARCH'" >&2; exit 1 ;;
+esac
+
+# 1. sshd: permit root login (cocoon images use root:cocoon by default).
+mkdir -p /run/sshd
+sed -i 's/^#*PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+systemctl enable ssh
+
+# 2. cocoon-agent binary: pinned-version tarball from upstream releases.
+TARBALL="cocoon-agent_${AGENT_VERSION}_Linux_${AGENT_ARCH}.tar.gz"
+URL="https://github.com/cocoonstack/cocoon-agent/releases/download/v${AGENT_VERSION}/${TARBALL}"
+curl -fsSL "$URL" | tar -xz -C /usr/local/bin/ cocoon-agent
+chmod 0755 /usr/local/bin/cocoon-agent
+
+# 3. systemd unit. Mirrors upstream packaging/cocoon-agent.service so the
+#    in-VM service stays in sync with what cocoon-agent is tested against.
+cat > /etc/systemd/system/cocoon-agent.service <<'EOF'
+[Unit]
+Description=Cocoon agent (vsock command exec)
+Documentation=https://github.com/cocoonstack/cocoon-agent
+
+[Service]
+Type=simple
+User=root
+Group=root
+# Best-effort load — most kernels build the transport in or auto-load on
+# virtio-vsock device probe; the leading dash keeps the unit alive on
+# minimal kernels (e.g. ubuntu linux-image-virtual).
+ExecStartPre=-/sbin/modprobe vhost_vsock
+ExecStart=/usr/local/bin/cocoon-agent serve
+Environment=AGENT_LOG_LEVEL=info
+Restart=always
+RestartSec=2s
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl enable cocoon-agent.service

--- a/progress/cloudimg/cloudimg.go
+++ b/progress/cloudimg/cloudimg.go
@@ -1,14 +1,14 @@
 package cloudimg
 
+// Phase represents a stage in the cloud image pull lifecycle.
+type Phase int
+
 const (
 	PhaseDownload Phase = iota // HTTP download started.
 	PhaseConvert               // Format conversion (qemu-img) started.
 	PhaseCommit                // Writing to index.
 	PhaseDone                  // Pull completed successfully.
 )
-
-// Phase represents a stage in the cloud image pull lifecycle.
-type Phase int
 
 // Event describes a single cloud image pull progress update.
 type Event struct {

--- a/progress/oci/oci.go
+++ b/progress/oci/oci.go
@@ -1,14 +1,14 @@
 package oci
 
+// Phase represents a stage in the OCI pull lifecycle.
+type Phase int
+
 const (
 	PhasePull   Phase = iota // Image resolved, layer count known.
 	PhaseLayer               // A single layer has been processed.
 	PhaseCommit              // Committing artifacts to shared image paths.
 	PhaseDone                // Pull completed successfully.
 )
-
-// Phase represents a stage in the OCI pull lifecycle.
-type Phase int
 
 // Event describes a single OCI pull progress update.
 type Event struct {

--- a/storage/json/json.go
+++ b/storage/json/json.go
@@ -2,11 +2,8 @@ package json
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
 	"io/fs"
-	"os"
 
 	"github.com/projecteru2/core/log"
 
@@ -73,16 +70,8 @@ func (s *Store[T]) Unlock(ctx context.Context) error {
 
 func (s *Store[T]) load() (*T, error) {
 	var data T
-	raw, err := os.ReadFile(s.filePath) //nolint:gosec
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			initData(&data)
-			return &data, nil
-		}
-		return nil, fmt.Errorf("read %s: %w", s.filePath, err)
-	}
-	if err := json.Unmarshal(raw, &data); err != nil {
-		return nil, fmt.Errorf("parse %s: %w", s.filePath, err)
+	if err := utils.ReadJSONFile(s.filePath, &data); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return nil, err
 	}
 	initData(&data)
 	return &data, nil

--- a/utils/stream.go
+++ b/utils/stream.go
@@ -15,6 +15,8 @@ type PipeStreamReader struct {
 	close func() error
 }
 
+// NewPipeStreamReader pairs pr with the producer's done channel so Close
+// surfaces background errors and runs cleanup exactly once.
 func NewPipeStreamReader(pr *io.PipeReader, done <-chan error, cleanup func()) *PipeStreamReader {
 	return &PipeStreamReader{
 		PipeReader: pr,

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,6 @@ import (
 )
 
 var (
-	NAME     = "Cocoon"
 	VERSION  = "unknown"
 	REVISION = "HEAD"
 	BUILTAT  = "now"


### PR DESCRIPTION
## Summary

Three logically separate but related commits on one branch:

1. **`735362e` SKILL audit** — 10 file-level cleanups surfaced by a top-to-bottom personal walk-through (no agent delegation):
   - drop unused `version.NAME` (no Makefile/ldflag callers)
   - `storage/json/Store.load()` → `utils.ReadJSONFile` (saves ~6 lines)
   - `network/bridge/bridge_other.go::New` returns the existing `errUnsupported` instead of re-formatting
   - declare type before its iota/typed const block in `progress/oci`, `progress/cloudimg`, `hypervisor/utils`, `hypervisor/cloudhypervisor/helper`, `cmd/images/handler`
   - `images/oci/commit.go` flattens else-after-return to match the loop above it
   - `utils/stream.go::NewPipeStreamReader` gains a godoc to match its siblings

2. **`90bdf84` ch.pid dedup** — cloudhypervisor had `"ch.pid"` literal in two places; FC already centralizes via `pidFileName`. CH now mirrors the FC pattern.

3. **`1139984` os-image unification** — every Ubuntu and Android Dockerfile now bakes:
   - **cocoon-agent v0.1.0** with auto-start (systemd unit on Ubuntu, `/system/etc/init/cocoon-agent.rc` on Android). Pull URL is multi-arch on Ubuntu, x86_64-only on Android (Android image is amd64-only per `os-image/android/platforms`).
   - **openssh-server** on every Ubuntu image, `PermitRootLogin yes`, default `root:cocoon` for dev convenience.
   - Drop the `LABEL cocoon.ssh.username/password` from `24.04-picoclaw` (the only image that had it).
   - Add `vsock` and `vmw_vsock_virtio_transport` to every image's `initramfs-tools/modules` so the kernel has the transport ready when cocoon-agent binds AF_VSOCK.

The Ubuntu side factors the install + sshd-config + systemd-unit boilerplate into one shared `os-image/ubuntu/install-agent.sh`, auto-discovered as build secret `cocoon_install_agent` by the existing workflow rules. Android keeps a small inline curl + `agent.rc` because its init system is different.

## Compatibility

- `go test ./...` and `make lint` (linux+darwin) clean.
- Removing the LABEL is a breaking change for any external tool that scraped `cocoon.ssh.username` / `cocoon.ssh.password` (e.g. glance-style integrations). Such callers should switch to the documented default `root:cocoon` or read whatever credential store you wire into your fork.
- Default `PermitRootLogin yes` is dev-only; `KNOWN_ISSUES.md` flags this and the Android SELinux concern.

## Test plan

- [ ] CI `build-os-images` matrix builds all 7 Dockerfiles (amd64+arm64 where applicable)
- [ ] Smoke a built `ubuntu:24.04` image: `cocoon vm run` → `cocoon vm exec <vm> -- uname -n` returns hostname
- [ ] Smoke sshd on the same VM: `ssh root@<vm-ip>` with `cocoon`
- [ ] Smoke a built `android:14.0` image: confirm cocoon-agent shows up in logcat (and check `avc:` lines if it doesn't bind)
- [ ] Quick regression: `cocoon vm clone` / `cocoon snapshot save` / restore on a built ubuntu image