### PR TITLE
feat(vm): cocoon vm net --nics N — runtime NIC resize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ tmp/*
 
 .claude/*
 cocoon-test
+
+# Local scratch / test scripts (not for upstream)
+/scratch/

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -251,7 +251,7 @@ Cocoon does not wait for B0EJ — there is no reliable signal from the CH HTTP A
 - The guest may continue to reference a NIC whose host plumbing is gone, hanging the in-guest driver.
 - The pending eject may surface later as `Cannot register ioevent: File exists` when CH next tries to reuse that slot (e.g. a subsequent hot-add).
 
-Quiesce the guest NIC (ip link set down + NetworkManager remove on Linux; Disable-PnpDevice + driver unbind on Windows) before reducing the count. Or pass `--keep-host-on-remove` to defer the host teardown.
+Quiesce the guest NIC (ip link set down + NetworkManager remove on Linux; Disable-PnpDevice + driver unbind on Windows) before reducing the count.
 
 Firecracker is not supported: FC has no NIC hot-plug / hot-unplug API.
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -242,6 +242,19 @@ Mitigations for production users:
 
 Control-plane traffic from cocoon-managed hosts (vk-cocoon, `cocoon vm exec`) goes through cocoon-agent over vsock and never depends on SSH credentials.
 
+## NIC hot-remove leaves the PCI slot pending on Cloud Hypervisor
+
+`cocoon vm net --nics N` tears down host TAP/veth/CNI plumbing immediately after `vm.remove-device` returns. CH only frees the PCI slot (and unregisters the device's ioeventfds) when the guest writes to the ACPI hot-plug controller (B0EJ) in response to the SCI raised by `remove-device`. If the guest is stopped, paused, or its NIC driver is wedged, the slot stays `Allocated` until the guest cooperates.
+
+Cocoon does not wait for B0EJ — there is no reliable signal from the CH HTTP API. The user accepts:
+
+- The guest may continue to reference a NIC whose host plumbing is gone, hanging the in-guest driver.
+- The pending eject may surface later as `Cannot register ioevent: File exists` when CH next tries to reuse that slot (e.g. a subsequent hot-add).
+
+Quiesce the guest NIC (ip link set down + NetworkManager remove on Linux; Disable-PnpDevice + driver unbind on Windows) before reducing the count. Or pass `--keep-host-on-remove` to defer the host teardown.
+
+Firecracker is not supported: FC has no NIC hot-plug / hot-unplug API.
+
 ## Android cocoon-agent service may be blocked by SELinux
 
 `os-image/android/{14.0,15.0}` install the cocoon-agent binary at `/system/bin/cocoon-agent` and register it via `/system/etc/init/cocoon-agent.rc`. Android's SELinux policies don't ship with a domain for cocoon-agent, so the service may run in `init`'s domain or be denied outright depending on the redroid build.

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -255,6 +255,10 @@ Quiesce the guest NIC (ip link set down + NetworkManager remove on Linux; Disabl
 
 Firecracker is not supported: FC has no NIC hot-plug / hot-unplug API.
 
+## NIC hot-remove during clone hot-swap cannot wait for guest B0EJ
+
+Plain `cocoon vm net --nics N` polls CH's `device_tree` after `vm.remove-device` until the guest ACKs B0EJ via ACPI/SCI (typically < 1 s on Linux, a few seconds on Windows). The clone path's `hotSwapNets` runs while the VM is paused, so the guest cannot process SCI — eject stays pending until resume. The clone path therefore returns without waiting and adds the fresh NICs against half-removed device-tree state. This is the long-standing CH limitation cocoon was designed around; the new wait only applies to the running-VM resize.
+
 ## Android cocoon-agent service may be blocked by SELinux
 
 `os-image/android/{14.0,15.0}` install the cocoon-agent binary at `/system/bin/cocoon-agent` and register it via `/system/etc/init/cocoon-agent.rc`. Android's SELinux policies don't ship with a domain for cocoon-agent, so the service may run in `init`'s domain or be denied outright depending on the redroid build.

--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ cocoon vm device detach my-vm --id mygpu
 
 ## NIC Hot-Resize (Cloud Hypervisor only)
 
-`cocoon vm net --nics N VM` brings the running VM's NIC count to `N`. Adds allocate new TAP/CNI/bridge plumbing on the host and hot-plug a fresh NIC into the guest; removes pop NICs from the tail (LIFO) via `vm.remove-device` and tear down the host plumbing.
+`cocoon vm net --nics N VM` brings the running VM's NIC count to `N`. To add NICs, cocoon allocates new host TAP/CNI/bridge plumbing and hot-plugs a fresh NIC into the guest. To remove NICs, it pops from the tail (LIFO) via `vm.remove-device` and tears down the host plumbing.
 
 ```bash
 # Add a second NIC (or any number).

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ cocoon
 │   ├── device
 │   │   ├── attach [flags] VM     Attach a VFIO PCI device (CH only)
 │   │   └── detach [flags] VM     Detach a VFIO PCI device by --id
+│   ├── net [flags] VM             Resize NIC count on a running VM (CH only)
 │   └── debug [flags] IMAGE        Generate hypervisor launch command (dry run)
 ├── snapshot
 │   ├── save [flags] VM            Create a snapshot from a running VM
@@ -519,6 +520,25 @@ cocoon vm device detach my-vm --id mygpu
 ```
 
 `cocoon vm inspect VM` includes an `attached_devices` field for running VMs that surfaces every attached vhost-user-fs share and VFIO device, read live from CH `vm.info`. The field is omitted for stopped VMs.
+
+## NIC Hot-Resize (Cloud Hypervisor only)
+
+`cocoon vm net --nics N VM` brings the running VM's NIC count to `N`. Adds allocate new TAP/CNI/bridge plumbing on the host and hot-plug a fresh NIC into the guest; removes pop NICs from the tail (LIFO) via `vm.remove-device` and tear down the host plumbing.
+
+```bash
+# Add a second NIC (or any number).
+cocoon vm net my-vm --nics 2
+
+# Remove a NIC (LIFO from the tail).
+cocoon vm net my-vm --nics 1
+
+# Keep host plumbing in place after vm.remove-device.
+cocoon vm net my-vm --nics 1 --keep-host-on-remove
+```
+
+Cocoon manages **host-side** plumbing only. CH's `vm.remove-device` marks the slot for ejection but the actual eject only happens when the guest cooperates via ACPI (B0EJ write). The host TAP / veth / CNI lease are torn down immediately after the API call regardless. Quiesce in-guest NIC state (driver unbind, NetworkManager removal, Windows NDIS halt) **before** reducing the count, or the in-guest driver will reference plumbing that no longer exists. Use `--keep-host-on-remove` if you want to defer host teardown.
+
+A VM started with zero NICs cannot be resized up (the VM record carries no provider hint). Start with at least one NIC if you plan to resize.
 
 ## Windows Support
 

--- a/README.md
+++ b/README.md
@@ -531,12 +531,9 @@ cocoon vm net my-vm --nics 2
 
 # Remove a NIC (LIFO from the tail).
 cocoon vm net my-vm --nics 1
-
-# Keep host plumbing in place after vm.remove-device.
-cocoon vm net my-vm --nics 1 --keep-host-on-remove
 ```
 
-Cocoon manages **host-side** plumbing only. CH's `vm.remove-device` marks the slot for ejection but the actual eject only happens when the guest cooperates via ACPI (B0EJ write). The host TAP / veth / CNI lease are torn down immediately after the API call regardless. Quiesce in-guest NIC state (driver unbind, NetworkManager removal, Windows NDIS halt) **before** reducing the count, or the in-guest driver will reference plumbing that no longer exists. Use `--keep-host-on-remove` if you want to defer host teardown.
+Cocoon manages **host-side** plumbing only. CH's `vm.remove-device` marks the slot for ejection but the actual eject only happens when the guest cooperates via ACPI (B0EJ write). The host TAP / veth / CNI lease are torn down immediately after the API call regardless. Quiesce in-guest NIC state (driver unbind, NetworkManager removal, Windows NDIS halt) **before** reducing the count, or the in-guest driver will reference plumbing that no longer exists.
 
 A VM started with zero NICs cannot be resized up (the VM record carries no provider hint). Start with at least one NIC if you plan to resize.
 

--- a/cmd/vm/attach.go
+++ b/cmd/vm/attach.go
@@ -9,13 +9,14 @@ import (
 	"github.com/spf13/cobra"
 
 	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
+	"github.com/cocoonstack/cocoon/config"
 	"github.com/cocoonstack/cocoon/extend/fs"
 	"github.com/cocoonstack/cocoon/extend/vfio"
 	"github.com/cocoonstack/cocoon/hypervisor"
 )
 
 func (h Handler) FsAttach(cmd *cobra.Command, args []string) error {
-	ctx, a, err := resolveAttacher[fs.Attacher](h, cmd, args, "fs attach", fs.ErrUnsupportedBackend)
+	ctx, _, _, a, err := resolveAttacher[fs.Attacher](h, cmd, args, "fs attach", fs.ErrUnsupportedBackend)
 	if err != nil {
 		return err
 	}
@@ -35,7 +36,7 @@ func (h Handler) FsAttach(cmd *cobra.Command, args []string) error {
 }
 
 func (h Handler) FsDetach(cmd *cobra.Command, args []string) error {
-	ctx, a, err := resolveAttacher[fs.Attacher](h, cmd, args, "fs detach", fs.ErrUnsupportedBackend)
+	ctx, _, _, a, err := resolveAttacher[fs.Attacher](h, cmd, args, "fs detach", fs.ErrUnsupportedBackend)
 	if err != nil {
 		return err
 	}
@@ -51,7 +52,7 @@ func (h Handler) FsDetach(cmd *cobra.Command, args []string) error {
 }
 
 func (h Handler) DeviceAttach(cmd *cobra.Command, args []string) error {
-	ctx, a, err := resolveAttacher[vfio.Attacher](h, cmd, args, "device attach", vfio.ErrUnsupportedBackend)
+	ctx, _, _, a, err := resolveAttacher[vfio.Attacher](h, cmd, args, "device attach", vfio.ErrUnsupportedBackend)
 	if err != nil {
 		return err
 	}
@@ -69,7 +70,7 @@ func (h Handler) DeviceAttach(cmd *cobra.Command, args []string) error {
 }
 
 func (h Handler) DeviceDetach(cmd *cobra.Command, args []string) error {
-	ctx, a, err := resolveAttacher[vfio.Attacher](h, cmd, args, "device detach", vfio.ErrUnsupportedBackend)
+	ctx, _, _, a, err := resolveAttacher[vfio.Attacher](h, cmd, args, "device detach", vfio.ErrUnsupportedBackend)
 	if err != nil {
 		return err
 	}
@@ -85,23 +86,24 @@ func (h Handler) DeviceDetach(cmd *cobra.Command, args []string) error {
 }
 
 // resolveAttacher resolves args[0] to a hypervisor implementing A
-// (fs.Attacher / vfio.Attacher). op ("fs attach", "device detach") prefixes
-// both error wraps so callers see the operation, not just the type-assert.
-func resolveAttacher[A any](h Handler, cmd *cobra.Command, args []string, op string, errUnsupported error) (context.Context, A, error) {
+// (fs.Attacher / vfio.Attacher / netresize.Resizer). op prefixes both error
+// wraps so callers see the operation. Returns the resolved hypervisor too
+// so callers can issue further generic ops (e.g. Inspect) without re-finding.
+func resolveAttacher[A any](h Handler, cmd *cobra.Command, args []string, op string, errUnsupported error) (context.Context, *config.Config, hypervisor.Hypervisor, A, error) {
 	var zero A
 	ctx, conf, err := h.Init(cmd)
 	if err != nil {
-		return ctx, zero, err
+		return ctx, nil, nil, zero, err
 	}
 	hyper, err := cmdcore.FindHypervisor(ctx, conf, args[0])
 	if err != nil {
-		return ctx, zero, fmt.Errorf("%s: %w", op, err)
+		return ctx, conf, nil, zero, fmt.Errorf("%s: %w", op, err)
 	}
 	a, ok := hyper.(A)
 	if !ok {
-		return ctx, zero, fmt.Errorf("%s: backend %s: %w", op, hyper.Type(), errUnsupported)
+		return ctx, conf, hyper, zero, fmt.Errorf("%s: backend %s: %w", op, hyper.Type(), errUnsupported)
 	}
-	return ctx, a, nil
+	return ctx, conf, hyper, a, nil
 }
 
 // classifyAttachErr surfaces ErrNotRunning more clearly than the generic wrap.

--- a/cmd/vm/attach.go
+++ b/cmd/vm/attach.go
@@ -85,10 +85,8 @@ func (h Handler) DeviceDetach(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// resolveAttacher resolves args[0] to a hypervisor implementing A
-// (fs.Attacher / vfio.Attacher / netresize.Resizer). op prefixes both error
-// wraps so callers see the operation. Returns the resolved hypervisor too
-// so callers can issue further generic ops (e.g. Inspect) without re-finding.
+// resolveAttacher resolves args[0] to a hypervisor implementing A; returns the
+// hypervisor too so callers can issue further generic ops without re-finding.
 func resolveAttacher[A any](h Handler, cmd *cobra.Command, args []string, op string, errUnsupported error) (context.Context, *config.Config, hypervisor.Hypervisor, A, error) {
 	var zero A
 	ctx, conf, err := h.Init(cmd)

--- a/cmd/vm/attach.go
+++ b/cmd/vm/attach.go
@@ -85,8 +85,7 @@ func (h Handler) DeviceDetach(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// resolveAttacher resolves args[0] to a hypervisor implementing A; returns the
-// hypervisor too so callers can issue further generic ops without re-finding.
+// resolveAttacher resolves args[0] to a hypervisor implementing A; also returns conf+hyper for further ops.
 func resolveAttacher[A any](h Handler, cmd *cobra.Command, args []string, op string, errUnsupported error) (context.Context, *config.Config, hypervisor.Hypervisor, A, error) {
 	var zero A
 	ctx, conf, err := h.Init(cmd)

--- a/cmd/vm/commands.go
+++ b/cmd/vm/commands.go
@@ -28,6 +28,7 @@ type Actions interface {
 	FsDetach(cmd *cobra.Command, args []string) error
 	DeviceAttach(cmd *cobra.Command, args []string) error
 	DeviceDetach(cmd *cobra.Command, args []string) error
+	NetResize(cmd *cobra.Command, args []string) error
 }
 
 // Command builds the "vm" parent command with all subcommands.
@@ -188,8 +189,23 @@ func Command(h Actions) *cobra.Command {
 		statusCmd,
 		buildFsCommand(h),
 		buildDeviceCommand(h),
+		buildNetCommand(h),
 	)
 	return vmCmd
+}
+
+func buildNetCommand(h Actions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "net VM",
+		Short: "Resize a running VM's NIC count (CH only); quiesce in-guest NIC state before reducing",
+		Args:  cobra.ExactArgs(1),
+		RunE:  h.NetResize,
+	}
+	cmd.Flags().Int("nics", -1, "target NIC count (required, >= 0)")
+	cmd.Flags().Bool("keep-host-on-remove", false, "skip host TAP/veth teardown after vm.remove-device")
+	_ = cmd.MarkFlagRequired("nics")
+	cmdcore.AddOutputFlag(cmd)
+	return cmd
 }
 
 func buildFsCommand(h Actions) *cobra.Command {

--- a/cmd/vm/commands.go
+++ b/cmd/vm/commands.go
@@ -202,7 +202,6 @@ func buildNetCommand(h Actions) *cobra.Command {
 		RunE:  h.NetResize,
 	}
 	cmd.Flags().Int("nics", -1, "target NIC count (required, >= 0)")
-	cmd.Flags().Bool("keep-host-on-remove", false, "skip host TAP/veth teardown after vm.remove-device")
 	_ = cmd.MarkFlagRequired("nics")
 	cmdcore.AddOutputFlag(cmd)
 	return cmd

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -386,7 +386,7 @@ func (h Handler) recoverNetwork(ctx context.Context, conf *config.Config, hyper 
 			continue
 		}
 		logger.Warnf(ctx, "network missing for VM %s, recovering", vm.ID)
-		if _, recoverErr := netProvider.Config(ctx, vm.ID, len(vm.NetworkConfigs), &vm.Config, vm.NetworkConfigs...); recoverErr != nil {
+		if _, recoverErr := netProvider.Add(ctx, vm.ID, &vm.Config, network.AddRecover(vm.NetworkConfigs)...); recoverErr != nil {
 			logger.Warnf(ctx, "recover network for VM %s: %v (start will fail)", vm.ID, recoverErr)
 		}
 	}

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -392,8 +392,7 @@ func (h Handler) recoverNetwork(ctx context.Context, conf *config.Config, hyper 
 	}
 }
 
-// providerForVM picks the network provider from persisted NetworkConfig;
-// cniProvider may be nil (lazy-init); bridgeCache must be non-nil.
+// providerForVM picks the network provider from persisted NetworkConfig; cniProvider may be nil (lazy-init), bridgeCache must be non-nil.
 func providerForVM(conf *config.Config, cniProvider network.Network, bridgeCache map[string]network.Network, configs []*types.NetworkConfig) (network.Network, error) {
 	if len(configs) == 0 {
 		return nil, fmt.Errorf("no network configs")

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -393,6 +393,8 @@ func (h Handler) recoverNetwork(ctx context.Context, conf *config.Config, hyper 
 }
 
 // providerForVM selects network provider from persisted NetworkConfig.
+// cniProvider may be nil — lazy-inited from conf when configs need CNI.
+// bridgeCache must be non-nil; resolved entries are inserted for reuse.
 func providerForVM(conf *config.Config, cniProvider network.Network, bridgeCache map[string]network.Network, configs []*types.NetworkConfig) (network.Network, error) {
 	if len(configs) == 0 {
 		return nil, fmt.Errorf("no network configs")
@@ -414,10 +416,10 @@ func providerForVM(conf *config.Config, cniProvider network.Network, bridgeCache
 		return p, nil
 	}
 	// "cni" or empty (backward compat).
-	if cniProvider == nil {
-		return nil, fmt.Errorf("cni provider not available")
+	if cniProvider != nil {
+		return cniProvider, nil
 	}
-	return cniProvider, nil
+	return cmdcore.InitNetwork(conf)
 }
 
 func batchRoutedCmd(ctx context.Context, cmd *cobra.Command, name, pastTense string, routed map[hypervisor.Hypervisor][]string, fn func(hypervisor.Hypervisor, []string) ([]string, error)) error {

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -392,9 +392,8 @@ func (h Handler) recoverNetwork(ctx context.Context, conf *config.Config, hyper 
 	}
 }
 
-// providerForVM selects network provider from persisted NetworkConfig.
-// cniProvider may be nil — lazy-inited from conf when configs need CNI.
-// bridgeCache must be non-nil; resolved entries are inserted for reuse.
+// providerForVM picks the network provider from persisted NetworkConfig;
+// cniProvider may be nil (lazy-init); bridgeCache must be non-nil.
 func providerForVM(conf *config.Config, cniProvider network.Network, bridgeCache map[string]network.Network, configs []*types.NetworkConfig) (network.Network, error) {
 	if len(configs) == 0 {
 		return nil, fmt.Errorf("no network configs")

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -399,7 +399,7 @@ func providerForVM(conf *config.Config, cniProvider network.Network, bridgeCache
 	}
 	// All NICs on a VM share the same backend.
 	cfg := configs[0]
-	if cfg.Backend == "bridge" {
+	if cfg.Backend == types.BackendBridge {
 		if cfg.BridgeDev == "" {
 			return nil, fmt.Errorf("bridge backend but no bridge device persisted")
 		}

--- a/cmd/vm/netresize.go
+++ b/cmd/vm/netresize.go
@@ -27,8 +27,7 @@ func (h Handler) NetResize(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("vm net: %w", err)
 	}
 	target, _ := cmd.Flags().GetInt("nics")
-	keepHost, _ := cmd.Flags().GetBool("keep-host-on-remove")
-	res, err := resizer.NetResize(ctx, args[0], netresize.Spec{Target: target, KeepHostOnRemove: keepHost}, plumbing)
+	res, err := resizer.NetResize(ctx, args[0], netresize.Spec{Target: target}, plumbing)
 	if err != nil {
 		return classifyAttachErr(err)
 	}

--- a/cmd/vm/netresize.go
+++ b/cmd/vm/netresize.go
@@ -43,8 +43,7 @@ func (h Handler) NetResize(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// plumbingForVM picks the provider matching the VM's existing NICs; zero NICs
-// is fatal because VMConfig carries no bridge hint to recover the choice.
+// plumbingForVM picks the provider for the VM's existing NICs; fails on zero NICs (VMConfig has no bridge hint).
 func plumbingForVM(conf *config.Config, configs []*types.NetworkConfig) (network.Network, error) {
 	if len(configs) == 0 {
 		return nil, fmt.Errorf("vm has zero NICs; resize up is not supported (start the VM with at least one NIC)")

--- a/cmd/vm/netresize.go
+++ b/cmd/vm/netresize.go
@@ -40,17 +40,11 @@ func (h Handler) NetResize(cmd *cobra.Command, args []string) error {
 }
 
 // plumbingForVM picks the network provider matching the VM's existing NICs.
-// Requires at least one NIC: VMConfig has no bridge hint, so a zero-NIC VM
-// can't be resized up without losing the original provider choice.
+// VMConfig has no bridge hint, so a zero-NIC VM can't be resized up without
+// losing the original provider choice.
 func plumbingForVM(conf *config.Config, configs []*types.NetworkConfig) (network.Network, error) {
 	if len(configs) == 0 {
 		return nil, fmt.Errorf("vm has zero NICs; resize up is not supported (start the VM with at least one NIC)")
 	}
-	if configs[0].Backend == types.BackendBridge {
-		if configs[0].BridgeDev == "" {
-			return nil, fmt.Errorf("bridge backend without bridge device")
-		}
-		return cmdcore.InitBridgeNetwork(conf, configs[0].BridgeDev)
-	}
-	return cmdcore.InitNetwork(conf)
+	return providerForVM(conf, nil, map[string]network.Network{}, configs)
 }

--- a/cmd/vm/netresize.go
+++ b/cmd/vm/netresize.go
@@ -1,0 +1,57 @@
+package vm
+
+import (
+	"fmt"
+
+	"github.com/projecteru2/core/log"
+	"github.com/spf13/cobra"
+
+	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
+	"github.com/cocoonstack/cocoon/config"
+	"github.com/cocoonstack/cocoon/extend/netresize"
+	"github.com/cocoonstack/cocoon/network"
+	"github.com/cocoonstack/cocoon/types"
+)
+
+func (h Handler) NetResize(cmd *cobra.Command, args []string) error {
+	ctx, conf, hyper, resizer, err := resolveAttacher[netresize.Resizer](h, cmd, args, "vm net", netresize.ErrUnsupportedBackend)
+	if err != nil {
+		return err
+	}
+	vm, err := hyper.Inspect(ctx, args[0])
+	if err != nil {
+		return fmt.Errorf("vm net: %w", err)
+	}
+	plumbing, err := plumbingForVM(conf, vm.NetworkConfigs)
+	if err != nil {
+		return fmt.Errorf("vm net: %w", err)
+	}
+	target, _ := cmd.Flags().GetInt("nics")
+	keepHost, _ := cmd.Flags().GetBool("keep-host-on-remove")
+	res, err := resizer.NetResize(ctx, args[0], netresize.Spec{Target: target, KeepHostOnRemove: keepHost}, plumbing)
+	if err != nil {
+		return classifyAttachErr(err)
+	}
+	if done, jsonErr := cmdcore.MaybeOutputJSON(cmd, res); done {
+		return jsonErr
+	}
+	log.WithFunc("cmd.vm.net").Infof(ctx, "resized %s: before=%d after=%d added=%d removed=%d",
+		args[0], res.Before, res.After, len(res.Added), len(res.Removed))
+	return nil
+}
+
+// plumbingForVM picks the network provider matching the VM's existing NICs.
+// Requires at least one NIC: VMConfig has no bridge hint, so a zero-NIC VM
+// can't be resized up without losing the original provider choice.
+func plumbingForVM(conf *config.Config, configs []*types.NetworkConfig) (network.Network, error) {
+	if len(configs) == 0 {
+		return nil, fmt.Errorf("vm has zero NICs; resize up is not supported (start the VM with at least one NIC)")
+	}
+	if configs[0].Backend == types.BackendBridge {
+		if configs[0].BridgeDev == "" {
+			return nil, fmt.Errorf("bridge backend without bridge device")
+		}
+		return cmdcore.InitBridgeNetwork(conf, configs[0].BridgeDev)
+	}
+	return cmdcore.InitNetwork(conf)
+}

--- a/cmd/vm/netresize.go
+++ b/cmd/vm/netresize.go
@@ -34,14 +34,17 @@ func (h Handler) NetResize(cmd *cobra.Command, args []string) error {
 	if done, jsonErr := cmdcore.MaybeOutputJSON(cmd, res); done {
 		return jsonErr
 	}
-	log.WithFunc("cmd.vm.net").Infof(ctx, "resized %s: before=%d after=%d added=%d removed=%d",
+	logger := log.WithFunc("cmd.vm.net")
+	logger.Infof(ctx, "resized %s: before=%d after=%d added=%d removed=%d",
 		args[0], res.Before, res.After, len(res.Added), len(res.Removed))
+	for _, w := range res.Warnings {
+		logger.Warnf(ctx, "%s: %s", args[0], w)
+	}
 	return nil
 }
 
-// plumbingForVM picks the network provider matching the VM's existing NICs.
-// VMConfig has no bridge hint, so a zero-NIC VM can't be resized up without
-// losing the original provider choice.
+// plumbingForVM picks the provider matching the VM's existing NICs; zero NICs
+// is fatal because VMConfig carries no bridge hint to recover the choice.
 func plumbingForVM(conf *config.Config, configs []*types.NetworkConfig) (network.Network, error) {
 	if len(configs) == 0 {
 		return nil, fmt.Errorf("vm has zero NICs; resize up is not supported (start the VM with at least one NIC)")

--- a/cmd/vm/run.go
+++ b/cmd/vm/run.go
@@ -480,7 +480,7 @@ func initNetwork(ctx context.Context, conf *config.Config, vmID string, nics int
 	// The network layer derives TAP queues from vmCfg.CPU.
 	origCPU := vmCfg.CPU
 	vmCfg.CPU = queues
-	configs, err := netProvider.Config(ctx, vmID, nics, vmCfg)
+	configs, err := netProvider.Add(ctx, vmID, vmCfg, network.AddRange(0, nics)...)
 	vmCfg.CPU = origCPU
 	if err != nil {
 		return nil, nil, fmt.Errorf("configure network: %w", err)

--- a/extend/netresize/netresize.go
+++ b/extend/netresize/netresize.go
@@ -1,0 +1,48 @@
+// Package netresize is the runtime interface for resizing a VM's NIC count.
+// Cocoon never touches the guest — the user must quiesce in-guest NIC state
+// (driver unbind / NetworkManager / NDIS) before reducing the count.
+package netresize
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+var ErrUnsupportedBackend = errors.New("backend does not support net resize")
+
+// Spec is one resize request.
+type Spec struct {
+	Target           int
+	KeepHostOnRemove bool
+}
+
+// NIC is one NIC's summary, returned in Result.Added / Result.Removed.
+type NIC struct {
+	Index int    `json:"index"`
+	TAP   string `json:"tap"`
+	MAC   string `json:"mac"`
+}
+
+// Result reports the before/after count and the NICs touched by the call.
+type Result struct {
+	Before  int   `json:"before"`
+	After   int   `json:"after"`
+	Added   []NIC `json:"added,omitempty"`
+	Removed []NIC `json:"removed,omitempty"`
+}
+
+// Resizer resizes the NIC count on a running VM.
+type Resizer interface {
+	NetResize(ctx context.Context, vmRef string, spec Spec) (Result, error)
+}
+
+// Normalize validates the spec. Returns an error if Target is negative.
+// Named for parity with extend/fs.Spec.Normalize even though no defaulting
+// is needed here.
+func (s *Spec) Normalize() error {
+	if s.Target < 0 {
+		return fmt.Errorf("--nics must be non-negative, got %d", s.Target)
+	}
+	return nil
+}

--- a/extend/netresize/netresize.go
+++ b/extend/netresize/netresize.go
@@ -7,6 +7,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
+	"github.com/cocoonstack/cocoon/network"
+	"github.com/cocoonstack/cocoon/types"
 )
 
 var ErrUnsupportedBackend = errors.New("backend does not support net resize")
@@ -32,14 +35,19 @@ type Result struct {
 	Removed []NIC `json:"removed,omitempty"`
 }
 
-// Resizer resizes the NIC count on a running VM.
-type Resizer interface {
-	NetResize(ctx context.Context, vmRef string, spec Spec) (Result, error)
+// Plumbing is the host-side network operations NetResize delegates to.
+// network.Network satisfies this implicitly.
+type Plumbing interface {
+	Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs ...network.AddSpec) ([]*types.NetworkConfig, error)
+	Remove(ctx context.Context, vmID string, indices ...int) error
 }
 
-// Normalize validates the spec. Returns an error if Target is negative.
-// Named for parity with extend/fs.Spec.Normalize even though no defaulting
-// is needed here.
+// Resizer resizes the NIC count on a running VM.
+type Resizer interface {
+	NetResize(ctx context.Context, vmRef string, spec Spec, plumbing Plumbing) (Result, error)
+}
+
+// Normalize validates the spec.
 func (s *Spec) Normalize() error {
 	if s.Target < 0 {
 		return fmt.Errorf("--nics must be non-negative, got %d", s.Target)

--- a/extend/netresize/netresize.go
+++ b/extend/netresize/netresize.go
@@ -16,8 +16,7 @@ var ErrUnsupportedBackend = errors.New("backend does not support net resize")
 
 // Spec is one resize request.
 type Spec struct {
-	Target           int
-	KeepHostOnRemove bool
+	Target int
 }
 
 // NIC is one NIC's summary, returned in Result.Added / Result.Removed.

--- a/extend/netresize/netresize.go
+++ b/extend/netresize/netresize.go
@@ -1,6 +1,4 @@
 // Package netresize is the runtime interface for resizing a VM's NIC count.
-// Cocoon never touches the guest — the user must quiesce in-guest NIC state
-// (driver unbind / NetworkManager / NDIS) before reducing the count.
 package netresize
 
 import (

--- a/extend/netresize/netresize.go
+++ b/extend/netresize/netresize.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cocoonstack/cocoon/types"
 )
 
+// ErrUnsupportedBackend signals the resolved hypervisor cannot resize NICs.
 var ErrUnsupportedBackend = errors.New("backend does not support net resize")
 
 // Spec is one resize request.
@@ -17,6 +18,7 @@ type Spec struct {
 	Target int
 }
 
+// NIC is one NIC summary surfaced through Result.Added / Result.Removed.
 type NIC struct {
 	Index int    `json:"index"`
 	TAP   string `json:"tap"`
@@ -39,10 +41,12 @@ type Plumbing interface {
 	Remove(ctx context.Context, vmID string, indices ...int) error
 }
 
+// Resizer resizes a running VM's NIC count.
 type Resizer interface {
 	NetResize(ctx context.Context, vmRef string, spec Spec, plumbing Plumbing) (Result, error)
 }
 
+// Normalize validates the spec.
 func (s *Spec) Normalize() error {
 	if s.Target < 0 {
 		return fmt.Errorf("--nics must be non-negative, got %d", s.Target)

--- a/extend/netresize/netresize.go
+++ b/extend/netresize/netresize.go
@@ -25,8 +25,7 @@ type NIC struct {
 	MAC   string `json:"mac"`
 }
 
-// Result reports the before/after count and NICs touched. Warnings surface
-// non-fatal divergence (e.g. host plumbing leak after a successful CH eject).
+// Result reports the before/after count, NICs touched, and non-fatal Warnings.
 type Result struct {
 	Before   int      `json:"before"`
 	After    int      `json:"after"`

--- a/extend/netresize/netresize.go
+++ b/extend/netresize/netresize.go
@@ -17,34 +17,32 @@ type Spec struct {
 	Target int
 }
 
-// NIC is one NIC's summary, returned in Result.Added / Result.Removed.
 type NIC struct {
 	Index int    `json:"index"`
 	TAP   string `json:"tap"`
 	MAC   string `json:"mac"`
 }
 
-// Result reports the before/after count and the NICs touched by the call.
+// Result reports the before/after count and NICs touched. Warnings surface
+// non-fatal divergence (e.g. host plumbing leak after a successful CH eject).
 type Result struct {
-	Before  int   `json:"before"`
-	After   int   `json:"after"`
-	Added   []NIC `json:"added,omitempty"`
-	Removed []NIC `json:"removed,omitempty"`
+	Before   int      `json:"before"`
+	After    int      `json:"after"`
+	Added    []NIC    `json:"added,omitempty"`
+	Removed  []NIC    `json:"removed,omitempty"`
+	Warnings []string `json:"warnings,omitempty"`
 }
 
-// Plumbing is the host-side network operations NetResize delegates to.
-// network.Network satisfies this implicitly.
+// Plumbing is the host-side network ops NetResize delegates to; network.Network satisfies it.
 type Plumbing interface {
 	Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs ...network.AddSpec) ([]*types.NetworkConfig, error)
 	Remove(ctx context.Context, vmID string, indices ...int) error
 }
 
-// Resizer resizes the NIC count on a running VM.
 type Resizer interface {
 	NetResize(ctx context.Context, vmRef string, spec Spec, plumbing Plumbing) (Result, error)
 }
 
-// Normalize validates the spec.
 func (s *Spec) Normalize() error {
 	if s.Target < 0 {
 		return fmt.Errorf("--nics must be non-negative, got %d", s.Target)

--- a/hypervisor/cloudhypervisor/api.go
+++ b/hypervisor/cloudhypervisor/api.go
@@ -119,4 +119,5 @@ type chVMInfoConfig struct {
 	Memory  chMemory      `json:"memory"`
 	Fs      []chFs        `json:"fs,omitempty"`
 	Devices []chDevice    `json:"devices,omitempty"`
+	Nets    []chNet       `json:"net,omitempty"`
 }

--- a/hypervisor/cloudhypervisor/api.go
+++ b/hypervisor/cloudhypervisor/api.go
@@ -1,5 +1,7 @@
 package cloudhypervisor
 
+import "encoding/json"
+
 type chVMConfig struct {
 	// Optional — pointer + omitempty (nil → omitted from JSON).
 	Payload *chPayload     `json:"payload,omitempty"`
@@ -110,7 +112,8 @@ type chPciDeviceInfo struct {
 }
 
 type chVMInfoResponse struct {
-	Config chVMInfoConfig `json:"config"`
+	Config     chVMInfoConfig             `json:"config"`
+	DeviceTree map[string]json.RawMessage `json:"device_tree,omitempty"`
 }
 
 type chVMInfoConfig struct {

--- a/hypervisor/cloudhypervisor/args.go
+++ b/hypervisor/cloudhypervisor/args.go
@@ -17,6 +17,8 @@ const (
 	// defaultDiskQueueSize is the virtio-blk queue depth per device.
 	defaultDiskQueueSize = 512
 	cidataFile           = "cidata.img"
+
+	cocoonNetIDPrefix = "cocoon-net-"
 )
 
 // kvBuilder accumulates key=value CLI fragments.
@@ -177,6 +179,11 @@ func networkConfigToNet(nc *types.NetworkConfig) chNet {
 		OffloadUFO:  true,
 		OffloadCsum: true,
 	}
+}
+
+// cocoonNetID is the deterministic CH device id for a cocoon-managed NIC.
+func cocoonNetID(mac string) string {
+	return cocoonNetIDPrefix + strings.ReplaceAll(mac, ":", "")
 }
 
 func storageConfigToDisk(storageConfig *types.StorageConfig, cpuCount, diskQueueSize int, noDirectIO bool) chDisk {

--- a/hypervisor/cloudhypervisor/clone.go
+++ b/hypervisor/cloudhypervisor/clone.go
@@ -310,7 +310,6 @@ func buildStateReplacements(chCfg *chVMConfig, storageConfigs []*types.StorageCo
 // adds fresh ones. Must run between vm.restore and vm.resume (VM paused).
 func hotSwapNets(ctx context.Context, hc *http.Client, oldNets []chNet, networkConfigs []*types.NetworkConfig) error {
 	logger := log.WithFunc("cloudhypervisor.hotSwapNets")
-	removedIDs := make([]string, 0, len(oldNets))
 	for _, oldNet := range oldNets {
 		if oldNet.ID == "" {
 			continue
@@ -318,23 +317,7 @@ func hotSwapNets(ctx context.Context, hc *http.Client, oldNets []chNet, networkC
 		if err := removeDeviceVM(ctx, hc, oldNet.ID); err != nil {
 			return fmt.Errorf("remove net device %s: %w", oldNet.ID, err)
 		}
-		removedIDs = append(removedIDs, oldNet.ID)
 		logger.Infof(ctx, "removed snapshot NIC %s (old MAC %s)", oldNet.ID, oldNet.MAC)
-	}
-	if len(removedIDs) > 0 {
-		info, err := getVMInfo(ctx, hc)
-		if err != nil {
-			return fmt.Errorf("verify post-remove vm.info: %w", err)
-		}
-		live := make(map[string]struct{}, len(info.Config.Nets))
-		for _, n := range info.Config.Nets {
-			live[n.ID] = struct{}{}
-		}
-		for _, id := range removedIDs {
-			if _, still := live[id]; still {
-				logger.Warnf(ctx, "NIC %s still in vm.info after vm.remove-device — eject pending in CH", id)
-			}
-		}
 	}
 	for i, nc := range networkConfigs {
 		newNet := networkConfigToNet(nc)

--- a/hypervisor/cloudhypervisor/clone.go
+++ b/hypervisor/cloudhypervisor/clone.go
@@ -321,6 +321,7 @@ func hotSwapNets(ctx context.Context, hc *http.Client, oldNets []chNet, networkC
 	}
 	for i, nc := range networkConfigs {
 		newNet := networkConfigToNet(nc)
+		newNet.ID = cocoonNetID(nc.MAC)
 		if err := addNetVM(ctx, hc, newNet); err != nil {
 			return fmt.Errorf("add net device %d/%d (MAC %s, TAP %s): %w",
 				i+1, len(networkConfigs), nc.MAC, nc.TAP, err)

--- a/hypervisor/cloudhypervisor/clone.go
+++ b/hypervisor/cloudhypervisor/clone.go
@@ -310,6 +310,7 @@ func buildStateReplacements(chCfg *chVMConfig, storageConfigs []*types.StorageCo
 // adds fresh ones. Must run between vm.restore and vm.resume (VM paused).
 func hotSwapNets(ctx context.Context, hc *http.Client, oldNets []chNet, networkConfigs []*types.NetworkConfig) error {
 	logger := log.WithFunc("cloudhypervisor.hotSwapNets")
+	removedIDs := make([]string, 0, len(oldNets))
 	for _, oldNet := range oldNets {
 		if oldNet.ID == "" {
 			continue
@@ -317,7 +318,23 @@ func hotSwapNets(ctx context.Context, hc *http.Client, oldNets []chNet, networkC
 		if err := removeDeviceVM(ctx, hc, oldNet.ID); err != nil {
 			return fmt.Errorf("remove net device %s: %w", oldNet.ID, err)
 		}
+		removedIDs = append(removedIDs, oldNet.ID)
 		logger.Infof(ctx, "removed snapshot NIC %s (old MAC %s)", oldNet.ID, oldNet.MAC)
+	}
+	if len(removedIDs) > 0 {
+		info, err := getVMInfo(ctx, hc)
+		if err != nil {
+			return fmt.Errorf("verify post-remove vm.info: %w", err)
+		}
+		live := make(map[string]struct{}, len(info.Config.Nets))
+		for _, n := range info.Config.Nets {
+			live[n.ID] = struct{}{}
+		}
+		for _, id := range removedIDs {
+			if _, still := live[id]; still {
+				logger.Warnf(ctx, "NIC %s still in vm.info after vm.remove-device — eject pending in CH", id)
+			}
+		}
 	}
 	for i, nc := range networkConfigs {
 		newNet := networkConfigToNet(nc)

--- a/hypervisor/cloudhypervisor/clone.go
+++ b/hypervisor/cloudhypervisor/clone.go
@@ -320,9 +320,7 @@ func hotSwapNets(ctx context.Context, hc *http.Client, oldNets []chNet, networkC
 		logger.Infof(ctx, "removed snapshot NIC %s (old MAC %s)", oldNet.ID, oldNet.MAC)
 	}
 	for i, nc := range networkConfigs {
-		newNet := networkConfigToNet(nc)
-		newNet.ID = cocoonNetID(nc.MAC)
-		if err := addNetVM(ctx, hc, newNet); err != nil {
+		if _, err := addCocoonNIC(ctx, hc, nc); err != nil {
 			return fmt.Errorf("add net device %d/%d (MAC %s, TAP %s): %w",
 				i+1, len(networkConfigs), nc.MAC, nc.TAP, err)
 		}

--- a/hypervisor/cloudhypervisor/extend.go
+++ b/hypervisor/cloudhypervisor/extend.go
@@ -216,26 +216,33 @@ func (ch *CloudHypervisor) detachWith(
 // alive (PID file + cmdline match — same gate as Backend.WithRunningVM),
 // and returns an http.Client connected to its CH API socket.
 func (ch *CloudHypervisor) runningVMClient(ctx context.Context, vmRef string) (*http.Client, error) {
+	hc, _, _, err := ch.runningVMClientWithRecord(ctx, vmRef)
+	return hc, err
+}
+
+// runningVMClientWithRecord is runningVMClient + (vmID, *VMRecord) so callers
+// that need the persisted record (e.g. netresize) avoid a second resolve+load.
+func (ch *CloudHypervisor) runningVMClientWithRecord(ctx context.Context, vmRef string) (*http.Client, string, hypervisor.VMRecord, error) {
 	vmID, err := ch.ResolveRef(ctx, vmRef)
 	if err != nil {
-		return nil, err
+		return nil, "", hypervisor.VMRecord{}, err
 	}
 	rec, err := ch.LoadRecord(ctx, vmID)
 	if err != nil {
-		return nil, err
+		return nil, "", hypervisor.VMRecord{}, err
 	}
 	if rec.State != types.VMStateRunning {
-		return nil, fmt.Errorf("vm %s is %s: %w", vmID, rec.State, hypervisor.ErrNotRunning)
+		return nil, "", hypervisor.VMRecord{}, fmt.Errorf("vm %s is %s: %w", vmID, rec.State, hypervisor.ErrNotRunning)
 	}
 	sockPath := hypervisor.SocketPath(rec.RunDir)
 	pid, pidErr := utils.ReadPIDFile(ch.PIDFilePath(rec.RunDir))
 	if pidErr != nil {
-		return nil, fmt.Errorf("vm %s read pidfile: %w: %w", vmID, pidErr, hypervisor.ErrNotRunning)
+		return nil, "", hypervisor.VMRecord{}, fmt.Errorf("vm %s read pidfile: %w: %w", vmID, pidErr, hypervisor.ErrNotRunning)
 	}
 	if !utils.VerifyProcessCmdline(pid, ch.conf.BinaryName(), sockPath) {
-		return nil, fmt.Errorf("vm %s pid %d not %s: %w", vmID, pid, ch.conf.BinaryName(), hypervisor.ErrNotRunning)
+		return nil, "", hypervisor.VMRecord{}, fmt.Errorf("vm %s pid %d not %s: %w", vmID, pid, ch.conf.BinaryName(), hypervisor.ErrNotRunning)
 	}
-	return utils.NewSocketHTTPClient(sockPath), nil
+	return utils.NewSocketHTTPClient(sockPath), vmID, rec, nil
 }
 
 // listWith is the shared skeleton for inspect-time enumeration.

--- a/hypervisor/cloudhypervisor/extend.go
+++ b/hypervisor/cloudhypervisor/extend.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/cocoonstack/cocoon/extend/fs"
+	"github.com/cocoonstack/cocoon/extend/netresize"
 	"github.com/cocoonstack/cocoon/extend/vfio"
 	"github.com/cocoonstack/cocoon/hypervisor"
 	"github.com/cocoonstack/cocoon/types"
@@ -17,10 +18,11 @@ import (
 )
 
 var (
-	_ fs.Attacher   = (*CloudHypervisor)(nil)
-	_ fs.Lister     = (*CloudHypervisor)(nil)
-	_ vfio.Attacher = (*CloudHypervisor)(nil)
-	_ vfio.Lister   = (*CloudHypervisor)(nil)
+	_ fs.Attacher       = (*CloudHypervisor)(nil)
+	_ fs.Lister         = (*CloudHypervisor)(nil)
+	_ vfio.Attacher     = (*CloudHypervisor)(nil)
+	_ vfio.Lister       = (*CloudHypervisor)(nil)
+	_ netresize.Resizer = (*CloudHypervisor)(nil)
 )
 
 // FsAttach hot-plugs a vhost-user-fs device onto a running CH VM.

--- a/hypervisor/cloudhypervisor/extend.go
+++ b/hypervisor/cloudhypervisor/extend.go
@@ -220,8 +220,7 @@ func (ch *CloudHypervisor) runningVMClient(ctx context.Context, vmRef string) (*
 	return hc, err
 }
 
-// runningVMClientWithRecord is runningVMClient + (vmID, *VMRecord) so callers
-// that need the persisted record (e.g. netresize) avoid a second resolve+load.
+// runningVMClientWithRecord is runningVMClient + the resolved vmID and record.
 func (ch *CloudHypervisor) runningVMClientWithRecord(ctx context.Context, vmRef string) (*http.Client, string, hypervisor.VMRecord, error) {
 	vmID, err := ch.ResolveRef(ctx, vmRef)
 	if err != nil {

--- a/hypervisor/cloudhypervisor/helper.go
+++ b/hypervisor/cloudhypervisor/helper.go
@@ -184,6 +184,18 @@ func addNetVM(ctx context.Context, hc *http.Client, net chNet) error {
 	return vmPutJSON(ctx, hc, "vm.add-net", "add-net request", net, http.StatusOK, http.StatusNoContent)
 }
 
+// addCocoonNIC posts vm.add-net with the deterministic cocoon-net-<mac> id so
+// resize-up and clone hot-swap converge on the same id convention. Returns the
+// id for caller-side rollback.
+func addCocoonNIC(ctx context.Context, hc *http.Client, nc *types.NetworkConfig) (string, error) {
+	chN := networkConfigToNet(nc)
+	chN.ID = cocoonNetID(nc.MAC)
+	if err := addNetVM(ctx, hc, chN); err != nil {
+		return "", err
+	}
+	return chN.ID, nil
+}
+
 // getVMInfo fetches vm.info; cocoon uses it to detect tag/id conflicts
 // before hot-add and to surface attached devices through inspect.
 func getVMInfo(ctx context.Context, hc *http.Client) (*chVMInfoResponse, error) {

--- a/hypervisor/cloudhypervisor/helper.go
+++ b/hypervisor/cloudhypervisor/helper.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/projecteru2/core/log"
 
@@ -178,6 +179,22 @@ func addDiskVM(ctx context.Context, hc *http.Client, disk chDisk) error {
 // the original success.
 func removeDeviceVM(ctx context.Context, hc *http.Client, deviceID string) error {
 	return vmPutJSON(ctx, hc, "vm.remove-device", "remove-device request", map[string]string{"id": deviceID})
+}
+
+// waitDeviceEjected blocks until id is gone from CH's device_tree. CH's
+// vm.remove-device only flags pending eject and mutates vm_config; the actual
+// device_tree removal happens when the guest writes B0EJ via ACPI/SCI. Pause
+// / snapshot iterate device_tree, so they error out if called before the
+// guest acks. Linux acks within < 1 s; Windows can take several seconds.
+func waitDeviceEjected(ctx context.Context, hc *http.Client, deviceID string, timeout time.Duration) error {
+	return utils.WaitFor(ctx, timeout, 100*time.Millisecond, func() (bool, error) {
+		info, err := getVMInfo(ctx, hc)
+		if err != nil {
+			return false, err
+		}
+		_, present := info.DeviceTree[deviceID]
+		return !present, nil
+	})
 }
 
 func addNetVM(ctx context.Context, hc *http.Client, net chNet) error {

--- a/hypervisor/cloudhypervisor/helper.go
+++ b/hypervisor/cloudhypervisor/helper.go
@@ -187,6 +187,9 @@ func addNetVM(ctx context.Context, hc *http.Client, net chNet) error {
 // addCocoonNIC posts vm.add-net with the deterministic cocoon-net-<mac> id
 // shared by resize-up and clone hot-swap; returns the id for rollback.
 func addCocoonNIC(ctx context.Context, hc *http.Client, nc *types.NetworkConfig) (string, error) {
+	if nc == nil {
+		return "", fmt.Errorf("addCocoonNIC: nil network config")
+	}
 	chN := networkConfigToNet(nc)
 	chN.ID = cocoonNetID(nc.MAC)
 	if err := addNetVM(ctx, hc, chN); err != nil {

--- a/hypervisor/cloudhypervisor/helper.go
+++ b/hypervisor/cloudhypervisor/helper.go
@@ -184,9 +184,8 @@ func addNetVM(ctx context.Context, hc *http.Client, net chNet) error {
 	return vmPutJSON(ctx, hc, "vm.add-net", "add-net request", net, http.StatusOK, http.StatusNoContent)
 }
 
-// addCocoonNIC posts vm.add-net with the deterministic cocoon-net-<mac> id so
-// resize-up and clone hot-swap converge on the same id convention. Returns the
-// id for caller-side rollback.
+// addCocoonNIC posts vm.add-net with the deterministic cocoon-net-<mac> id
+// shared by resize-up and clone hot-swap; returns the id for rollback.
 func addCocoonNIC(ctx context.Context, hc *http.Client, nc *types.NetworkConfig) (string, error) {
 	chN := networkConfigToNet(nc)
 	chN.ID = cocoonNetID(nc.MAC)

--- a/hypervisor/cloudhypervisor/helper.go
+++ b/hypervisor/cloudhypervisor/helper.go
@@ -181,11 +181,7 @@ func removeDeviceVM(ctx context.Context, hc *http.Client, deviceID string) error
 	return vmPutJSON(ctx, hc, "vm.remove-device", "remove-device request", map[string]string{"id": deviceID})
 }
 
-// waitDeviceEjected blocks until id is gone from CH's device_tree. CH's
-// vm.remove-device only flags pending eject and mutates vm_config; the actual
-// device_tree removal happens when the guest writes B0EJ via ACPI/SCI. Pause
-// / snapshot iterate device_tree, so they error out if called before the
-// guest acks. Linux acks within < 1 s; Windows can take several seconds.
+// waitDeviceEjected blocks until id is gone from CH's device_tree.
 func waitDeviceEjected(ctx context.Context, hc *http.Client, deviceID string, timeout time.Duration) error {
 	return utils.WaitFor(ctx, timeout, 100*time.Millisecond, func() (bool, error) {
 		info, err := getVMInfo(ctx, hc)

--- a/hypervisor/cloudhypervisor/helper.go
+++ b/hypervisor/cloudhypervisor/helper.go
@@ -197,8 +197,7 @@ func addNetVM(ctx context.Context, hc *http.Client, net chNet) error {
 	return vmPutJSON(ctx, hc, "vm.add-net", "add-net request", net, http.StatusOK, http.StatusNoContent)
 }
 
-// addCocoonNIC posts vm.add-net with the deterministic cocoon-net-<mac> id
-// shared by resize-up and clone hot-swap; returns the id for rollback.
+// addCocoonNIC posts vm.add-net with the deterministic cocoon-net-<mac> id; returns id for rollback.
 func addCocoonNIC(ctx context.Context, hc *http.Client, nc *types.NetworkConfig) (string, error) {
 	if nc == nil {
 		return "", fmt.Errorf("addCocoonNIC: nil network config")

--- a/hypervisor/cloudhypervisor/netresize.go
+++ b/hypervisor/cloudhypervisor/netresize.go
@@ -39,7 +39,7 @@ func (ch *CloudHypervisor) NetResize(ctx context.Context, vmRef string, spec net
 	case spec.Target > current:
 		return ch.netResizeAdd(ctx, hc, vmID, &rec.Config, plumbing, current, spec.Target, res)
 	default:
-		return ch.netResizeRemove(ctx, hc, info, vmID, rec.NetworkConfigs, plumbing, current, spec.Target, spec.KeepHostOnRemove, res)
+		return ch.netResizeRemove(ctx, hc, info, vmID, rec.NetworkConfigs, plumbing, current, spec.Target, res)
 	}
 }
 
@@ -71,7 +71,7 @@ func (ch *CloudHypervisor) netResizeAdd(ctx context.Context, hc *http.Client, vm
 	return res, nil
 }
 
-func (ch *CloudHypervisor) netResizeRemove(ctx context.Context, hc *http.Client, info *chVMInfoResponse, vmID string, ncs []*types.NetworkConfig, plumbing netresize.Plumbing, current, target int, keepHost bool, res netresize.Result) (netresize.Result, error) {
+func (ch *CloudHypervisor) netResizeRemove(ctx context.Context, hc *http.Client, info *chVMInfoResponse, vmID string, ncs []*types.NetworkConfig, plumbing netresize.Plumbing, current, target int, res netresize.Result) (netresize.Result, error) {
 	macToID := make(map[string]string, len(info.Config.Nets))
 	for _, n := range info.Config.Nets {
 		macToID[strings.ToLower(n.MAC)] = n.ID
@@ -85,10 +85,8 @@ func (ch *CloudHypervisor) netResizeRemove(ctx context.Context, hc *http.Client,
 		if err := removeDeviceVM(ctx, hc, chID); err != nil {
 			return res, fmt.Errorf("vm.remove-device nic %d (%s): %w", i, chID, err)
 		}
-		if !keepHost {
-			if err := plumbing.Remove(ctx, vmID, i); err != nil {
-				return res, fmt.Errorf("nic %d host plumbing: %w", i, err)
-			}
+		if err := plumbing.Remove(ctx, vmID, i); err != nil {
+			return res, fmt.Errorf("nic %d host plumbing: %w", i, err)
 		}
 		if err := ch.truncateNetworkConfigs(ctx, vmID, i); err != nil {
 			return res, fmt.Errorf("persist remove nic %d: %w", i, err)

--- a/hypervisor/cloudhypervisor/netresize.go
+++ b/hypervisor/cloudhypervisor/netresize.go
@@ -99,7 +99,7 @@ func (ch *CloudHypervisor) netResizeRemove(ctx context.Context, hc *http.Client,
 			return res, fmt.Errorf("persist remove nic %d: %w", i, err)
 		}
 		if plumbingErr != nil {
-			logger.Warnf(ctx, "host plumbing leaked for vm %s nic %d (gc will reclaim): %v", vmID, i, plumbingErr)
+			logger.Warnf(ctx, "host plumbing leaked for vm %s nic %d (stop+restart will reclaim): %v", vmID, i, plumbingErr)
 		}
 		res.Removed = append(res.Removed, netresize.NIC{Index: i, TAP: nc.TAP, MAC: nc.MAC})
 		res.After = i

--- a/hypervisor/cloudhypervisor/netresize.go
+++ b/hypervisor/cloudhypervisor/netresize.go
@@ -19,15 +19,11 @@ func (ch *CloudHypervisor) NetResize(ctx context.Context, vmRef string, spec net
 	if err := spec.Normalize(); err != nil {
 		return netresize.Result{}, err
 	}
-	hc, info, err := ch.inspectRunning(ctx, vmRef)
+	hc, vmID, rec, err := ch.runningVMClientWithRecord(ctx, vmRef)
 	if err != nil {
 		return netresize.Result{}, err
 	}
-	vmID, err := ch.ResolveRef(ctx, vmRef)
-	if err != nil {
-		return netresize.Result{}, err
-	}
-	rec, err := ch.LoadRecord(ctx, vmID)
+	info, err := getVMInfo(ctx, hc)
 	if err != nil {
 		return netresize.Result{}, err
 	}
@@ -63,6 +59,14 @@ func (ch *CloudHypervisor) netResizeAdd(ctx context.Context, hc *http.Client, vm
 			return res, fmt.Errorf("vm.add-net nic %d: %w", i, err)
 		}
 		if err := ch.appendNetworkConfig(ctx, vmID, nc); err != nil {
+			// CH already accepted the device; without rollback, the next
+			// resize would mis-count or collide on the deterministic id.
+			if rmErr := removeDeviceVM(ctx, hc, chN.ID); rmErr != nil {
+				logger.Warnf(ctx, "rollback vm.remove-device %s after persist failure: %v", chN.ID, rmErr)
+			}
+			if rmErr := plumbing.Remove(ctx, vmID, i); rmErr != nil {
+				logger.Warnf(ctx, "rollback host plumbing for nic %d: %v", i, rmErr)
+			}
 			return res, fmt.Errorf("persist nic %d: %w", i, err)
 		}
 		res.Added = append(res.Added, netresize.NIC{Index: i, TAP: nc.TAP, MAC: nc.MAC})
@@ -72,6 +76,7 @@ func (ch *CloudHypervisor) netResizeAdd(ctx context.Context, hc *http.Client, vm
 }
 
 func (ch *CloudHypervisor) netResizeRemove(ctx context.Context, hc *http.Client, info *chVMInfoResponse, vmID string, ncs []*types.NetworkConfig, plumbing netresize.Plumbing, current, target int, res netresize.Result) (netresize.Result, error) {
+	logger := log.WithFunc("cloudhypervisor.NetResize.remove")
 	macToID := make(map[string]string, len(info.Config.Nets))
 	for _, n := range info.Config.Nets {
 		macToID[strings.ToLower(n.MAC)] = n.ID
@@ -85,11 +90,16 @@ func (ch *CloudHypervisor) netResizeRemove(ctx context.Context, hc *http.Client,
 		if err := removeDeviceVM(ctx, hc, chID); err != nil {
 			return res, fmt.Errorf("vm.remove-device nic %d (%s): %w", i, chID, err)
 		}
-		if err := plumbing.Remove(ctx, vmID, i); err != nil {
-			return res, fmt.Errorf("nic %d host plumbing: %w", i, err)
-		}
+		// CH accepted the eject; cocoon must drop the record even if host
+		// plumbing teardown leaks. Skipping truncate would block convergence
+		// — the next resize would re-read the stale NIC and fail MAC lookup.
+		plumbingErr := plumbing.Remove(ctx, vmID, i)
 		if err := ch.truncateNetworkConfigs(ctx, vmID, i); err != nil {
+			logger.Errorf(ctx, err, "persistence diverged from CH for vm %s nic %d (%s): live device removed, cocoon record retained", vmID, i, chID)
 			return res, fmt.Errorf("persist remove nic %d: %w", i, err)
+		}
+		if plumbingErr != nil {
+			logger.Warnf(ctx, "host plumbing leaked for vm %s nic %d (gc will reclaim): %v", vmID, i, plumbingErr)
 		}
 		res.Removed = append(res.Removed, netresize.NIC{Index: i, TAP: nc.TAP, MAC: nc.MAC})
 		res.After = i

--- a/hypervisor/cloudhypervisor/netresize.go
+++ b/hypervisor/cloudhypervisor/netresize.go
@@ -15,8 +15,7 @@ import (
 	"github.com/cocoonstack/cocoon/types"
 )
 
-// ejectWaitTimeout caps how long we block on guest B0EJ between vm.remove-device
-// and the host plumbing teardown. Linux acks in < 1 s; Windows can take a few.
+// ejectWaitTimeout bounds the wait for guest B0EJ; Linux acks < 1 s, Windows can take a few.
 const ejectWaitTimeout = 10 * time.Second
 
 // NetResize brings the VM's NIC count to spec.Target on a running CH VM.
@@ -64,8 +63,7 @@ func (ch *CloudHypervisor) netResizeAdd(ctx context.Context, hc *http.Client, vm
 			return res, fmt.Errorf("vm.add-net nic %d: %w", i, err)
 		}
 		if err := ch.appendNetworkConfig(ctx, vmID, nc); err != nil {
-			// Symmetric with netResizeRemove: wait for guest B0EJ before tearing
-			// down host plumbing so we don't yank a TAP CH's ioeventfd still owns.
+			// Wait for B0EJ before host teardown (symmetric with netResizeRemove).
 			if rmErr := removeDeviceVM(ctx, hc, chID); rmErr != nil {
 				logger.Warnf(ctx, "rollback vm.remove-device %s after persist failure: %v", chID, rmErr)
 			} else if wErr := waitDeviceEjected(ctx, hc, chID, ejectWaitTimeout); wErr != nil {

--- a/hypervisor/cloudhypervisor/netresize.go
+++ b/hypervisor/cloudhypervisor/netresize.go
@@ -41,6 +41,7 @@ func (ch *CloudHypervisor) NetResize(ctx context.Context, vmRef string, spec net
 
 func (ch *CloudHypervisor) netResizeAdd(ctx context.Context, hc *http.Client, vmID string, vmCfg *types.VMConfig, plumbing netresize.Plumbing, from, target int, res netresize.Result) (netresize.Result, error) {
 	logger := log.WithFunc("cloudhypervisor.NetResize.add")
+	res.Added = make([]netresize.NIC, 0, target-from)
 	for i := from; i < target; i++ {
 		ncs, err := plumbing.Add(ctx, vmID, vmCfg, network.AddSpec{Index: i})
 		if err != nil {
@@ -75,6 +76,7 @@ func (ch *CloudHypervisor) netResizeAdd(ctx context.Context, hc *http.Client, vm
 
 func (ch *CloudHypervisor) netResizeRemove(ctx context.Context, hc *http.Client, info *chVMInfoResponse, vmID string, ncs []*types.NetworkConfig, plumbing netresize.Plumbing, current, target int, res netresize.Result) (netresize.Result, error) {
 	logger := log.WithFunc("cloudhypervisor.NetResize.remove")
+	res.Removed = make([]netresize.NIC, 0, current-target)
 	macToID := make(map[string]string, len(info.Config.Nets))
 	for _, n := range info.Config.Nets {
 		macToID[strings.ToLower(n.MAC)] = n.ID

--- a/hypervisor/cloudhypervisor/netresize.go
+++ b/hypervisor/cloudhypervisor/netresize.go
@@ -49,9 +49,8 @@ func (ch *CloudHypervisor) netResizeAdd(ctx context.Context, hc *http.Client, vm
 			return res, fmt.Errorf("nic %d: plumbing returned %d configs", i, len(ncs))
 		}
 		nc := ncs[0]
-		chN := networkConfigToNet(nc)
-		chN.ID = cocoonNetID(nc.MAC)
-		if err := addNetVM(ctx, hc, chN); err != nil {
+		chID, err := addCocoonNIC(ctx, hc, nc)
+		if err != nil {
 			if rmErr := plumbing.Remove(ctx, vmID, i); rmErr != nil {
 				logger.Warnf(ctx, "rollback host plumbing for nic %d: %v", i, rmErr)
 			}
@@ -59,8 +58,8 @@ func (ch *CloudHypervisor) netResizeAdd(ctx context.Context, hc *http.Client, vm
 		}
 		if err := ch.appendNetworkConfig(ctx, vmID, nc); err != nil {
 			// without rollback the deterministic id collides on the next resize.
-			if rmErr := removeDeviceVM(ctx, hc, chN.ID); rmErr != nil {
-				logger.Warnf(ctx, "rollback vm.remove-device %s after persist failure: %v", chN.ID, rmErr)
+			if rmErr := removeDeviceVM(ctx, hc, chID); rmErr != nil {
+				logger.Warnf(ctx, "rollback vm.remove-device %s after persist failure: %v", chID, rmErr)
 			}
 			if rmErr := plumbing.Remove(ctx, vmID, i); rmErr != nil {
 				logger.Warnf(ctx, "rollback host plumbing for nic %d: %v", i, rmErr)

--- a/hypervisor/cloudhypervisor/netresize.go
+++ b/hypervisor/cloudhypervisor/netresize.go
@@ -15,8 +15,9 @@ import (
 	"github.com/cocoonstack/cocoon/types"
 )
 
-// ejectWaitTimeout caps how long we block on guest B0EJ between vm.remove-device and the host plumbing teardown.
-const ejectWaitTimeout = 5 * time.Second
+// ejectWaitTimeout caps how long we block on guest B0EJ between vm.remove-device
+// and the host plumbing teardown. Linux acks in < 1 s; Windows can take a few.
+const ejectWaitTimeout = 10 * time.Second
 
 // NetResize brings the VM's NIC count to spec.Target on a running CH VM.
 func (ch *CloudHypervisor) NetResize(ctx context.Context, vmRef string, spec netresize.Spec, plumbing netresize.Plumbing) (netresize.Result, error) {
@@ -63,9 +64,12 @@ func (ch *CloudHypervisor) netResizeAdd(ctx context.Context, hc *http.Client, vm
 			return res, fmt.Errorf("vm.add-net nic %d: %w", i, err)
 		}
 		if err := ch.appendNetworkConfig(ctx, vmID, nc); err != nil {
-			// without rollback the deterministic id collides on the next resize.
+			// Symmetric with netResizeRemove: wait for guest B0EJ before tearing
+			// down host plumbing so we don't yank a TAP CH's ioeventfd still owns.
 			if rmErr := removeDeviceVM(ctx, hc, chID); rmErr != nil {
 				logger.Warnf(ctx, "rollback vm.remove-device %s after persist failure: %v", chID, rmErr)
+			} else if wErr := waitDeviceEjected(ctx, hc, chID, ejectWaitTimeout); wErr != nil {
+				logger.Warnf(ctx, "rollback wait eject %s after persist failure: %v", chID, wErr)
 			}
 			if rmErr := plumbing.Remove(ctx, vmID, i); rmErr != nil {
 				logger.Warnf(ctx, "rollback host plumbing for nic %d: %v", i, rmErr)

--- a/hypervisor/cloudhypervisor/netresize.go
+++ b/hypervisor/cloudhypervisor/netresize.go
@@ -1,0 +1,124 @@
+package cloudhypervisor
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/projecteru2/core/log"
+
+	"github.com/cocoonstack/cocoon/extend/netresize"
+	"github.com/cocoonstack/cocoon/hypervisor"
+	"github.com/cocoonstack/cocoon/network"
+	"github.com/cocoonstack/cocoon/types"
+)
+
+// NetResize brings the VM's NIC count to spec.Target.
+func (ch *CloudHypervisor) NetResize(ctx context.Context, vmRef string, spec netresize.Spec, plumbing netresize.Plumbing) (netresize.Result, error) {
+	if err := spec.Normalize(); err != nil {
+		return netresize.Result{}, err
+	}
+	hc, info, err := ch.inspectRunning(ctx, vmRef)
+	if err != nil {
+		return netresize.Result{}, err
+	}
+	vmID, err := ch.ResolveRef(ctx, vmRef)
+	if err != nil {
+		return netresize.Result{}, err
+	}
+	rec, err := ch.LoadRecord(ctx, vmID)
+	if err != nil {
+		return netresize.Result{}, err
+	}
+	current := len(rec.NetworkConfigs)
+	res := netresize.Result{Before: current, After: current}
+	switch {
+	case spec.Target == current:
+		return res, nil
+	case spec.Target > current:
+		return ch.netResizeAdd(ctx, hc, vmID, &rec.Config, plumbing, current, spec.Target, res)
+	default:
+		return ch.netResizeRemove(ctx, hc, info, vmID, rec.NetworkConfigs, plumbing, current, spec.Target, spec.KeepHostOnRemove, res)
+	}
+}
+
+func (ch *CloudHypervisor) netResizeAdd(ctx context.Context, hc *http.Client, vmID string, vmCfg *types.VMConfig, plumbing netresize.Plumbing, from, target int, res netresize.Result) (netresize.Result, error) {
+	logger := log.WithFunc("cloudhypervisor.NetResize.add")
+	for i := from; i < target; i++ {
+		ncs, err := plumbing.Add(ctx, vmID, vmCfg, network.AddSpec{Index: i})
+		if err != nil {
+			return res, fmt.Errorf("nic %d host plumbing: %w", i, err)
+		}
+		if len(ncs) != 1 || ncs[0] == nil {
+			return res, fmt.Errorf("nic %d: plumbing returned %d configs", i, len(ncs))
+		}
+		nc := ncs[0]
+		chN := networkConfigToNet(nc)
+		chN.ID = cocoonNetID(nc.MAC)
+		if err := addNetVM(ctx, hc, chN); err != nil {
+			if rmErr := plumbing.Remove(ctx, vmID, i); rmErr != nil {
+				logger.Warnf(ctx, "rollback host plumbing for nic %d: %v", i, rmErr)
+			}
+			return res, fmt.Errorf("vm.add-net nic %d: %w", i, err)
+		}
+		if err := ch.appendNetworkConfig(ctx, vmID, nc); err != nil {
+			return res, fmt.Errorf("persist nic %d: %w", i, err)
+		}
+		res.Added = append(res.Added, netresize.NIC{Index: i, TAP: nc.TAP, MAC: nc.MAC})
+		res.After = i + 1
+	}
+	return res, nil
+}
+
+func (ch *CloudHypervisor) netResizeRemove(ctx context.Context, hc *http.Client, info *chVMInfoResponse, vmID string, ncs []*types.NetworkConfig, plumbing netresize.Plumbing, current, target int, keepHost bool, res netresize.Result) (netresize.Result, error) {
+	macToID := make(map[string]string, len(info.Config.Nets))
+	for _, n := range info.Config.Nets {
+		macToID[strings.ToLower(n.MAC)] = n.ID
+	}
+	for i := current - 1; i >= target; i-- {
+		nc := ncs[i]
+		chID := macToID[strings.ToLower(nc.MAC)]
+		if chID == "" {
+			return res, fmt.Errorf("nic %d MAC %s: no live device", i, nc.MAC)
+		}
+		if err := removeDeviceVM(ctx, hc, chID); err != nil {
+			return res, fmt.Errorf("vm.remove-device nic %d (%s): %w", i, chID, err)
+		}
+		if !keepHost {
+			if err := plumbing.Remove(ctx, vmID, i); err != nil {
+				return res, fmt.Errorf("nic %d host plumbing: %w", i, err)
+			}
+		}
+		if err := ch.truncateNetworkConfigs(ctx, vmID, i); err != nil {
+			return res, fmt.Errorf("persist remove nic %d: %w", i, err)
+		}
+		res.Removed = append(res.Removed, netresize.NIC{Index: i, TAP: nc.TAP, MAC: nc.MAC})
+		res.After = i
+	}
+	return res, nil
+}
+
+func (ch *CloudHypervisor) appendNetworkConfig(ctx context.Context, vmID string, nc *types.NetworkConfig) error {
+	return ch.DB.Update(ctx, func(idx *hypervisor.VMIndex) error {
+		r := idx.VMs[vmID]
+		if r == nil {
+			return hypervisor.ErrNotFound
+		}
+		r.NetworkConfigs = append(r.NetworkConfigs, nc)
+		return nil
+	})
+}
+
+func (ch *CloudHypervisor) truncateNetworkConfigs(ctx context.Context, vmID string, length int) error {
+	return ch.DB.Update(ctx, func(idx *hypervisor.VMIndex) error {
+		r := idx.VMs[vmID]
+		if r == nil {
+			return hypervisor.ErrNotFound
+		}
+		if length < len(r.NetworkConfigs) {
+			r.NetworkConfigs = r.NetworkConfigs[:length]
+		}
+		return nil
+	})
+}

--- a/hypervisor/cloudhypervisor/netresize.go
+++ b/hypervisor/cloudhypervisor/netresize.go
@@ -98,7 +98,7 @@ func (ch *CloudHypervisor) netResizeRemove(ctx context.Context, hc *http.Client,
 			return res, fmt.Errorf("persist remove nic %d: %w", i, err)
 		}
 		if plumbingErr != nil {
-			msg := fmt.Sprintf("nic %d (%s) host plumbing leaked, stop+restart will reclaim: %v", i, chID, plumbingErr)
+			msg := fmt.Sprintf("nic %d (%s) host plumbing leaked, cocoon vm rm or gc will reclaim: %v", i, chID, plumbingErr)
 			logger.Warn(ctx, msg)
 			res.Warnings = append(res.Warnings, msg)
 		}

--- a/hypervisor/cloudhypervisor/netresize.go
+++ b/hypervisor/cloudhypervisor/netresize.go
@@ -14,16 +14,11 @@ import (
 	"github.com/cocoonstack/cocoon/types"
 )
 
-// NetResize brings the VM's NIC count to spec.Target.
 func (ch *CloudHypervisor) NetResize(ctx context.Context, vmRef string, spec netresize.Spec, plumbing netresize.Plumbing) (netresize.Result, error) {
 	if err := spec.Normalize(); err != nil {
 		return netresize.Result{}, err
 	}
 	hc, vmID, rec, err := ch.runningVMClientWithRecord(ctx, vmRef)
-	if err != nil {
-		return netresize.Result{}, err
-	}
-	info, err := getVMInfo(ctx, hc)
 	if err != nil {
 		return netresize.Result{}, err
 	}
@@ -35,6 +30,10 @@ func (ch *CloudHypervisor) NetResize(ctx context.Context, vmRef string, spec net
 	case spec.Target > current:
 		return ch.netResizeAdd(ctx, hc, vmID, &rec.Config, plumbing, current, spec.Target, res)
 	default:
+		info, infoErr := getVMInfo(ctx, hc)
+		if infoErr != nil {
+			return res, infoErr
+		}
 		return ch.netResizeRemove(ctx, hc, info, vmID, rec.NetworkConfigs, plumbing, current, spec.Target, res)
 	}
 }
@@ -59,8 +58,7 @@ func (ch *CloudHypervisor) netResizeAdd(ctx context.Context, hc *http.Client, vm
 			return res, fmt.Errorf("vm.add-net nic %d: %w", i, err)
 		}
 		if err := ch.appendNetworkConfig(ctx, vmID, nc); err != nil {
-			// CH already accepted the device; without rollback, the next
-			// resize would mis-count or collide on the deterministic id.
+			// without rollback the deterministic id collides on the next resize.
 			if rmErr := removeDeviceVM(ctx, hc, chN.ID); rmErr != nil {
 				logger.Warnf(ctx, "rollback vm.remove-device %s after persist failure: %v", chN.ID, rmErr)
 			}
@@ -90,16 +88,17 @@ func (ch *CloudHypervisor) netResizeRemove(ctx context.Context, hc *http.Client,
 		if err := removeDeviceVM(ctx, hc, chID); err != nil {
 			return res, fmt.Errorf("vm.remove-device nic %d (%s): %w", i, chID, err)
 		}
-		// CH accepted the eject; cocoon must drop the record even if host
-		// plumbing teardown leaks. Skipping truncate would block convergence
-		// — the next resize would re-read the stale NIC and fail MAC lookup.
+		// CH eject is irrevocable; truncate even if plumbing leaks, else the
+		// next resize re-reads the stale NIC and fails MAC lookup.
 		plumbingErr := plumbing.Remove(ctx, vmID, i)
 		if err := ch.truncateNetworkConfigs(ctx, vmID, i); err != nil {
 			logger.Errorf(ctx, err, "persistence diverged from CH for vm %s nic %d (%s): live device removed, cocoon record retained", vmID, i, chID)
 			return res, fmt.Errorf("persist remove nic %d: %w", i, err)
 		}
 		if plumbingErr != nil {
-			logger.Warnf(ctx, "host plumbing leaked for vm %s nic %d (stop+restart will reclaim): %v", vmID, i, plumbingErr)
+			msg := fmt.Sprintf("nic %d (%s) host plumbing leaked, stop+restart will reclaim: %v", i, chID, plumbingErr)
+			logger.Warn(ctx, msg)
+			res.Warnings = append(res.Warnings, msg)
 		}
 		res.Removed = append(res.Removed, netresize.NIC{Index: i, TAP: nc.TAP, MAC: nc.MAC})
 		res.After = i

--- a/hypervisor/cloudhypervisor/netresize.go
+++ b/hypervisor/cloudhypervisor/netresize.go
@@ -83,6 +83,9 @@ func (ch *CloudHypervisor) netResizeRemove(ctx context.Context, hc *http.Client,
 	}
 	for i := current - 1; i >= target; i-- {
 		nc := ncs[i]
+		if nc == nil {
+			return res, fmt.Errorf("nic %d: nil network config", i)
+		}
 		chID := macToID[strings.ToLower(nc.MAC)]
 		if chID == "" {
 			return res, fmt.Errorf("nic %d MAC %s: no live device", i, nc.MAC)

--- a/hypervisor/cloudhypervisor/netresize.go
+++ b/hypervisor/cloudhypervisor/netresize.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cocoonstack/cocoon/types"
 )
 
+// NetResize brings the VM's NIC count to spec.Target on a running CH VM.
 func (ch *CloudHypervisor) NetResize(ctx context.Context, vmRef string, spec netresize.Spec, plumbing netresize.Plumbing) (netresize.Result, error) {
 	if err := spec.Normalize(); err != nil {
 		return netresize.Result{}, err
@@ -107,9 +108,9 @@ func (ch *CloudHypervisor) netResizeRemove(ctx context.Context, hc *http.Client,
 
 func (ch *CloudHypervisor) appendNetworkConfig(ctx context.Context, vmID string, nc *types.NetworkConfig) error {
 	return ch.DB.Update(ctx, func(idx *hypervisor.VMIndex) error {
-		r := idx.VMs[vmID]
-		if r == nil {
-			return hypervisor.ErrNotFound
+		r, err := idx.GetRecord(vmID)
+		if err != nil {
+			return err
 		}
 		r.NetworkConfigs = append(r.NetworkConfigs, nc)
 		return nil
@@ -118,9 +119,9 @@ func (ch *CloudHypervisor) appendNetworkConfig(ctx context.Context, vmID string,
 
 func (ch *CloudHypervisor) truncateNetworkConfigs(ctx context.Context, vmID string, length int) error {
 	return ch.DB.Update(ctx, func(idx *hypervisor.VMIndex) error {
-		r := idx.VMs[vmID]
-		if r == nil {
-			return hypervisor.ErrNotFound
+		r, err := idx.GetRecord(vmID)
+		if err != nil {
+			return err
 		}
 		if length < len(r.NetworkConfigs) {
 			r.NetworkConfigs = r.NetworkConfigs[:length]

--- a/hypervisor/cloudhypervisor/netresize.go
+++ b/hypervisor/cloudhypervisor/netresize.go
@@ -15,9 +15,8 @@ import (
 	"github.com/cocoonstack/cocoon/types"
 )
 
-// ejectWaitTimeout caps how long we block on guest B0EJ between vm.remove-device
-// and the host plumbing teardown. Linux acks in < 1 s; Windows can take a few.
-const ejectWaitTimeout = 15 * time.Second
+// ejectWaitTimeout caps how long we block on guest B0EJ between vm.remove-device and the host plumbing teardown.
+const ejectWaitTimeout = 5 * time.Second
 
 // NetResize brings the VM's NIC count to spec.Target on a running CH VM.
 func (ch *CloudHypervisor) NetResize(ctx context.Context, vmRef string, spec netresize.Spec, plumbing netresize.Plumbing) (netresize.Result, error) {
@@ -98,13 +97,9 @@ func (ch *CloudHypervisor) netResizeRemove(ctx context.Context, hc *http.Client,
 		if err := removeDeviceVM(ctx, hc, chID); err != nil {
 			return res, fmt.Errorf("vm.remove-device nic %d (%s): %w", i, chID, err)
 		}
-		// CH only flags pending eject — wait for the guest to ACK via B0EJ so
-		// the device_tree entry is gone before pause/snapshot iterate it.
 		if err := waitDeviceEjected(ctx, hc, chID, ejectWaitTimeout); err != nil {
 			return res, fmt.Errorf("wait eject nic %d (%s): %w", i, chID, err)
 		}
-		// CH eject is irrevocable; truncate even if plumbing leaks, else the
-		// next resize re-reads the stale NIC and fails MAC lookup.
 		plumbingErr := plumbing.Remove(ctx, vmID, i)
 		if err := ch.truncateNetworkConfigs(ctx, vmID, i); err != nil {
 			logger.Errorf(ctx, err, "persistence diverged from CH for vm %s nic %d (%s): live device removed, cocoon record retained", vmID, i, chID)

--- a/hypervisor/cloudhypervisor/netresize.go
+++ b/hypervisor/cloudhypervisor/netresize.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/projecteru2/core/log"
 
@@ -13,6 +14,10 @@ import (
 	"github.com/cocoonstack/cocoon/network"
 	"github.com/cocoonstack/cocoon/types"
 )
+
+// ejectWaitTimeout caps how long we block on guest B0EJ between vm.remove-device
+// and the host plumbing teardown. Linux acks in < 1 s; Windows can take a few.
+const ejectWaitTimeout = 15 * time.Second
 
 // NetResize brings the VM's NIC count to spec.Target on a running CH VM.
 func (ch *CloudHypervisor) NetResize(ctx context.Context, vmRef string, spec netresize.Spec, plumbing netresize.Plumbing) (netresize.Result, error) {
@@ -92,6 +97,11 @@ func (ch *CloudHypervisor) netResizeRemove(ctx context.Context, hc *http.Client,
 		}
 		if err := removeDeviceVM(ctx, hc, chID); err != nil {
 			return res, fmt.Errorf("vm.remove-device nic %d (%s): %w", i, chID, err)
+		}
+		// CH only flags pending eject — wait for the guest to ACK via B0EJ so
+		// the device_tree entry is gone before pause/snapshot iterate it.
+		if err := waitDeviceEjected(ctx, hc, chID, ejectWaitTimeout); err != nil {
+			return res, fmt.Errorf("wait eject nic %d (%s): %w", i, chID, err)
 		}
 		// CH eject is irrevocable; truncate even if plumbing leaks, else the
 		// next resize re-reads the stale NIC and fails MAC lookup.

--- a/network/bridge/bridge_linux.go
+++ b/network/bridge/bridge_linux.go
@@ -68,7 +68,7 @@ func (b *Bridge) Verify(_ context.Context, vmID string) error {
 }
 
 // Add allocates TAP devices on the bridge for the given specs.
-func (b *Bridge) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs ...network.AddSpec) ([]*types.NetworkConfig, error) {
+func (b *Bridge) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs ...network.AddSpec) (configs []*types.NetworkConfig, retErr error) {
 	if len(specs) == 0 {
 		return nil, nil
 	}
@@ -79,7 +79,15 @@ func (b *Bridge) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, sp
 		return nil, fmt.Errorf("find bridge: %w", err)
 	}
 
-	configs := make([]*types.NetworkConfig, 0, len(specs))
+	var added []int
+	defer func() {
+		if retErr == nil || len(added) == 0 {
+			return
+		}
+		_ = tearDownTAPs(vmID, added, true)
+	}()
+
+	configs = make([]*types.NetworkConfig, 0, len(specs))
 	for _, spec := range specs {
 		name := tapName(vmID, spec.Index)
 		mac := generateMAC()
@@ -90,6 +98,7 @@ func (b *Bridge) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, sp
 		if cErr := createTAP(name, queues); cErr != nil {
 			return nil, fmt.Errorf("create tap %s: %w", name, cErr)
 		}
+		added = append(added, spec.Index)
 
 		tap, lErr := netlink.LinkByName(name)
 		if lErr != nil {
@@ -97,7 +106,6 @@ func (b *Bridge) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, sp
 		}
 
 		if mErr := netlink.LinkSetMaster(tap, br); mErr != nil {
-			_ = netlink.LinkDel(tap)
 			return nil, fmt.Errorf("add %s to %s: %w", name, b.bridgeDev, mErr)
 		}
 
@@ -108,7 +116,6 @@ func (b *Bridge) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, sp
 		_ = network.TuneTAP(tap)
 
 		if uErr := netlink.LinkSetUp(tap); uErr != nil {
-			_ = netlink.LinkDel(tap)
 			return nil, fmt.Errorf("set %s up: %w", name, uErr)
 		}
 

--- a/network/bridge/bridge_linux.go
+++ b/network/bridge/bridge_linux.go
@@ -127,17 +127,7 @@ func (b *Bridge) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, sp
 
 // Remove deletes the TAP devices for the given indices.
 func (b *Bridge) Remove(_ context.Context, vmID string, indices ...int) error {
-	for _, i := range indices {
-		name := tapName(vmID, i)
-		link, err := netlink.LinkByName(name)
-		if err != nil {
-			return fmt.Errorf("find tap %s: %w", name, err)
-		}
-		if err := netlink.LinkDel(link); err != nil {
-			return fmt.Errorf("delete tap %s: %w", name, err)
-		}
-	}
-	return nil
+	return tearDownTAPs(vmID, indices, false)
 }
 
 // Delete removes TAP devices for the given VMs.
@@ -160,23 +150,42 @@ func (b *Bridge) RegisterGC(orch *gc.Orchestrator) {
 	gc.Register(orch, GCModule(b.conf.RootDir))
 }
 
-// CleanupTAPs removes bridge TAP devices for the given VM IDs.
-// It does not require a Bridge instance and is safe to call
-// even when no bridge TAPs exist (no-op per VM).
+// CleanupTAPs probes and removes bridge TAP devices for the given VM IDs.
+// No-op per VM if none exist; safe without a Bridge instance.
 func CleanupTAPs(vmIDs []string) []string {
-	var cleaned []string
+	cleaned := make([]string, 0, len(vmIDs))
 	for _, vmID := range vmIDs {
+		var indices []int
 		for i := 0; ; i++ {
-			name := tapName(vmID, i)
-			l, err := netlink.LinkByName(name)
-			if err != nil {
-				break // no more TAPs for this VM
+			if _, err := netlink.LinkByName(tapName(vmID, i)); err != nil {
+				break
 			}
-			_ = netlink.LinkDel(l)
+			indices = append(indices, i)
 		}
+		_ = tearDownTAPs(vmID, indices, true)
 		cleaned = append(cleaned, vmID)
 	}
 	return cleaned
+}
+
+func tearDownTAPs(vmID string, indices []int, bestEffort bool) error {
+	for _, i := range indices {
+		name := tapName(vmID, i)
+		link, err := netlink.LinkByName(name)
+		if err != nil {
+			if bestEffort {
+				continue
+			}
+			return fmt.Errorf("find tap %s: %w", name, err)
+		}
+		if err := netlink.LinkDel(link); err != nil {
+			if bestEffort {
+				continue
+			}
+			return fmt.Errorf("delete tap %s: %w", name, err)
+		}
+	}
+	return nil
 }
 
 func createTAP(name string, numQueues int) error {

--- a/network/bridge/bridge_linux.go
+++ b/network/bridge/bridge_linux.go
@@ -79,7 +79,7 @@ func (b *Bridge) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, sp
 		return nil, fmt.Errorf("find bridge: %w", err)
 	}
 
-	var added []int
+	added := make([]int, 0, len(specs))
 	defer func() {
 		if retErr == nil || len(added) == 0 {
 			return

--- a/network/bridge/bridge_linux.go
+++ b/network/bridge/bridge_linux.go
@@ -67,53 +67,49 @@ func (b *Bridge) Verify(_ context.Context, vmID string) error {
 	return nil
 }
 
-// Config creates TAP devices and adds them to the bridge.
-func (b *Bridge) Config(ctx context.Context, vmID string, numNICs int, vmCfg *types.VMConfig, existing ...*types.NetworkConfig) ([]*types.NetworkConfig, error) {
-	logger := log.WithFunc("bridge.Config")
+// Add allocates TAP devices on the bridge for the given specs.
+func (b *Bridge) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs ...network.AddSpec) ([]*types.NetworkConfig, error) {
+	if len(specs) == 0 {
+		return nil, nil
+	}
+	logger := log.WithFunc("bridge.Add")
 
 	br, err := netlink.LinkByIndex(b.bridgeIdx)
 	if err != nil {
 		return nil, fmt.Errorf("find bridge: %w", err)
 	}
 
-	var configs []*types.NetworkConfig
-	for i := range numNICs {
-		name := tapName(vmID, i)
-
-		var mac string
-		if i < len(existing) && existing[i] != nil {
-			mac = existing[i].MAC
-		} else {
-			mac = generateMAC()
+	configs := make([]*types.NetworkConfig, 0, len(specs))
+	for _, spec := range specs {
+		name := tapName(vmID, spec.Index)
+		mac := generateMAC()
+		if spec.Existing != nil {
+			mac = spec.Existing.MAC
 		}
-
 		queues := network.NetNumQueues(vmCfg.CPU)
-		if err := createTAP(name, queues); err != nil {
-			return nil, fmt.Errorf("create tap %s: %w", name, err)
+		if cErr := createTAP(name, queues); cErr != nil {
+			return nil, fmt.Errorf("create tap %s: %w", name, cErr)
 		}
 
-		tap, err := netlink.LinkByName(name)
-		if err != nil {
-			return nil, fmt.Errorf("find tap %s: %w", name, err)
+		tap, lErr := netlink.LinkByName(name)
+		if lErr != nil {
+			return nil, fmt.Errorf("find tap %s: %w", name, lErr)
 		}
 
-		if err := netlink.LinkSetMaster(tap, br); err != nil {
+		if mErr := netlink.LinkSetMaster(tap, br); mErr != nil {
 			_ = netlink.LinkDel(tap)
-			return nil, fmt.Errorf("add %s to %s: %w", name, b.bridgeDev, err)
+			return nil, fmt.Errorf("add %s to %s: %w", name, b.bridgeDev, mErr)
 		}
 
-		// Disable FDB source MAC learning per-packet overhead.
 		_ = netlink.LinkSetLearning(tap, false)
-
 		if mtu := br.Attrs().MTU; mtu > 0 {
 			_ = netlink.LinkSetMTU(tap, mtu)
 		}
-
 		_ = network.TuneTAP(tap)
 
-		if err := netlink.LinkSetUp(tap); err != nil {
+		if uErr := netlink.LinkSetUp(tap); uErr != nil {
 			_ = netlink.LinkDel(tap)
-			return nil, fmt.Errorf("set %s up: %w", name, err)
+			return nil, fmt.Errorf("set %s up: %w", name, uErr)
 		}
 
 		configs = append(configs, &types.NetworkConfig{
@@ -124,9 +120,24 @@ func (b *Bridge) Config(ctx context.Context, vmID string, numNICs int, vmCfg *ty
 			Backend:   typ,
 			BridgeDev: b.bridgeDev,
 		})
-		logger.Debugf(ctx, "NIC %d: tap=%s mac=%s bridge=%s", i, name, mac, b.bridgeDev)
+		logger.Debugf(ctx, "NIC %d: tap=%s mac=%s bridge=%s", spec.Index, name, mac, b.bridgeDev)
 	}
 	return configs, nil
+}
+
+// Remove deletes the TAP devices for the given indices.
+func (b *Bridge) Remove(_ context.Context, vmID string, indices ...int) error {
+	for _, i := range indices {
+		name := tapName(vmID, i)
+		link, err := netlink.LinkByName(name)
+		if err != nil {
+			return fmt.Errorf("find tap %s: %w", name, err)
+		}
+		if err := netlink.LinkDel(link); err != nil {
+			return fmt.Errorf("delete tap %s: %w", name, err)
+		}
+	}
+	return nil
 }
 
 // Delete removes TAP devices for the given VMs.

--- a/network/bridge/bridge_linux.go
+++ b/network/bridge/bridge_linux.go
@@ -117,7 +117,7 @@ func (b *Bridge) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, sp
 			MAC:       mac,
 			NumQueues: queues,
 			QueueSize: network.ResolveQueueSize(vmCfg.QueueSize),
-			Backend:   typ,
+			Backend:   types.BackendBridge,
 			BridgeDev: b.bridgeDev,
 		})
 		logger.Debugf(ctx, "NIC %d: tap=%s mac=%s bridge=%s", spec.Index, name, mac, b.bridgeDev)

--- a/network/bridge/bridge_other.go
+++ b/network/bridge/bridge_other.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cocoonstack/cocoon/config"
 	"github.com/cocoonstack/cocoon/gc"
+	"github.com/cocoonstack/cocoon/network"
 	"github.com/cocoonstack/cocoon/types"
 )
 
@@ -28,10 +29,13 @@ func (b *Bridge) Type() string { return "bridge" }
 // Verify is not supported.
 func (b *Bridge) Verify(_ context.Context, _ string) error { return errUnsupported }
 
-// Config is not supported.
-func (b *Bridge) Config(_ context.Context, _ string, _ int, _ *types.VMConfig, _ ...*types.NetworkConfig) ([]*types.NetworkConfig, error) {
+// Add is not supported.
+func (b *Bridge) Add(_ context.Context, _ string, _ *types.VMConfig, _ ...network.AddSpec) ([]*types.NetworkConfig, error) {
 	return nil, errUnsupported
 }
+
+// Remove is not supported.
+func (b *Bridge) Remove(_ context.Context, _ string, _ ...int) error { return errUnsupported }
 
 // Delete is not supported.
 func (b *Bridge) Delete(_ context.Context, _ []string) ([]string, error) { return nil, errUnsupported }

--- a/network/cni/cni.go
+++ b/network/cni/cni.go
@@ -127,8 +127,7 @@ func (c *CNI) deleteVM(ctx context.Context, vmID string) error {
 	}); err != nil {
 		return fmt.Errorf("read network index: %w", err)
 	}
-	// Run unconditionally — a VM resized to 0 NICs has no records but still
-	// owns its netns (Remove preserves it by design).
+	// Run even when records is empty: a VM resized to 0 NICs still owns its netns.
 	nsPath := netnsPath(vmID)
 	ids, _ := c.tearDownNICs(ctx, vmID, nsPath, records, false, true)
 	nsName := netnsName(vmID)

--- a/network/cni/cni.go
+++ b/network/cni/cni.go
@@ -142,17 +142,25 @@ func (c *CNI) deleteVM(ctx context.Context, vmID string) error {
 }
 
 // tearDownNICs runs CNI DEL (and optionally TAP delete) for each record.
-// bestEffort=true logs errors and continues; false returns on the first.
-// Returns the record IDs successfully torn down so the caller can sweep them
-// from the index in one Update.
+// bestEffort=true logs errors and always appends the id (caller still sweeps
+// the DB; the netns deletion that follows reclaims kernel-side state anyway).
+// bestEffort=false returns on the first CNI/TAP failure so the caller can
+// surface "remove" intent failures without dropping live DB records.
+// Returns the record IDs eligible for index removal.
 func (c *CNI) tearDownNICs(ctx context.Context, vmID, nsPath string, records []networkRecord, deleteTAP, bestEffort bool) ([]string, error) {
-	if c.cniConf == nil {
-		if bestEffort {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("%w: no conflist found in %s", network.ErrNotConfigured, c.conf.CNIConfDir)
-	}
 	logger := log.WithFunc("cni.tearDownNICs")
+	if c.cniConf == nil {
+		if !bestEffort {
+			return nil, fmt.Errorf("%w: no conflist found in %s", network.ErrNotConfigured, c.conf.CNIConfDir)
+		}
+		// No CNI configured: nothing to DEL, but the DB records must still
+		// be reclaimable. Return every id so the caller can sweep them.
+		ids := make([]string, 0, len(records))
+		for _, rec := range records {
+			ids = append(ids, rec.ID)
+		}
+		return ids, nil
+	}
 	ids := make([]string, 0, len(records))
 	for _, rec := range records {
 		cl, err := c.confListByName(rec.Type)
@@ -164,14 +172,20 @@ func (c *CNI) tearDownNICs(ctx context.Context, vmID, nsPath string, records []n
 			continue
 		}
 		if err := c.cniDel(ctx, cl, vmID, nsPath, rec.IfName); err != nil {
+			if !bestEffort {
+				return ids, fmt.Errorf("cni del %s/%s: %w", vmID, rec.IfName, err)
+			}
 			logger.Warnf(ctx, "CNI DEL %s/%s: %v", vmID, rec.IfName, err)
 		}
 		if deleteTAP {
-			var i int
-			if _, err := fmt.Sscanf(rec.IfName, "eth%d", &i); err == nil {
-				if err := deleteTAPInNetns(nsPath, tapNameForVM(vmID, i)); err != nil && !bestEffort {
-					return ids, fmt.Errorf("delete tap %s: %w", tapNameForVM(vmID, i), err)
+			var idx int
+			if _, scanErr := fmt.Sscanf(rec.IfName, "eth%d", &idx); scanErr != nil {
+				logger.Warnf(ctx, "parse ifname %q for %s: %v (skip tap delete)", rec.IfName, vmID, scanErr)
+			} else if delErr := deleteTAPInNetns(nsPath, tapNameForVM(vmID, idx)); delErr != nil {
+				if !bestEffort {
+					return ids, fmt.Errorf("delete tap %s: %w", tapNameForVM(vmID, idx), delErr)
 				}
+				logger.Warnf(ctx, "delete tap %s in netns %s: %v", tapNameForVM(vmID, idx), nsPath, delErr)
 			}
 		}
 		ids = append(ids, rec.ID)

--- a/network/cni/cni.go
+++ b/network/cni/cni.go
@@ -180,12 +180,7 @@ func (c *CNI) delNICs(ctx context.Context, vmID, nsPath string, records []networ
 			logger.Warnf(ctx, "conflist %q not found for CNI DEL %s/%s: %v", rec.Type, vmID, rec.IfName, err)
 			continue
 		}
-		rt := &libcni.RuntimeConf{
-			ContainerID: vmID,
-			NetNS:       nsPath,
-			IfName:      rec.IfName,
-		}
-		if err := c.cniConf.DelNetworkList(ctx, cl, rt); err != nil {
+		if err := c.cniDel(ctx, cl, vmID, nsPath, rec.IfName); err != nil {
 			logger.Warnf(ctx, "CNI DEL %s/%s: %v", vmID, rec.IfName, err)
 		}
 	}

--- a/network/cni/cni.go
+++ b/network/cni/cni.go
@@ -127,9 +127,8 @@ func (c *CNI) deleteVM(ctx context.Context, vmID string) error {
 	}); err != nil {
 		return fmt.Errorf("read network index: %w", err)
 	}
-	if len(records) == 0 {
-		return nil
-	}
+	// Run unconditionally — a VM resized to 0 NICs has no records but still
+	// owns its netns (Remove preserves it by design).
 	nsPath := netnsPath(vmID)
 	ids, _ := c.tearDownNICs(ctx, vmID, nsPath, records, false, true)
 	nsName := netnsName(vmID)

--- a/network/cni/cni.go
+++ b/network/cni/cni.go
@@ -137,9 +137,9 @@ func (c *CNI) deleteVM(ctx context.Context, vmID string) error {
 	return c.deleteRecords(ctx, ids)
 }
 
-// tearDownNICs runs CNI DEL (+ optional TAP delete) per record. bestEffort
-// logs and continues; otherwise the first CNI/TAP failure aborts and only
-// fully-torn-down records are returned for DB sweep.
+// tearDownNICs attempts CNI DEL (+ optional TAP delete) for every record.
+// Returns ids of fully-clean records and the first error; bestEffort=false
+// stops after the first failed record (post-cleanup attempt).
 func (c *CNI) tearDownNICs(ctx context.Context, vmID, nsPath string, records []networkRecord, deleteTAP, bestEffort bool) ([]string, error) {
 	logger := log.WithFunc("cni.tearDownNICs")
 	if c.cniConf == nil {
@@ -154,32 +154,36 @@ func (c *CNI) tearDownNICs(ctx context.Context, vmID, nsPath string, records []n
 	}
 	ids := make([]string, 0, len(records))
 	for _, rec := range records {
+		var recErr error
 		cl, err := c.confListByName(rec.Type)
 		if err != nil {
-			if !bestEffort {
-				return ids, err
-			}
+			recErr = err
 			logger.Warnf(ctx, "conflist %q not found for CNI DEL %s/%s: %v", rec.Type, vmID, rec.IfName, err)
-			continue
 		}
-		if err := c.cniDel(ctx, cl, vmID, nsPath, rec.IfName); err != nil {
-			if !bestEffort {
-				return ids, fmt.Errorf("cni del %s/%s: %w", vmID, rec.IfName, err)
+		if cl != nil {
+			if err := c.cniDel(ctx, cl, vmID, nsPath, rec.IfName); err != nil {
+				if recErr == nil {
+					recErr = fmt.Errorf("cni del %s/%s: %w", vmID, rec.IfName, err)
+				}
+				logger.Warnf(ctx, "CNI DEL %s/%s: %v", vmID, rec.IfName, err)
 			}
-			logger.Warnf(ctx, "CNI DEL %s/%s: %v", vmID, rec.IfName, err)
 		}
 		if deleteTAP {
 			var idx int
 			if _, scanErr := fmt.Sscanf(rec.IfName, "eth%d", &idx); scanErr != nil {
 				logger.Warnf(ctx, "parse ifname %q for %s: %v (skip tap delete)", rec.IfName, vmID, scanErr)
 			} else if delErr := deleteTAPInNetns(nsPath, tapNameForVM(vmID, idx)); delErr != nil {
-				if !bestEffort {
-					return ids, fmt.Errorf("delete tap %s: %w", tapNameForVM(vmID, idx), delErr)
+				if recErr == nil {
+					recErr = fmt.Errorf("delete tap %s: %w", tapNameForVM(vmID, idx), delErr)
 				}
 				logger.Warnf(ctx, "delete tap %s in netns %s: %v", tapNameForVM(vmID, idx), nsPath, delErr)
 			}
 		}
-		ids = append(ids, rec.ID)
+		if recErr == nil {
+			ids = append(ids, rec.ID)
+		} else if !bestEffort {
+			return ids, recErr
+		}
 	}
 	return ids, nil
 }

--- a/network/cni/cni.go
+++ b/network/cni/cni.go
@@ -185,24 +185,6 @@ func (c *CNI) tearDownNICs(ctx context.Context, vmID, nsPath string, records []n
 	return ids, nil
 }
 
-// delNICs is the lockless CNI DEL loop for gc.Collect; store-aware paths use tearDownNICs.
-func (c *CNI) delNICs(ctx context.Context, vmID, nsPath string, records []networkRecord) {
-	if c.cniConf == nil {
-		return
-	}
-	logger := log.WithFunc("cni.delNICs")
-	for _, rec := range records {
-		cl, err := c.confListByName(rec.Type)
-		if err != nil {
-			logger.Warnf(ctx, "conflist %q not found for CNI DEL %s/%s: %v", rec.Type, vmID, rec.IfName, err)
-			continue
-		}
-		if err := c.cniDel(ctx, cl, vmID, nsPath, rec.IfName); err != nil {
-			logger.Warnf(ctx, "CNI DEL %s/%s: %v", vmID, rec.IfName, err)
-		}
-	}
-}
-
 func (c *CNI) deleteRecords(ctx context.Context, ids []string) error {
 	if len(ids) == 0 {
 		return nil

--- a/network/cni/cni.go
+++ b/network/cni/cni.go
@@ -38,10 +38,8 @@ type CNI struct {
 	cniConf     *libcni.CNIConfig
 }
 
-// New creates a CNI network provider.
-// CNI conflist loading is best-effort at creation time; if no conflist is
-// available (e.g. no network needed), Delete/Inspect/List still work.
-// Config() will fail if the conflist is not loaded.
+// New creates a CNI provider; conflist loading is best-effort so Delete/Inspect/List
+// still work when none are available — Add fails in that case.
 func New(conf *config.Config) (*CNI, error) {
 	if conf == nil {
 		return nil, fmt.Errorf("config is nil")
@@ -141,20 +139,15 @@ func (c *CNI) deleteVM(ctx context.Context, vmID string) error {
 	return c.deleteRecords(ctx, ids)
 }
 
-// tearDownNICs runs CNI DEL (and optionally TAP delete) for each record.
-// bestEffort=true logs errors and always appends the id (caller still sweeps
-// the DB; the netns deletion that follows reclaims kernel-side state anyway).
-// bestEffort=false returns on the first CNI/TAP failure so the caller can
-// surface "remove" intent failures without dropping live DB records.
-// Returns the record IDs eligible for index removal.
+// tearDownNICs runs CNI DEL (+ optional TAP delete) per record. bestEffort
+// logs and continues; otherwise the first CNI/TAP failure aborts and only
+// fully-torn-down records are returned for DB sweep.
 func (c *CNI) tearDownNICs(ctx context.Context, vmID, nsPath string, records []networkRecord, deleteTAP, bestEffort bool) ([]string, error) {
 	logger := log.WithFunc("cni.tearDownNICs")
 	if c.cniConf == nil {
 		if !bestEffort {
 			return nil, fmt.Errorf("%w: no conflist found in %s", network.ErrNotConfigured, c.conf.CNIConfDir)
 		}
-		// No CNI configured: nothing to DEL, but the DB records must still
-		// be reclaimable. Return every id so the caller can sweep them.
 		ids := make([]string, 0, len(records))
 		for _, rec := range records {
 			ids = append(ids, rec.ID)
@@ -193,9 +186,7 @@ func (c *CNI) tearDownNICs(ctx context.Context, vmID, nsPath string, records []n
 	return ids, nil
 }
 
-// delNICs is the per-record CNI DEL loop without store access; used by the
-// lockless gc.Collect path. The store-aware Delete/Remove paths go through
-// tearDownNICs.
+// delNICs is the lockless CNI DEL loop for gc.Collect; store-aware paths use tearDownNICs.
 func (c *CNI) delNICs(ctx context.Context, vmID, nsPath string, records []networkRecord) {
 	if c.cniConf == nil {
 		return

--- a/network/cni/cni.go
+++ b/network/cni/cni.go
@@ -141,9 +141,7 @@ func (c *CNI) deleteVM(ctx context.Context, vmID string) error {
 	return c.deleteRecords(ctx, allIDs)
 }
 
-// tearDownNICs attempts CNI DEL (+ optional TAP delete) for every record.
-// Returns the first error; bestEffort=false stops after the first failed
-// record (post-cleanup attempt). Callers own DB-record sweep separately.
+// tearDownNICs runs CNI DEL (+ optional TAP delete) per record; bestEffort=false stops at first failure. Caller sweeps DB.
 func (c *CNI) tearDownNICs(ctx context.Context, vmID, nsPath string, records []networkRecord, deleteTAP, bestEffort bool) error {
 	logger := log.WithFunc("cni.tearDownNICs")
 	if c.cniConf == nil {

--- a/network/cni/cni.go
+++ b/network/cni/cni.go
@@ -113,13 +113,7 @@ func (c *CNI) List(ctx context.Context) ([]*types.Network, error) {
 	})
 }
 
-// Delete removes all network resources for the given VM IDs:
-//  1. CNI DEL for each NIC (releases IP from IPAM, removes veth pair).
-//  2. Remove the named netns (kernel cleans up bridge + tap automatically).
-//  3. Remove network records from the DB.
-//
-// Best-effort: failing to clean one VM does not block others.
-// Returns the VM IDs that were fully cleaned.
+// Delete tears down all NICs for each VM and removes the netns. Best-effort.
 func (c *CNI) Delete(ctx context.Context, vmIDs []string) ([]string, error) {
 	result := utils.ForEach(ctx, vmIDs, func(ctx context.Context, vmID string) error {
 		return c.deleteVM(ctx, vmID)
@@ -127,9 +121,7 @@ func (c *CNI) Delete(ctx context.Context, vmIDs []string) ([]string, error) {
 	return result.Succeeded, result.Err()
 }
 
-// deleteVM cleans up all network resources for a single VM.
 func (c *CNI) deleteVM(ctx context.Context, vmID string) error {
-	// Collect value-copies of records for this VM.
 	var records []networkRecord
 	if err := c.store.With(ctx, func(idx *networkIndex) error {
 		records = idx.byVMID(vmID)
@@ -137,38 +129,59 @@ func (c *CNI) deleteVM(ctx context.Context, vmID string) error {
 	}); err != nil {
 		return fmt.Errorf("read network index: %w", err)
 	}
-
-	// Nothing to clean — VM had no network or was already cleaned.
 	if len(records) == 0 {
 		return nil
 	}
-
 	nsPath := netnsPath(vmID)
-
-	// CNI DEL for each NIC — releases IPs from IPAM and removes veth pairs.
-	// Best-effort: log failures but continue. Netns deletion cleans up
-	// devices anyway; CNI DEL is primarily for IPAM bookkeeping.
-	c.delNICs(ctx, vmID, nsPath, records)
-
-	// deleteNetns retries briefly to handle async fd cleanup after process kill.
+	ids, _ := c.tearDownNICs(ctx, vmID, nsPath, records, false, true)
 	nsName := netnsName(vmID)
 	if err := deleteNetns(ctx, nsName); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("remove netns %s: %w", nsPath, err)
 	}
-
-	return c.store.Update(ctx, func(idx *networkIndex) error {
-		for id, rec := range idx.Networks {
-			if rec != nil && rec.VMID == vmID {
-				delete(idx.Networks, id)
-			}
-		}
-		return nil
-	})
+	return c.deleteRecords(ctx, ids)
 }
 
-// delNICs performs best-effort CNI DEL for each NIC record.
-// Failures are logged but never returned — netns deletion cleans up
-// devices anyway; CNI DEL is primarily for IPAM bookkeeping.
+// tearDownNICs runs CNI DEL (and optionally TAP delete) for each record.
+// bestEffort=true logs errors and continues; false returns on the first.
+// Returns the record IDs successfully torn down so the caller can sweep them
+// from the index in one Update.
+func (c *CNI) tearDownNICs(ctx context.Context, vmID, nsPath string, records []networkRecord, deleteTAP, bestEffort bool) ([]string, error) {
+	if c.cniConf == nil {
+		if bestEffort {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("%w: no conflist found in %s", network.ErrNotConfigured, c.conf.CNIConfDir)
+	}
+	logger := log.WithFunc("cni.tearDownNICs")
+	ids := make([]string, 0, len(records))
+	for _, rec := range records {
+		cl, err := c.confListByName(rec.Type)
+		if err != nil {
+			if !bestEffort {
+				return ids, err
+			}
+			logger.Warnf(ctx, "conflist %q not found for CNI DEL %s/%s: %v", rec.Type, vmID, rec.IfName, err)
+			continue
+		}
+		if err := c.cniDel(ctx, cl, vmID, nsPath, rec.IfName); err != nil {
+			logger.Warnf(ctx, "CNI DEL %s/%s: %v", vmID, rec.IfName, err)
+		}
+		if deleteTAP {
+			var i int
+			if _, err := fmt.Sscanf(rec.IfName, "eth%d", &i); err == nil {
+				if err := deleteTAPInNetns(nsPath, tapNameForVM(vmID, i)); err != nil && !bestEffort {
+					return ids, fmt.Errorf("delete tap %s: %w", tapNameForVM(vmID, i), err)
+				}
+			}
+		}
+		ids = append(ids, rec.ID)
+	}
+	return ids, nil
+}
+
+// delNICs is the per-record CNI DEL loop without store access; used by the
+// lockless gc.Collect path. The store-aware Delete/Remove paths go through
+// tearDownNICs.
 func (c *CNI) delNICs(ctx context.Context, vmID, nsPath string, records []networkRecord) {
 	if c.cniConf == nil {
 		return
@@ -184,6 +197,18 @@ func (c *CNI) delNICs(ctx context.Context, vmID, nsPath string, records []networ
 			logger.Warnf(ctx, "CNI DEL %s/%s: %v", vmID, rec.IfName, err)
 		}
 	}
+}
+
+func (c *CNI) deleteRecords(ctx context.Context, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	return c.store.Update(ctx, func(idx *networkIndex) error {
+		for _, id := range ids {
+			delete(idx.Networks, id)
+		}
+		return nil
+	})
 }
 
 // confListByName resolves a conflist by name.

--- a/network/cni/cni.go
+++ b/network/cni/cni.go
@@ -129,30 +129,29 @@ func (c *CNI) deleteVM(ctx context.Context, vmID string) error {
 	}
 	// Run even when records is empty: a VM resized to 0 NICs still owns its netns.
 	nsPath := netnsPath(vmID)
-	ids, _ := c.tearDownNICs(ctx, vmID, nsPath, records, false, true)
+	_ = c.tearDownNICs(ctx, vmID, nsPath, records, false, true)
 	nsName := netnsName(vmID)
 	if err := deleteNetns(ctx, nsName); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("remove netns %s: %w", nsPath, err)
 	}
-	return c.deleteRecords(ctx, ids)
+	allIDs := make([]string, 0, len(records))
+	for _, rec := range records {
+		allIDs = append(allIDs, rec.ID)
+	}
+	return c.deleteRecords(ctx, allIDs)
 }
 
 // tearDownNICs attempts CNI DEL (+ optional TAP delete) for every record.
-// Returns ids of fully-clean records and the first error; bestEffort=false
-// stops after the first failed record (post-cleanup attempt).
-func (c *CNI) tearDownNICs(ctx context.Context, vmID, nsPath string, records []networkRecord, deleteTAP, bestEffort bool) ([]string, error) {
+// Returns the first error; bestEffort=false stops after the first failed
+// record (post-cleanup attempt). Callers own DB-record sweep separately.
+func (c *CNI) tearDownNICs(ctx context.Context, vmID, nsPath string, records []networkRecord, deleteTAP, bestEffort bool) error {
 	logger := log.WithFunc("cni.tearDownNICs")
 	if c.cniConf == nil {
 		if !bestEffort {
-			return nil, fmt.Errorf("%w: no conflist found in %s", network.ErrNotConfigured, c.conf.CNIConfDir)
+			return fmt.Errorf("%w: no conflist found in %s", network.ErrNotConfigured, c.conf.CNIConfDir)
 		}
-		ids := make([]string, 0, len(records))
-		for _, rec := range records {
-			ids = append(ids, rec.ID)
-		}
-		return ids, nil
+		return nil
 	}
-	ids := make([]string, 0, len(records))
 	for _, rec := range records {
 		var recErr error
 		cl, err := c.confListByName(rec.Type)
@@ -179,13 +178,11 @@ func (c *CNI) tearDownNICs(ctx context.Context, vmID, nsPath string, records []n
 				logger.Warnf(ctx, "delete tap %s in netns %s: %v", tapNameForVM(vmID, idx), nsPath, delErr)
 			}
 		}
-		if recErr == nil {
-			ids = append(ids, rec.ID)
-		} else if !bestEffort {
-			return ids, recErr
+		if recErr != nil && !bestEffort {
+			return recErr
 		}
 	}
-	return ids, nil
+	return nil
 }
 
 func (c *CNI) deleteRecords(ctx context.Context, ids []string) error {

--- a/network/cni/create.go
+++ b/network/cni/create.go
@@ -174,7 +174,7 @@ func (c *CNI) Remove(ctx context.Context, vmID string, indices ...int) error {
 		picked = append(picked, rec)
 		pickedIDs = append(pickedIDs, rec.ID)
 	}
-	_, err := c.tearDownNICs(ctx, vmID, netnsPath(vmID), picked, true, false)
+	err := c.tearDownNICs(ctx, vmID, netnsPath(vmID), picked, true, false)
 	return errors.Join(err, c.deleteRecords(ctx, pickedIDs))
 }
 

--- a/network/cni/create.go
+++ b/network/cni/create.go
@@ -175,10 +175,7 @@ func (c *CNI) Remove(ctx context.Context, vmID string, indices ...int) error {
 		pickedIDs = append(pickedIDs, rec.ID)
 	}
 	_, err := c.tearDownNICs(ctx, vmID, netnsPath(vmID), picked, true, false)
-	if delErr := c.deleteRecords(ctx, pickedIDs); delErr != nil && err == nil {
-		err = delErr
-	}
-	return err
+	return errors.Join(err, c.deleteRecords(ctx, pickedIDs))
 }
 
 func (c *CNI) cniDel(ctx context.Context, confList *libcni.NetworkConfigList, vmID, nsPath, ifName string) error {

--- a/network/cni/create.go
+++ b/network/cni/create.go
@@ -100,7 +100,7 @@ func (c *CNI) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs
 			MAC:       mac,
 			NumQueues: network.NetNumQueues(vmCfg.CPU),
 			QueueSize: network.ResolveQueueSize(vmCfg.QueueSize),
-			Backend:   typ,
+			Backend:   types.BackendCNI,
 			NetnsPath: nsPath,
 			Network:   netInfo,
 		}

--- a/network/cni/create.go
+++ b/network/cni/create.go
@@ -145,6 +145,9 @@ func (c *CNI) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs
 }
 
 // Remove tears down NIC plumbing for the given indices; preserves the netns.
+// DB records for picked indices are always swept so a later resize-up at the
+// same index does not see a stale eth<idx> entry; CNI/TAP failures still
+// propagate as the returned error.
 func (c *CNI) Remove(ctx context.Context, vmID string, indices ...int) error {
 	if len(indices) == 0 {
 		return nil
@@ -161,6 +164,7 @@ func (c *CNI) Remove(ctx context.Context, vmID string, indices ...int) error {
 		byIfName[r.IfName] = r
 	}
 	picked := make([]networkRecord, 0, len(indices))
+	pickedIDs := make([]string, 0, len(indices))
 	for _, i := range indices {
 		ifName := fmt.Sprintf("eth%d", i)
 		rec, ok := byIfName[ifName]
@@ -168,10 +172,10 @@ func (c *CNI) Remove(ctx context.Context, vmID string, indices ...int) error {
 			return fmt.Errorf("nic %d (%s): no record", i, ifName)
 		}
 		picked = append(picked, rec)
+		pickedIDs = append(pickedIDs, rec.ID)
 	}
-	ids, err := c.tearDownNICs(ctx, vmID, netnsPath(vmID), picked, true, false)
-	// Sweep partially-torn-down records even on abort, else they leak DB rows.
-	if delErr := c.deleteRecords(ctx, ids); delErr != nil && err == nil {
+	_, err := c.tearDownNICs(ctx, vmID, netnsPath(vmID), picked, true, false)
+	if delErr := c.deleteRecords(ctx, pickedIDs); delErr != nil && err == nil {
 		err = delErr
 	}
 	return err

--- a/network/cni/create.go
+++ b/network/cni/create.go
@@ -2,7 +2,10 @@ package cni
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
+	"os"
 
 	"github.com/containernetworking/cni/libcni"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
@@ -14,83 +17,85 @@ import (
 	"github.com/cocoonstack/cocoon/utils"
 )
 
-// Config creates the netns, runs CNI ADD, and wires each NIC to a tap via TC.
-func (c *CNI) Config(ctx context.Context, vmID string, numNICs int, vmCfg *types.VMConfig, existing ...*types.NetworkConfig) (configs []*types.NetworkConfig, retErr error) {
+// Add creates the netns (if absent) and allocates each NIC's CNI plumbing.
+func (c *CNI) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs ...network.AddSpec) (configs []*types.NetworkConfig, retErr error) {
 	if c.cniConf == nil {
 		return nil, fmt.Errorf("%w: no conflist found in %s", network.ErrNotConfigured, c.conf.CNIConfDir)
+	}
+	if len(specs) == 0 {
+		return nil, nil
 	}
 	confList, err := c.confListByName(vmCfg.Network)
 	if err != nil {
 		return nil, err
 	}
 	vmCfg.Network = confList.Name
-	logger := log.WithFunc("cni.Config")
+	logger := log.WithFunc("cni.Add")
 
 	nsName := netnsName(vmID)
 	nsPath := netnsPath(vmID)
 
-	if err := createNetns(nsName); err != nil {
-		return nil, fmt.Errorf("create netns %s: %w", nsName, err)
+	createdNetns, err := ensureNetns(nsName, nsPath)
+	if err != nil {
+		return nil, fmt.Errorf("ensure netns %s: %w", nsName, err)
 	}
 
-	var addedIFs []string
+	addedIFs := make([]string, 0, len(specs))
 	defer func() {
 		if retErr == nil {
 			return
 		}
 		for _, ifn := range addedIFs {
-			rt := &libcni.RuntimeConf{
-				ContainerID: vmID,
-				NetNS:       nsPath,
-				IfName:      ifn,
-			}
-			if delErr := c.cniConf.DelNetworkList(ctx, confList, rt); delErr != nil {
+			if delErr := c.cniDel(ctx, confList, vmID, nsPath, ifn); delErr != nil {
 				logger.Warnf(ctx, "rollback CNI DEL %s/%s: %v", vmID, ifn, delErr)
 			}
 		}
-		_ = deleteNetns(ctx, nsName)
+		if createdNetns {
+			_ = deleteNetns(ctx, nsName)
+		}
 	}()
 
-	for i := range numNICs {
-		ifName := fmt.Sprintf("eth%d", i)
-		tapName := tapNameForVM(vmID, i)
+	type freshNIC struct {
+		index int
+		cfg   *types.NetworkConfig
+	}
+	configs = make([]*types.NetworkConfig, 0, len(specs))
+	fresh := make([]freshNIC, 0, len(specs))
+	for _, spec := range specs {
+		ifName := fmt.Sprintf("eth%d", spec.Index)
+		tapName := tapNameForVM(vmID, spec.Index)
 
-		rt := &libcni.RuntimeConf{
-			ContainerID: vmID,
-			NetNS:       nsPath,
-			IfName:      ifName,
-		}
-
-		if i < len(existing) && existing[i] != nil {
-			if delErr := c.cniConf.DelNetworkList(ctx, confList, rt); delErr != nil {
+		rt := &libcni.RuntimeConf{ContainerID: vmID, NetNS: nsPath, IfName: ifName}
+		if spec.Existing != nil {
+			if delErr := c.cniDel(ctx, confList, vmID, nsPath, ifName); delErr != nil {
 				logger.Warnf(ctx, "pre-recovery CNI DEL %s/%s: %v (continuing)", vmID, ifName, delErr)
 			}
-			if existing[i].Network != nil && existing[i].Network.IP != "" {
-				rt.Args = [][2]string{{"IgnoreUnknown", "1"}, {"IP", existing[i].Network.IP}}
+			if spec.Existing.Network != nil && spec.Existing.Network.IP != "" {
+				rt.Args = [][2]string{{"IgnoreUnknown", "1"}, {"IP", spec.Existing.Network.IP}}
 			}
 		}
 
-		cniResult, err := c.cniConf.AddNetworkList(ctx, confList, rt)
-		if err != nil {
-			return nil, fmt.Errorf("cni add %s/%s: %w", vmID, ifName, err)
+		cniResult, addErr := c.cniConf.AddNetworkList(ctx, confList, rt)
+		if addErr != nil {
+			return nil, fmt.Errorf("cni add %s/%s: %w", vmID, ifName, addErr)
 		}
 		addedIFs = append(addedIFs, ifName)
 
-		netInfo, err := extractNetworkInfo(cniResult)
-		if err != nil {
-			return nil, fmt.Errorf("parse CNI result: %w", err)
+		netInfo, parseErr := extractNetworkInfo(cniResult)
+		if parseErr != nil {
+			return nil, fmt.Errorf("parse CNI result: %w", parseErr)
 		}
 
 		var overrideMAC string
-		if i < len(existing) && existing[i] != nil {
-			overrideMAC = existing[i].MAC
+		if spec.Existing != nil {
+			overrideMAC = spec.Existing.MAC
 		}
 		mac, setupErr := setupTCRedirect(nsPath, ifName, tapName, network.NetNumQueues(vmCfg.CPU), overrideMAC)
 		if setupErr != nil {
 			return nil, fmt.Errorf("setup tc-redirect %s: %w", vmID, setupErr)
 		}
 
-		configs = append(configs, &types.NetworkConfig{
+		cfg := &types.NetworkConfig{
 			TAP:       tapName,
 			MAC:       mac,
 			NumQueues: network.NetNumQueues(vmCfg.CPU),
@@ -98,7 +103,11 @@ func (c *CNI) Config(ctx context.Context, vmID string, numNICs int, vmCfg *types
 			Backend:   typ,
 			NetnsPath: nsPath,
 			Network:   netInfo,
-		})
+		}
+		configs = append(configs, cfg)
+		if spec.Existing == nil {
+			fresh = append(fresh, freshNIC{index: spec.Index, cfg: cfg})
+		}
 
 		var logIP, logGW string
 		if netInfo != nil {
@@ -106,34 +115,102 @@ func (c *CNI) Config(ctx context.Context, vmID string, numNICs int, vmCfg *types
 			logGW = netInfo.Gateway
 		}
 		logger.Debugf(ctx, "NIC %d: %s ip=%s gw=%s tap=%s mac=%s",
-			i, ifName, logIP, logGW, tapName, mac)
-	}
-
-	if len(existing) > 0 {
-		return configs, nil
+			spec.Index, ifName, logIP, logGW, tapName, mac)
 	}
 
 	return configs, c.store.Update(ctx, func(idx *networkIndex) error {
-		for i, cfg := range configs {
+		for _, f := range fresh {
 			netID := utils.GenerateID()
 			var net types.Network
-			if cfg.Network != nil {
-				net = *cfg.Network
+			if f.cfg.Network != nil {
+				net = *f.cfg.Network
 			}
 			idx.Networks[netID] = &networkRecord{
 				ID:      netID,
 				Type:    confList.Name,
 				Network: net,
 				VMID:    vmID,
-				IfName:  fmt.Sprintf("eth%d", i),
+				IfName:  fmt.Sprintf("eth%d", f.index),
 			}
 		}
 		return nil
 	})
 }
 
+// Remove tears down NIC plumbing for the given indices; preserves the netns.
+func (c *CNI) Remove(ctx context.Context, vmID string, indices ...int) error {
+	if len(indices) == 0 {
+		return nil
+	}
+	if c.cniConf == nil {
+		return fmt.Errorf("%w: no conflist found in %s", network.ErrNotConfigured, c.conf.CNIConfDir)
+	}
+	nsPath := netnsPath(vmID)
+	logger := log.WithFunc("cni.Remove")
+
+	var records []networkRecord
+	if err := c.store.With(ctx, func(idx *networkIndex) error {
+		records = idx.byVMID(vmID)
+		return nil
+	}); err != nil {
+		return fmt.Errorf("read network index: %w", err)
+	}
+	byIfName := make(map[string]networkRecord, len(records))
+	for _, r := range records {
+		byIfName[r.IfName] = r
+	}
+
+	idsToDelete := make([]string, 0, len(indices))
+	for _, i := range indices {
+		ifName := fmt.Sprintf("eth%d", i)
+		rec, ok := byIfName[ifName]
+		if !ok {
+			return fmt.Errorf("nic %d (%s): no record", i, ifName)
+		}
+		confList, err := c.confListByName(rec.Type)
+		if err != nil {
+			return fmt.Errorf("nic %d: %w", i, err)
+		}
+		if delErr := c.cniDel(ctx, confList, vmID, nsPath, ifName); delErr != nil {
+			logger.Warnf(ctx, "CNI DEL %s/%s: %v", vmID, ifName, delErr)
+		}
+		if err := deleteTAPInNetns(nsPath, tapNameForVM(vmID, i)); err != nil {
+			return fmt.Errorf("delete tap %s: %w", tapNameForVM(vmID, i), err)
+		}
+		idsToDelete = append(idsToDelete, rec.ID)
+	}
+
+	return c.store.Update(ctx, func(idx *networkIndex) error {
+		for _, id := range idsToDelete {
+			delete(idx.Networks, id)
+		}
+		return nil
+	})
+}
+
+// cniDel runs CNI DEL for one NIC; shared by Add (recovery + rollback) and Remove.
+func (c *CNI) cniDel(ctx context.Context, confList *libcni.NetworkConfigList, vmID, nsPath, ifName string) error {
+	rt := &libcni.RuntimeConf{ContainerID: vmID, NetNS: nsPath, IfName: ifName}
+	return c.cniConf.DelNetworkList(ctx, confList, rt)
+}
+
 func tapNameForVM(vmID string, nic int) string {
 	return fmt.Sprintf("tap%s-%d", network.VMIDPrefix(vmID), nic)
+}
+
+// ensureNetns creates the netns when /var/run/netns/<name> is absent.
+// The bool reports whether this call did the creation, so rollback only
+// tears down a netns we just made.
+func ensureNetns(name, nsPath string) (bool, error) {
+	if _, err := os.Stat(nsPath); err == nil {
+		return false, nil
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return false, err
+	}
+	if err := createNetns(name); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // extractNetworkInfo converts a CNI ADD result into types.Network.

--- a/network/cni/create.go
+++ b/network/cni/create.go
@@ -145,9 +145,7 @@ func (c *CNI) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs
 }
 
 // Remove tears down NIC plumbing for the given indices; preserves the netns.
-// DB records for picked indices are always swept so a later resize-up at the
-// same index does not see a stale eth<idx> entry; CNI/TAP failures still
-// propagate as the returned error.
+// Always sweeps DB records for picked indices so resize-up to the same index isn't stale; CNI/TAP errors still propagate.
 func (c *CNI) Remove(ctx context.Context, vmID string, indices ...int) error {
 	if len(indices) == 0 {
 		return nil

--- a/network/cni/create.go
+++ b/network/cni/create.go
@@ -40,14 +40,21 @@ func (c *CNI) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs
 		return nil, fmt.Errorf("ensure netns %s: %w", nsName, err)
 	}
 
-	addedIFs := make([]string, 0, len(specs))
+	addedIdx := make([]int, 0, len(specs))
 	defer func() {
 		if retErr == nil {
 			return
 		}
-		for _, ifn := range addedIFs {
+		for _, i := range addedIdx {
+			ifn := fmt.Sprintf("eth%d", i)
 			if delErr := c.cniDel(ctx, confList, vmID, nsPath, ifn); delErr != nil {
 				logger.Warnf(ctx, "rollback CNI DEL %s/%s: %v", vmID, ifn, delErr)
+			}
+			// setupTCRedirect creates the TAP; it would leak if the netns persists.
+			if !createdNetns {
+				if delErr := deleteTAPInNetns(nsPath, tapNameForVM(vmID, i)); delErr != nil {
+					logger.Warnf(ctx, "rollback tap delete %s: %v", tapNameForVM(vmID, i), delErr)
+				}
 			}
 		}
 		if createdNetns {
@@ -79,7 +86,7 @@ func (c *CNI) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs
 		if addErr != nil {
 			return nil, fmt.Errorf("cni add %s/%s: %w", vmID, ifName, addErr)
 		}
-		addedIFs = append(addedIFs, ifName)
+		addedIdx = append(addedIdx, spec.Index)
 
 		netInfo, parseErr := extractNetworkInfo(cniResult)
 		if parseErr != nil {
@@ -169,7 +176,6 @@ func (c *CNI) Remove(ctx context.Context, vmID string, indices ...int) error {
 	return c.deleteRecords(ctx, ids)
 }
 
-// cniDel runs CNI DEL for one NIC; shared by Add (recovery + rollback) and Remove.
 func (c *CNI) cniDel(ctx context.Context, confList *libcni.NetworkConfigList, vmID, nsPath, ifName string) error {
 	rt := &libcni.RuntimeConf{ContainerID: vmID, NetNS: nsPath, IfName: ifName}
 	return c.cniConf.DelNetworkList(ctx, confList, rt)
@@ -179,9 +185,7 @@ func tapNameForVM(vmID string, nic int) string {
 	return fmt.Sprintf("tap%s-%d", network.VMIDPrefix(vmID), nic)
 }
 
-// ensureNetns creates the netns when /var/run/netns/<name> is absent.
-// The bool reports whether this call did the creation, so rollback only
-// tears down a netns we just made.
+// ensureNetns creates the netns if missing; bool reports whether this call did the creation.
 func ensureNetns(name, nsPath string) (bool, error) {
 	if _, err := os.Stat(nsPath); err == nil {
 		return false, nil

--- a/network/cni/create.go
+++ b/network/cni/create.go
@@ -170,8 +170,7 @@ func (c *CNI) Remove(ctx context.Context, vmID string, indices ...int) error {
 		picked = append(picked, rec)
 	}
 	ids, err := c.tearDownNICs(ctx, vmID, netnsPath(vmID), picked, true, false)
-	// Always sweep fully-torn-down records, even when tearDownNICs aborted on
-	// a later NIC; otherwise the cleaned ones leak DB rows until vm delete.
+	// Sweep partially-torn-down records even on abort, else they leak DB rows.
 	if delErr := c.deleteRecords(ctx, ids); delErr != nil && err == nil {
 		err = delErr
 	}

--- a/network/cni/create.go
+++ b/network/cni/create.go
@@ -170,10 +170,12 @@ func (c *CNI) Remove(ctx context.Context, vmID string, indices ...int) error {
 		picked = append(picked, rec)
 	}
 	ids, err := c.tearDownNICs(ctx, vmID, netnsPath(vmID), picked, true, false)
-	if err != nil {
-		return err
+	// Always sweep fully-torn-down records, even when tearDownNICs aborted on
+	// a later NIC; otherwise the cleaned ones leak DB rows until vm delete.
+	if delErr := c.deleteRecords(ctx, ids); delErr != nil && err == nil {
+		err = delErr
 	}
-	return c.deleteRecords(ctx, ids)
+	return err
 }
 
 func (c *CNI) cniDel(ctx context.Context, confList *libcni.NetworkConfigList, vmID, nsPath, ifName string) error {

--- a/network/cni/create.go
+++ b/network/cni/create.go
@@ -142,12 +142,6 @@ func (c *CNI) Remove(ctx context.Context, vmID string, indices ...int) error {
 	if len(indices) == 0 {
 		return nil
 	}
-	if c.cniConf == nil {
-		return fmt.Errorf("%w: no conflist found in %s", network.ErrNotConfigured, c.conf.CNIConfDir)
-	}
-	nsPath := netnsPath(vmID)
-	logger := log.WithFunc("cni.Remove")
-
 	var records []networkRecord
 	if err := c.store.With(ctx, func(idx *networkIndex) error {
 		records = idx.byVMID(vmID)
@@ -159,33 +153,20 @@ func (c *CNI) Remove(ctx context.Context, vmID string, indices ...int) error {
 	for _, r := range records {
 		byIfName[r.IfName] = r
 	}
-
-	idsToDelete := make([]string, 0, len(indices))
+	picked := make([]networkRecord, 0, len(indices))
 	for _, i := range indices {
 		ifName := fmt.Sprintf("eth%d", i)
 		rec, ok := byIfName[ifName]
 		if !ok {
 			return fmt.Errorf("nic %d (%s): no record", i, ifName)
 		}
-		confList, err := c.confListByName(rec.Type)
-		if err != nil {
-			return fmt.Errorf("nic %d: %w", i, err)
-		}
-		if delErr := c.cniDel(ctx, confList, vmID, nsPath, ifName); delErr != nil {
-			logger.Warnf(ctx, "CNI DEL %s/%s: %v", vmID, ifName, delErr)
-		}
-		if err := deleteTAPInNetns(nsPath, tapNameForVM(vmID, i)); err != nil {
-			return fmt.Errorf("delete tap %s: %w", tapNameForVM(vmID, i), err)
-		}
-		idsToDelete = append(idsToDelete, rec.ID)
+		picked = append(picked, rec)
 	}
-
-	return c.store.Update(ctx, func(idx *networkIndex) error {
-		for _, id := range idsToDelete {
-			delete(idx.Networks, id)
-		}
-		return nil
-	})
+	ids, err := c.tearDownNICs(ctx, vmID, netnsPath(vmID), picked, true, false)
+	if err != nil {
+		return err
+	}
+	return c.deleteRecords(ctx, ids)
 }
 
 // cniDel runs CNI DEL for one NIC; shared by Add (recovery + rollback) and Remove.

--- a/network/cni/create_darwin.go
+++ b/network/cni/create_darwin.go
@@ -18,3 +18,7 @@ func deleteNetns(_ context.Context, _ string) error {
 func setupTCRedirect(_, _, _ string, _ int, _ string) (string, error) {
 	return "", errNotSupported
 }
+
+func deleteTAPInNetns(_, _ string) error {
+	return errNotSupported
+}

--- a/network/cni/create_linux.go
+++ b/network/cni/create_linux.go
@@ -52,6 +52,17 @@ func deleteNetns(ctx context.Context, name string) error {
 	})
 }
 
+// deleteTAPInNetns deletes a named TAP device inside target netns.
+func deleteTAPInNetns(nsPath, tapName string) error {
+	return cns.WithNetNSPath(nsPath, func(_ cns.NetNS) error {
+		link, err := netlink.LinkByName(tapName)
+		if err != nil {
+			return fmt.Errorf("find %s: %w", tapName, err)
+		}
+		return netlink.LinkDel(link)
+	})
+}
+
 // setupTCRedirect wires ifName <-> tapName inside target netns, returns MAC.
 func setupTCRedirect(nsPath, ifName, tapName string, queues int, overrideMAC string) (string, error) {
 	var mac string

--- a/network/cni/gc.go
+++ b/network/cni/gc.go
@@ -76,7 +76,7 @@ func (c *CNI) GCModule() gc.Module[cniSnapshot] {
 				}
 
 				// 2. CNI DEL per NIC — best-effort IPAM release.
-				c.delNICs(ctx, vmID, netnsPath(vmID), records)
+				_, _ = c.tearDownNICs(ctx, vmID, netnsPath(vmID), records, false, true)
 
 				// 3. Remove the named netns (with retry for async kernel fd cleanup).
 				nsName := netnsName(vmID)

--- a/network/cni/gc.go
+++ b/network/cni/gc.go
@@ -76,7 +76,7 @@ func (c *CNI) GCModule() gc.Module[cniSnapshot] {
 				}
 
 				// 2. CNI DEL per NIC — best-effort IPAM release.
-				_, _ = c.tearDownNICs(ctx, vmID, netnsPath(vmID), records, false, true)
+				_ = c.tearDownNICs(ctx, vmID, netnsPath(vmID), records, false, true)
 
 				// 3. Remove the named netns (with retry for async kernel fd cleanup).
 				nsName := netnsName(vmID)

--- a/network/network.go
+++ b/network/network.go
@@ -19,27 +19,17 @@ type AddSpec struct {
 	Existing *types.NetworkConfig
 }
 
-// Network defines the interface for a network provider (CNI, bridge, ...).
 type Network interface {
 	Type() string
-
-	// Verify checks whether the network namespace / TAPs for a VM exist.
 	Verify(ctx context.Context, vmID string) error
-
-	// Add allocates NIC host plumbing for the given specs; idempotent re: netns.
 	Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs ...AddSpec) ([]*types.NetworkConfig, error)
-
-	// Remove tears down NIC host plumbing for the given indices; preserves netns.
 	Remove(ctx context.Context, vmID string, indices ...int) error
-
 	Delete(context.Context, []string) ([]string, error)
 	Inspect(context.Context, string) (*types.Network, error)
 	List(context.Context) ([]*types.Network, error)
-
 	RegisterGC(*gc.Orchestrator)
 }
 
-// AddRange returns specs for a contiguous range of fresh NICs.
 func AddRange(from, count int) []AddSpec {
 	out := make([]AddSpec, count)
 	for i := range out {
@@ -48,7 +38,6 @@ func AddRange(from, count int) []AddSpec {
 	return out
 }
 
-// AddRecover returns specs for re-creating existing NICs at slots 0..len-1.
 func AddRecover(existing []*types.NetworkConfig) []AddSpec {
 	out := make([]AddSpec, len(existing))
 	for i, e := range existing {

--- a/network/network.go
+++ b/network/network.go
@@ -13,21 +13,46 @@ var (
 	ErrNotConfigured = errors.New("network provider not configured")
 )
 
-// Network defines the interface for a network provider (CNI, etc.).
+// AddSpec is one NIC's add request; Existing != nil reuses MAC/IP for recovery.
+type AddSpec struct {
+	Index    int
+	Existing *types.NetworkConfig
+}
+
+// Network defines the interface for a network provider (CNI, bridge, ...).
 type Network interface {
 	Type() string
 
-	// Verify checks whether the network namespace for a VM exists.
-	// Returns nil if the netns is present, an error otherwise.
+	// Verify checks whether the network namespace / TAPs for a VM exist.
 	Verify(ctx context.Context, vmID string) error
-	// Config creates network namespace, bridge, and tap for a VM.
-	// When existing configs are provided (recovery after host reboot),
-	// the netns and tap devices are recreated using the persisted MAC addresses.
-	// NOTE: vmCfg.Network may be mutated to record the resolved conflist name.
-	Config(ctx context.Context, vmID string, numNICs int, vmCfg *types.VMConfig, existing ...*types.NetworkConfig) ([]*types.NetworkConfig, error)
+
+	// Add allocates NIC host plumbing for the given specs; idempotent re: netns.
+	Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs ...AddSpec) ([]*types.NetworkConfig, error)
+
+	// Remove tears down NIC host plumbing for the given indices; preserves netns.
+	Remove(ctx context.Context, vmID string, indices ...int) error
+
 	Delete(context.Context, []string) ([]string, error)
 	Inspect(context.Context, string) (*types.Network, error)
 	List(context.Context) ([]*types.Network, error)
 
 	RegisterGC(*gc.Orchestrator)
+}
+
+// AddRange returns specs for a contiguous range of fresh NICs.
+func AddRange(from, count int) []AddSpec {
+	out := make([]AddSpec, count)
+	for i := range out {
+		out[i] = AddSpec{Index: from + i}
+	}
+	return out
+}
+
+// AddRecover returns specs for re-creating existing NICs at slots 0..len-1.
+func AddRecover(existing []*types.NetworkConfig) []AddSpec {
+	out := make([]AddSpec, len(existing))
+	for i, e := range existing {
+		out[i] = AddSpec{Index: i, Existing: e}
+	}
+	return out
 }

--- a/network/network.go
+++ b/network/network.go
@@ -19,6 +19,7 @@ type AddSpec struct {
 	Existing *types.NetworkConfig
 }
 
+// Network is the per-VM host-side networking provider (CNI, bridge, ...).
 type Network interface {
 	Type() string
 	Verify(ctx context.Context, vmID string) error
@@ -30,6 +31,7 @@ type Network interface {
 	RegisterGC(*gc.Orchestrator)
 }
 
+// AddRange builds AddSpecs for a contiguous block of fresh NIC indices.
 func AddRange(from, count int) []AddSpec {
 	out := make([]AddSpec, count)
 	for i := range out {
@@ -38,6 +40,7 @@ func AddRange(from, count int) []AddSpec {
 	return out
 }
 
+// AddRecover builds AddSpecs for re-creating existing NICs (post-reboot recovery).
 func AddRecover(existing []*types.NetworkConfig) []AddSpec {
 	out := make([]AddSpec, len(existing))
 	for i, e := range existing {

--- a/types/network.go
+++ b/types/network.go
@@ -1,5 +1,11 @@
 package types
 
+// Network backend identifiers stored in NetworkConfig.Backend.
+const (
+	BackendCNI    = "cni"
+	BackendBridge = "bridge"
+)
+
 // NetworkConfig describes a single NIC attached to a VM.
 type NetworkConfig struct {
 	TAP       string `json:"tap"`


### PR DESCRIPTION
## Summary

- New CLI `cocoon vm net --nics N <vm>` resizes the NIC count on a running VM (CH only). To add, cocoon allocates fresh TAP/CNI/bridge plumbing and calls `vm.add-net`; to remove, it pops NICs from the tail (LIFO) via `vm.remove-device` and tears down host plumbing.
- `network.Network` interface refactor: `Config(numNICs, existing...)` → variadic `Add(specs ...AddSpec)` / `Remove(indices ...int)` for symmetric NIC-level ops; `Delete` and `Remove` share a `tearDown` helper.

## Design decisions

- **Host plumbing torn down immediately after `vm.remove-device` returns** — CH's HTTP API has no reliable eject signal (the slot/ioeventfd cleanup only happens when the guest writes B0EJ via ACPI/SCI). User accepts in-guest driver hang risk and is responsible for quiescing the NIC before reducing the count.
- **CH only for v1** — Firecracker has no NIC hot-plug/unplug API; the resize call returns `netresize.ErrUnsupportedBackend`.
- **CH device IDs derived from MAC** (`cocoon-net-<mac-no-colons>`) — not persisted in `types.NetworkConfig`; remove path looks up live IDs via `vm.info` + MAC match so boot-time NICs (CH auto `_netN`) and cocoon-added NICs both work. `clone.hotSwapNets` uses the same id convention via the shared `addCocoonNIC` helper.
- **DB persistence with rollback** — `netResizeAdd` rolls back CH + plumbing on persistence failure; `netResizeRemove` always truncates the cocoon record once CH accepts the eject (leaked host plumbing is reclaimed by gc / `cocoon vm rm`) so the next resize can converge.
- **Zero-NIC VMs cannot be resized up** — VMConfig has no bridge hint; the original provider choice is lost once all NICs are removed.

## Test plan

- [x] `make lint` 0 issues on linux/amd64 + darwin/amd64
- [x] `go test ./...` all green
- [ ] Manual: Linux cloudimg VM — boot with 1 NIC, resize to 3, verify DHCP on all three, resize back to 1
- [ ] Manual: bridge backend — same flow
- [ ] Manual: Windows VM — resize down after disabling NIC in guest
- [ ] Manual: FC VM — `vm net --nics 1` returns `ErrUnsupportedBackend`
- [ ] Manual: clone smoke — verify hotSwapNets still works post-refactor, no warnings under normal flow