### PR TITLE
feat(image): validate ref shape against ImageType before auto-pull

### DIFF
--- a/cmd/core/ensure_image_test.go
+++ b/cmd/core/ensure_image_test.go
@@ -98,9 +98,8 @@ func TestEnsureImage_ForceWhenDigestPinned(t *testing.T) {
 	}
 }
 
-// Issue 38 regression: a cloudimg vmCfg.Image without an http(s) scheme
-// must not reach Pull — that would surface as `unsupported protocol scheme`
-// from http.Get. The shape guard short-circuits with an actionable warning.
+// A cloudimg ref without an http(s) scheme reaching Pull surfaces as
+// `unsupported protocol scheme` from http.Get; the shape guard short-circuits.
 func TestEnsureImage_SkipsBadShape(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -109,6 +108,7 @@ func TestEnsureImage_SkipsBadShape(t *testing.T) {
 	}{
 		{"cloudimg bare OCI ref", "simular/win10:22h2-20260510", types.ImageTypeCloudImg},
 		{"cloudimg local name", "win11", types.ImageTypeCloudImg},
+		{"cloudimg non-http scheme", "file:///foo.img", types.ImageTypeCloudImg},
 		{"oci malformed ref", "::bad::", types.ImageTypeOCI},
 	}
 	for _, tt := range tests {
@@ -119,6 +119,29 @@ func TestEnsureImage_SkipsBadShape(t *testing.T) {
 			})
 			if len(f.pullRefs) != 0 {
 				t.Errorf("Pull called %d time(s) with %v, want 0 (shape should have failed)", len(f.pullRefs), f.pullRefs)
+			}
+		})
+	}
+}
+
+// Acceptance counterpart: well-formed refs must reach Pull.
+func TestEnsureImage_AcceptsGoodShape(t *testing.T) {
+	tests := []struct {
+		name      string
+		image     string
+		imageType string
+	}{
+		{"cloudimg https url", "https://cloud-images.ubuntu.com/x.img", types.ImageTypeCloudImg},
+		{"oci tagged ref", "ghcr.io/cocoonstack/cocoon/ubuntu:24.04", types.ImageTypeOCI},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &fakeImageBackend{typ: tt.imageType}
+			EnsureImage(t.Context(), []imagebackend.Images{f}, &types.VMConfig{
+				Config: types.Config{Image: tt.image, ImageType: tt.imageType},
+			})
+			if len(f.pullRefs) != 1 || f.pullRefs[0] != tt.image {
+				t.Errorf("Pull = %v, want one call for %q", f.pullRefs, tt.image)
 			}
 		})
 	}

--- a/cmd/core/ensure_image_test.go
+++ b/cmd/core/ensure_image_test.go
@@ -98,6 +98,32 @@ func TestEnsureImage_ForceWhenDigestPinned(t *testing.T) {
 	}
 }
 
