### PR TITLE
style(utils): trim RunQemuImg godoc + move subprocess marker inline

### DIFF
--- a/utils/qemuimg.go
+++ b/utils/qemuimg.go
@@ -7,20 +7,15 @@ import (
 	"strings"
 )
 
-// RunQemuImg shells out to qemu-img with the supplied args (e.g.
-// "create", "-f", "qcow2", ...) and wraps any non-zero exit with the
-// trimmed combined output. Use this for operations that have no
-// meaningful stdout (create, resize, convert). For queries that need
-// a clean stdout payload — e.g. `info --output=json` — call
-// exec.CommandContext directly.
-//
-// cocoon shells out to qemu-img because there is no mature Go qcow2
-// writer that covers create/resize/convert with the same fidelity;
-// upstream qemu-img is authoritative for the disk-format matrix.
+// RunQemuImg shells out to qemu-img and wraps any non-zero exit with the
+// trimmed combined output. Use this for operations without meaningful
+// stdout (create, resize, convert); for queries that need a clean stdout
+// payload (e.g. `info --output=json`), call exec.CommandContext directly.
 func RunQemuImg(ctx context.Context, args ...string) error {
 	if len(args) == 0 {
 		return fmt.Errorf("qemu-img: no args")
 	}
+	// shell out because no Go qcow2 writer covers create/resize/convert at qemu-img's fidelity.
 	out, err := exec.CommandContext(ctx, "qemu-img", args...).CombinedOutput() //nolint:gosec
 	if err != nil {
 		return fmt.Errorf("qemu-img %s: %s: %w", args[0], strings.TrimSpace(string(out)), err)


### PR DESCRIPTION
## Summary

Comment audit on 205 Go files turned up one trim candidate. `utils.RunQemuImg`'s 10-line godoc duplicated the "shell out because qemu-img is authoritative" rationale that all 5 other subprocess sites in cocoonv2 keep as a 1-line `// shell out because…` comment next to the `exec.Command` call:

- `images/oci/erofs.go` — `// shell out because no Go EROFS writer library; mkfs.erofs is authoritative.`
- `images/cloudimg/inspect.go` — `// shell out because no Go inspector covers the full disk format matrix; qemu-img is authoritative.`
- `hypervisor/utils.go` — `// shell out because no Go ext4 formatter library; mkfs.ext4 is authoritative.`
- `hypervisor/cloudhypervisor/start.go` — `// shell out: the cloud-hypervisor binary is the authoritative VMM.`
- `hypervisor/firecracker/start.go` — `// shell out: the firecracker binary is the authoritative VMM.`

`RunQemuImg`'s godoc was the only one carrying the rationale as a separate paragraph in the doc comment. Trim to:
- Godoc keeps the actual contract (when to use, when NOT to use).
- Subprocess justification moves onto the `exec.CommandContext` line for sibling parity.

## Audit summary (no other actionable findings)

**Senior SKILL.md walk** on 205 files:
- const/var blocks, sentinels, logging, context, file org, error wrap, no Chinese, no shadow — all clean.
- Long comment blocks (23 of 6+ lines, 34 of 4–5 lines) reviewed — 22/23 long-blocks and a 10-sample of medium-blocks carry load-bearing engineering rationale (race conditions, perf numbers, contract enumerations, non-obvious invariants). 1 trim applied (this PR).

**/simplify x3 parallel** (reuse/quality/efficiency, 27 findings total) — verified each, all bogus or known-design:
- Quality: `console/resize.go` "goroutine never exits" — `for range closed-channel` is correct Go idiom; `fc/start.go` "subprocess leak" — relay is intentionally detached (Setpgid); `cmd/vm/status.go` "no ctx.Done() at outer loop" — ctx.Done IS the first outer case; `console/relay.go` channel buffering — documented "caller closes conn" contract.
- Efficiency: `cmd/vm/exec.go` "byte-per-read alloc" — buffer allocated once outside loop, comment explains why bufio would over-read; `images/oci/oci.go imageSizer` "redundant stats" — each stat is a different file (blob/kernel/initrd); `cloudimg/commit.go` "double ValidFile" — pre-lock probe + in-txn race-safe check, different purposes.
- Reuse: `fc/snapshot.go` vs `ch/snapshot.go` `buildSnapshotMeta` — structurally different (FC trusts rec order, CH reconciles against config.json; FC mutates BootConfig, CH passes through). `fc/api.go putJSON` vs `ch/helper.go vmPutJSON` — semantically opposite (FC retries idempotent PUTs, CH calls DoAPIOnce for non-idempotent). Unifying would manufacture abstractions that hide meaningful differences.

`make lint` linux+darwin: 0 issues. `go test ./...`: green.

## Test plan

- [x] `make lint` clean both GOOSes
- [x] `go test ./...` green
- [x] Sibling subprocess sites all carry inline `// shell out…` markers — pattern now uniform