+// Issue 38 regression: a cloudimg vmCfg.Image without an http(s) scheme
+// must not reach Pull — that would surface as `unsupported protocol scheme`
+// from http.Get. The shape guard short-circuits with an actionable warning.
+func TestEnsureImage_SkipsBadShape(t *testing.T) {
+	tests := []struct {
+		name      string
+		image     string
+		imageType string
+	}{
+		{"cloudimg bare OCI ref", "simular/win10:22h2-20260510", types.ImageTypeCloudImg},
+		{"cloudimg local name", "win11", types.ImageTypeCloudImg},
+		{"oci malformed ref", "::bad::", types.ImageTypeOCI},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &fakeImageBackend{typ: tt.imageType}
+			EnsureImage(t.Context(), []imagebackend.Images{f}, &types.VMConfig{
+				Config: types.Config{Image: tt.image, ImageType: tt.imageType},
+			})
+			if len(f.pullRefs) != 0 {
+				t.Errorf("Pull called %d time(s) with %v, want 0 (shape should have failed)", len(f.pullRefs), f.pullRefs)
+			}
+		})
+	}
+}
+
 func TestEnsureImage_SkipsPullWhenDigestLocal(t *testing.T) {
 	const digest = "sha256:adafd938488daa114be898848eb24b9b0afffc21ac18f8b11f3f0057644b11e1"
 	f := &fakeImageBackend{

--- a/cmd/core/helpers.go
+++ b/cmd/core/helpers.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -248,6 +249,10 @@ func EnsureImage(ctx context.Context, backends []imagebackend.Images, vmCfg *typ
 		// Pull by digest reference when available — ensures we get the exact
 		// version recorded at snapshot time, not whatever the tag points to now.
 		pullRef := digestPullRef(vmCfg.Image, vmCfg.ImageDigest, vmCfg.ImageType)
+		if shapeErr := validateRefShape(pullRef, vmCfg.ImageType); shapeErr != nil {
+			logger.Warnf(ctx, "skipping auto-pull of %s: %v — pre-pull manually if missing", pullRef, shapeErr)
+			return
+		}
 		logger.Infof(ctx, "base image not found locally, pulling %s ...", pullRef)
 		// Pinned digest with no local hit: force past cloudimg's URL-keyed cache.
 		needForce := vmCfg.ImageDigest != ""
@@ -489,6 +494,28 @@ func FormatSize(bytes int64) string {
 
 func IsURL(ref string) bool {
 	return strings.HasPrefix(ref, "http://") || strings.HasPrefix(ref, "https://")
+}
+
+// validateRefShape catches malformed base-image refs before they hit a backend
+// that would return a misleading downstream error. Each backend expects a
+// different ref form: cloudimg fetches over HTTP so the ref must be a URL
+// with scheme; OCI pulls via container registry protocol so the ref must be
+// parseable by name.ParseReference (registry/repo:tag or repo@digest).
+// A bare OCI form leaking into the cloudimg path (the issue 38 failure mode)
+// would otherwise surface as `unsupported protocol scheme ""` from http.Get.
+func validateRefShape(ref, imageType string) error {
+	switch imageType {
+	case types.ImageTypeCloudImg:
+		u, err := url.Parse(ref)
+		if err != nil || u.Scheme == "" {
+			return fmt.Errorf("cloudimg ref %q is not an http(s) URL (imported or bare OCI ref?)", ref)
+		}
+	case types.ImageTypeOCI:
+		if _, err := name.ParseReference(ref); err != nil {
+			return fmt.Errorf("oci ref %q is not a valid OCI reference: %w", ref, err)
+		}
+	}
+	return nil
 }
 
 // digestPullRef pins OCI pulls by digest; returns image as-is for others.

--- a/cmd/core/helpers.go
+++ b/cmd/core/helpers.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -497,17 +496,14 @@ func IsURL(ref string) bool {
 }
 
 // validateRefShape catches malformed base-image refs before they hit a backend
-// that would return a misleading downstream error. Each backend expects a
-// different ref form: cloudimg fetches over HTTP so the ref must be a URL
-// with scheme; OCI pulls via container registry protocol so the ref must be
-// parseable by name.ParseReference (registry/repo:tag or repo@digest).
-// A bare OCI form leaking into the cloudimg path (the issue 38 failure mode)
-// would otherwise surface as `unsupported protocol scheme ""` from http.Get.
+// that would surface a misleading downstream error. cloudimg fetches over HTTP
+// (ref must start with http:// or https://); OCI pulls via registry protocol
+// (ref must parse via name.ParseReference). A bare OCI ref leaking into the
+// cloudimg path would otherwise surface as `unsupported protocol scheme ""`.
 func validateRefShape(ref, imageType string) error {
 	switch imageType {
 	case types.ImageTypeCloudImg:
-		u, err := url.Parse(ref)
-		if err != nil || u.Scheme == "" {
+		if !IsURL(ref) {
 			return fmt.Errorf("cloudimg ref %q is not an http(s) URL (imported or bare OCI ref?)", ref)
 		}
 	case types.ImageTypeOCI:


### PR DESCRIPTION
## Summary

`EnsureImage` drives pulls based on `vmCfg.ImageType` but never validated that `vmCfg.Image` actually has the shape the chosen backend can handle. Mismatch surfaces deep:

- A **cloudimg** backend with a bare OCI ref (\`simular/win10:22h2-20260510\` — the issue 38 failure mode) ran all the way down to \`http.Get()\` and returned \`unsupported protocol scheme \"\"\`.
- An **OCI** backend with a malformed ref reported a similarly downstream-looking error from \`go-containerregistry\`.

This PR adds \`validateRefShape(ref, imageType)\` ahead of \`Pull\`:

- \`cloudimg\` → must be a URL with scheme (\`http\`/\`https\`); bare refs or local names are imported images that auto-pull can't materialize anyway
- \`oci\` → must be parseable by \`name.ParseReference\`

Malformed refs short-circuit with an actionable warning instead of a wasted HTTP round-trip.

## Scope

This is a **defensive guard**, not the issue 38 fix proper. The real issue 38 fix lives on the **vk-cocoon** side: stop writing bare OCI refs into \`cocoonstack.snapshot.baseimage\` annotations for cloudimg bases. Once vk-cocoon writes fully-qualified \`/dl/{name}/{ref}\` URLs (which the [cocoonstack/epoch#4](https://github.com/cocoonstack/epoch/pull/4) routes now support), this guard becomes a no-op on the happy path — it only fires when something has gone wrong upstream.

Two complementary benefits independent of issue 38:

1. **Better error messages**: \`cocoon vm clone\` against mis-annotated snapshots fails fast with \"is not an http(s) URL (imported or bare OCI ref?)\" instead of \"unsupported protocol scheme\".
2. **Cross-registry parity**: \`validateRefShape\` doesn't assume epoch — the URL check just requires a scheme. Snapshots referencing arbitrary cloudimg sources (\`https://cloud-images.ubuntu.com/...\`, internal mirrors) all pass; only truly malformed refs are rejected.

## Test plan

- [x] New unit test \`TestEnsureImage_SkipsBadShape\` covers three malformed combinations:
  - cloudimg + bare OCI ref → skipped
  - cloudimg + local image name → skipped
  - OCI + unparseable ref → skipped
- [x] \`go test ./...\` clean
- [x] \`go build ./...\` clean
- [x] Existing \`TestEnsureImage_ForceWhenDigestPinned\` + \`TestEnsureImage_SkipsPullWhenDigestLocal\` unchanged

## Followups

- vk-cocoon side fix for issue 38: write \`baseimage\` annotation as fully-qualified URL with explicit ref (tag-pinned or manifest-digest-pinned form)