### PR TITLE
fix: kill orphan VMM via /proc cmdline fallback when pidfile pre-removed

### DIFF
--- a/hypervisor/state.go
+++ b/hypervisor/state.go
@@ -19,14 +19,25 @@ const socketProbeTimeout = 2 * time.Second
 
 // WithRunningVM calls fn if rec still points to a live VM process.
 func (b *Backend) WithRunningVM(ctx context.Context, rec *VMRecord, fn func(pid int) error) error {
+	logger := log.WithFunc(b.Typ + ".WithRunningVM")
 	pid, pidErr := utils.ReadPIDFile(b.PIDFilePath(rec.RunDir))
 	if pidErr != nil && !errors.Is(pidErr, fs.ErrNotExist) {
-		log.WithFunc(b.Typ+".WithRunningVM").Warnf(ctx, "read PID file: %v", pidErr)
+		logger.Warnf(ctx, "read PID file: %v", pidErr)
 	}
-	if !utils.VerifyProcessCmdline(pid, b.Conf.BinaryName(), SocketPath(rec.RunDir)) {
+	sockPath := SocketPath(rec.RunDir)
+	if utils.VerifyProcessCmdline(pid, b.Conf.BinaryName(), sockPath) {
+		return fn(pid)
+	}
+	// Covers pidfile/socket cleaned up before VMM exited.
+	scanned, scanErr := utils.FindVMMByCmdline(b.Conf.BinaryName(), sockPath)
+	if scanErr != nil {
+		logger.Warnf(ctx, "scan /proc for VM %s: %v", rec.ID, scanErr)
+	}
+	if len(scanned) == 0 {
 		return ErrNotRunning
 	}
-	return fn(pid)
+	logger.Warnf(ctx, "VM %s recovered live pids %v via cmdline scan", rec.ID, scanned)
+	return fn(scanned[0])
 }
 
 // IsAPISocketLive: (true,nil)=confirmed live; (false,nil)=ENOENT/ECONNREFUSED; (true,err)=fail-closed for unknown dial errors.

--- a/hypervisor/state.go
+++ b/hypervisor/state.go
@@ -31,7 +31,7 @@ func (b *Backend) WithRunningVM(ctx context.Context, rec *VMRecord, fn func(pid 
 	// Covers pidfile/socket cleaned up before VMM exited. Fail-closed if scan errors so callers don't treat inconclusive state as ErrNotRunning.
 	scanned, scanErr := utils.FindVMMByCmdline(b.Conf.BinaryName(), sockPath)
 	if scanErr != nil {
-		return fmt.Errorf("VM %s: pidfile-based check failed and /proc scan errored: %w", rec.ID, scanErr)
+		return fmt.Errorf("VM %s: pidfile-based check failed and /proc scan errored: %w (resolve the host issue and retry)", rec.ID, scanErr)
 	}
 	if len(scanned) == 0 {
 		return ErrNotRunning

--- a/hypervisor/state.go
+++ b/hypervisor/state.go
@@ -28,10 +28,10 @@ func (b *Backend) WithRunningVM(ctx context.Context, rec *VMRecord, fn func(pid 
 	if utils.VerifyProcessCmdline(pid, b.Conf.BinaryName(), sockPath) {
 		return fn(pid)
 	}
-	// Covers pidfile/socket cleaned up before VMM exited.
+	// Covers pidfile/socket cleaned up before VMM exited. Fail-closed if scan errors so callers don't treat inconclusive state as ErrNotRunning.
 	scanned, scanErr := utils.FindVMMByCmdline(b.Conf.BinaryName(), sockPath)
 	if scanErr != nil {
-		logger.Warnf(ctx, "scan /proc for VM %s: %v", rec.ID, scanErr)
+		return fmt.Errorf("VM %s: pidfile-based check failed and /proc scan errored: %w", rec.ID, scanErr)
 	}
 	if len(scanned) == 0 {
 		return ErrNotRunning

--- a/hypervisor/stop.go
+++ b/hypervisor/stop.go
@@ -56,6 +56,7 @@ func (b *Backend) DeleteAll(ctx context.Context, refs []string, force bool, stop
 		if loadErr != nil {
 			return loadErr
 		}
+		sockPath := SocketPath(rec.RunDir)
 		if runningErr := b.WithRunningVM(ctx, &rec, func(_ int) error {
 			if !force {
 				return fmt.Errorf("running (force required)")
@@ -70,9 +71,18 @@ func (b *Backend) DeleteAll(ctx context.Context, refs []string, force bool, stop
 				return ctxErr
 			}
 			if probeErr != nil {
-				return fmt.Errorf("refuse delete: api socket %s probe inconclusive: %w (resolve the host issue or kill the vmm process then retry)", SocketPath(rec.RunDir), probeErr)
+				return fmt.Errorf("refuse delete: api socket %s probe inconclusive: %w (resolve the host issue or kill the vmm process then retry)", sockPath, probeErr)
 			}
-			return fmt.Errorf("refuse delete: api socket %s still responsive (suspected orphan vmm; kill the vmm process then retry)", SocketPath(rec.RunDir))
+			return fmt.Errorf("refuse delete: api socket %s still responsive (suspected orphan vmm; kill the vmm process then retry)", sockPath)
+		}
+		// Catches workers/siblings the pidfile-based stop didn't see.
+		if scanned, _ := utils.FindVMMByCmdline(b.Conf.BinaryName(), sockPath); len(scanned) > 0 {
+			for _, pid := range scanned {
+				if termErr := utils.TerminateProcess(ctx, pid, b.Conf.BinaryName(), sockPath, b.Conf.TerminateGracePeriod()); termErr != nil {
+					return fmt.Errorf("terminate orphan VMM pid=%d for VM %s: %w", pid, id, termErr)
+				}
+				log.WithFunc(b.Typ+".Delete").Warnf(ctx, "killed orphan VMM pid=%d for VM %s", pid, id)
+			}
 		}
 		if rmErr := RemoveVMDirs(rec.RunDir, rec.LogDir); rmErr != nil {
 			return fmt.Errorf("cleanup VM dirs: %w", rmErr)

--- a/hypervisor/stop.go
+++ b/hypervisor/stop.go
@@ -78,7 +78,7 @@ func (b *Backend) DeleteAll(ctx context.Context, refs []string, force bool, stop
 		// Catches workers/siblings the pidfile-based stop didn't see; fail-closed on scan error so we never wipe rundir while VMM state is unknown.
 		scanned, scanErr := utils.FindVMMByCmdline(b.Conf.BinaryName(), sockPath)
 		if scanErr != nil {
-			return fmt.Errorf("refuse delete: VM %s /proc scan errored: %w (resolve host issue and retry)", id, scanErr)
+			return fmt.Errorf("refuse delete: VM %s /proc scan errored: %w (resolve the host issue and retry)", id, scanErr)
 		}
 		for _, pid := range scanned {
 			if termErr := utils.TerminateProcess(ctx, pid, b.Conf.BinaryName(), sockPath, b.Conf.TerminateGracePeriod()); termErr != nil {

--- a/hypervisor/stop.go
+++ b/hypervisor/stop.go
@@ -75,14 +75,16 @@ func (b *Backend) DeleteAll(ctx context.Context, refs []string, force bool, stop
 			}
 			return fmt.Errorf("refuse delete: api socket %s still responsive (suspected orphan vmm; kill the vmm process then retry)", sockPath)
 		}
-		// Catches workers/siblings the pidfile-based stop didn't see.
-		if scanned, _ := utils.FindVMMByCmdline(b.Conf.BinaryName(), sockPath); len(scanned) > 0 {
-			for _, pid := range scanned {
-				if termErr := utils.TerminateProcess(ctx, pid, b.Conf.BinaryName(), sockPath, b.Conf.TerminateGracePeriod()); termErr != nil {
-					return fmt.Errorf("terminate orphan VMM pid=%d for VM %s: %w", pid, id, termErr)
-				}
-				log.WithFunc(b.Typ+".Delete").Warnf(ctx, "killed orphan VMM pid=%d for VM %s", pid, id)
+		// Catches workers/siblings the pidfile-based stop didn't see; fail-closed on scan error so we never wipe rundir while VMM state is unknown.
+		scanned, scanErr := utils.FindVMMByCmdline(b.Conf.BinaryName(), sockPath)
+		if scanErr != nil {
+			return fmt.Errorf("refuse delete: VM %s /proc scan errored: %w (resolve host issue and retry)", id, scanErr)
+		}
+		for _, pid := range scanned {
+			if termErr := utils.TerminateProcess(ctx, pid, b.Conf.BinaryName(), sockPath, b.Conf.TerminateGracePeriod()); termErr != nil {
+				return fmt.Errorf("terminate orphan VMM pid=%d for VM %s: %w", pid, id, termErr)
 			}
+			log.WithFunc(b.Typ+".Delete").Warnf(ctx, "killed orphan VMM pid=%d for VM %s", pid, id)
 		}
 		if rmErr := RemoveVMDirs(rec.RunDir, rec.LogDir); rmErr != nil {
 			return fmt.Errorf("cleanup VM dirs: %w", rmErr)

--- a/utils/process.go
+++ b/utils/process.go
@@ -41,12 +41,12 @@ func IsProcessAlive(pid int) bool {
 }
 
 // VerifyProcessCmdline matches pid against binaryName + expectArg in
-// /proc/<pid>/cmdline; falls back to IsProcessAlive on non-Linux.
+// /proc/<pid>/cmdline; falls back to IsProcessAlive on non-Linux or read errors.
 func VerifyProcessCmdline(pid int, binaryName, expectArg string) bool {
 	if pid <= 0 {
 		return false
 	}
-	if match, ok := verifyProcessCmdline(pid, binaryName, expectArg); ok {
+	if match, err := verifyProcessCmdline(pid, binaryName, expectArg); err == nil {
 		return match
 	}
 	return IsProcessAlive(pid)

--- a/utils/process_linux.go
+++ b/utils/process_linux.go
@@ -3,7 +3,9 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
@@ -11,38 +13,50 @@ import (
 	"strings"
 )
 
-// FindVMMByCmdline returns pids whose argv[0] basename matches binaryName and args contain expectArg, sorted numerically.
+// FindVMMByCmdline returns pids whose argv[0] basename matches binaryName and args contain expectArg, sorted numerically; fails closed on non-ENOENT cmdline read errors.
 func FindVMMByCmdline(binaryName, expectArg string) ([]int, error) {
 	entries, err := os.ReadDir("/proc")
 	if err != nil {
 		return nil, err
 	}
 	var pids []int
+	var firstErr error
 	for _, e := range entries {
-		pid, err := strconv.Atoi(e.Name())
-		if err != nil || pid <= 0 {
+		pid, atoiErr := strconv.Atoi(e.Name())
+		if atoiErr != nil || pid <= 0 {
 			continue
 		}
-		if matched, _ := verifyProcessCmdline(pid, binaryName, expectArg); matched {
+		matched, readErr := verifyProcessCmdline(pid, binaryName, expectArg)
+		if readErr != nil {
+			// ENOENT = process exited mid-scan, safe to skip; everything else means we can't tell, so callers must fail closed.
+			if !errors.Is(readErr, fs.ErrNotExist) && firstErr == nil {
+				firstErr = fmt.Errorf("read /proc/%d/cmdline: %w", pid, readErr)
+			}
+			continue
+		}
+		if matched {
 			pids = append(pids, pid)
 		}
+	}
+	if firstErr != nil {
+		return nil, firstErr
 	}
 	slices.Sort(pids)
 	return pids, nil
 }
 
-// Match argv[0] basename strictly + expectArg substring on the rest so "bash -c 'cloud-hypervisor ...'" can't impersonate the VMM.
-func verifyProcessCmdline(pid int, binaryName, expectArg string) (matched, available bool) {
+// Match argv[0] basename strictly + expectArg substring on the rest so "bash -c 'cloud-hypervisor ...'" can't impersonate the VMM; error surfaces cmdline-read failures so callers distinguish transient ENOENT from real issues.
+func verifyProcessCmdline(pid int, binaryName, expectArg string) (bool, error) {
 	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
 	if err != nil {
-		return false, false
+		return false, err
 	}
 	argv0, rest, _ := strings.Cut(string(data), "\x00")
 	if filepath.Base(argv0) != binaryName {
-		return false, true
+		return false, nil
 	}
 	if expectArg == "" {
-		return true, true
+		return true, nil
 	}
-	return strings.Contains(rest, expectArg), true
+	return strings.Contains(rest, expectArg), nil
 }

--- a/utils/process_linux.go
+++ b/utils/process_linux.go
@@ -6,11 +6,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 )
 
-// FindVMMByCmdline returns pids whose argv[0] basename matches binaryName and args contain expectArg.
+// FindVMMByCmdline returns pids whose argv[0] basename matches binaryName and args contain expectArg, sorted numerically.
 func FindVMMByCmdline(binaryName, expectArg string) ([]int, error) {
 	entries, err := os.ReadDir("/proc")
 	if err != nil {
@@ -26,6 +27,7 @@ func FindVMMByCmdline(binaryName, expectArg string) ([]int, error) {
 			pids = append(pids, pid)
 		}
 	}
+	slices.Sort(pids)
 	return pids, nil
 }
 

--- a/utils/process_linux.go
+++ b/utils/process_linux.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -23,4 +24,23 @@ func verifyProcessCmdline(pid int, binaryName, expectArg string) (matched, avail
 		return true, true
 	}
 	return strings.Contains(rest, expectArg), true
+}
+
+// FindVMMByCmdline returns pids whose argv[0] basename matches binaryName and args contain marker.
+func FindVMMByCmdline(binaryName, marker string) ([]int, error) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil, err
+	}
+	var pids []int
+	for _, e := range entries {
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil || pid <= 0 {
+			continue
+		}
+		if matched, _ := verifyProcessCmdline(pid, binaryName, marker); matched {
+			pids = append(pids, pid)
+		}
+	}
+	return pids, nil
 }

--- a/utils/process_linux.go
+++ b/utils/process_linux.go
@@ -10,6 +10,25 @@ import (
 	"strings"
 )
 
+// FindVMMByCmdline returns pids whose argv[0] basename matches binaryName and args contain expectArg.
+func FindVMMByCmdline(binaryName, expectArg string) ([]int, error) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil, err
+	}
+	var pids []int
+	for _, e := range entries {
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil || pid <= 0 {
+			continue
+		}
+		if matched, _ := verifyProcessCmdline(pid, binaryName, expectArg); matched {
+			pids = append(pids, pid)
+		}
+	}
+	return pids, nil
+}
+
 // Match argv[0] basename strictly + expectArg substring on the rest so "bash -c 'cloud-hypervisor ...'" can't impersonate the VMM.
 func verifyProcessCmdline(pid int, binaryName, expectArg string) (matched, available bool) {
 	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
@@ -24,23 +43,4 @@ func verifyProcessCmdline(pid int, binaryName, expectArg string) (matched, avail
 		return true, true
 	}
 	return strings.Contains(rest, expectArg), true
-}
-
-// FindVMMByCmdline returns pids whose argv[0] basename matches binaryName and args contain marker.
-func FindVMMByCmdline(binaryName, marker string) ([]int, error) {
-	entries, err := os.ReadDir("/proc")
-	if err != nil {
-		return nil, err
-	}
-	var pids []int
-	for _, e := range entries {
-		pid, err := strconv.Atoi(e.Name())
-		if err != nil || pid <= 0 {
-			continue
-		}
-		if matched, _ := verifyProcessCmdline(pid, binaryName, marker); matched {
-			pids = append(pids, pid)
-		}
-	}
-	return pids, nil
 }

--- a/utils/process_other.go
+++ b/utils/process_other.go
@@ -5,3 +5,7 @@ package utils
 func verifyProcessCmdline(_ int, _, _ string) (matched, available bool) {
 	return false, false
 }
+
+func FindVMMByCmdline(_, _ string) ([]int, error) {
+	return nil, nil
+}

--- a/utils/process_other.go
+++ b/utils/process_other.go
@@ -2,10 +2,14 @@
 
 package utils
 
+import "errors"
+
+var errVerifyUnsupported = errors.New("verifyProcessCmdline: unsupported on this OS")
+
 func FindVMMByCmdline(_, _ string) ([]int, error) {
 	return nil, nil
 }
 
-func verifyProcessCmdline(_ int, _, _ string) (matched, available bool) {
-	return false, false
+func verifyProcessCmdline(_ int, _, _ string) (bool, error) {
+	return false, errVerifyUnsupported
 }

--- a/utils/process_other.go
+++ b/utils/process_other.go
@@ -2,10 +2,10 @@
 
 package utils
 
-func verifyProcessCmdline(_ int, _, _ string) (matched, available bool) {
-	return false, false
-}
-
 func FindVMMByCmdline(_, _ string) ([]int, error) {
 	return nil, nil
+}
+
+func verifyProcessCmdline(_ int, _, _ string) (matched, available bool) {
+	return false, false
 }

--- a/utils/process_test.go
+++ b/utils/process_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"testing"
 	"time"
@@ -246,12 +247,12 @@ func TestTerminateProcess_SIGTERMIgnored_FallsBackToKill(t *testing.T) {
 }
 
 func TestFindVMMByCmdline(t *testing.T) {
-	if _, err := os.Stat("/proc/self/cmdline"); err != nil {
-		t.Skip("/proc not available")
+	if runtime.GOOS != "linux" {
+		t.Skip("FindVMMByCmdline scans /proc — linux only")
 	}
 	marker := "cocoon-find-marker-" + strconv.Itoa(os.Getpid())
-	cmd := exec.Command("sleep", "60")
-	cmd.Args = []string{"sleep", marker, "60"}
+	// "sleep 60 && :" is a compound command so sh can't tail-exec into sleep and lose the marker arg.
+	cmd := exec.Command("sh", "-c", "sleep 60 && :", marker)
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -263,7 +264,7 @@ func TestFindVMMByCmdline(t *testing.T) {
 	// Poll briefly: cmdline is written by execve, so the parent may scan before /proc/<pid>/cmdline reflects argv.
 	var pids []int
 	for range 50 {
-		got, err := FindVMMByCmdline("sleep", marker)
+		got, err := FindVMMByCmdline("sh", marker)
 		if err != nil {
 			t.Fatalf("FindVMMByCmdline: %v", err)
 		}
@@ -280,7 +281,7 @@ func TestFindVMMByCmdline(t *testing.T) {
 	if got, _ := FindVMMByCmdline("definitely-no-such-binary", marker); len(got) != 0 {
 		t.Errorf("wrong-binary scan matched: %v", got)
 	}
-	if got, _ := FindVMMByCmdline("sleep", "no-such-marker"); len(got) != 0 {
+	if got, _ := FindVMMByCmdline("sh", "no-such-marker-"+marker); len(got) != 0 {
 		t.Errorf("wrong-marker scan matched: %v", got)
 	}
 }

--- a/utils/process_test.go
+++ b/utils/process_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -242,6 +243,46 @@ func TestTerminateProcess_SIGTERMIgnored_FallsBackToKill(t *testing.T) {
 	}
 
 	<-waitDone
+}
+
+func TestFindVMMByCmdline(t *testing.T) {
+	if _, err := os.Stat("/proc/self/cmdline"); err != nil {
+		t.Skip("/proc not available")
+	}
+	marker := "cocoon-find-marker-" + strconv.Itoa(os.Getpid())
+	cmd := exec.Command("sleep", "60")
+	cmd.Args = []string{"sleep", marker, "60"}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	// Poll briefly: cmdline is written by execve, so the parent may scan before /proc/<pid>/cmdline reflects argv.
+	var pids []int
+	for range 50 {
+		got, err := FindVMMByCmdline("sleep", marker)
+		if err != nil {
+			t.Fatalf("FindVMMByCmdline: %v", err)
+		}
+		if len(got) > 0 {
+			pids = got
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(pids) != 1 || pids[0] != cmd.Process.Pid {
+		t.Errorf("FindVMMByCmdline: got %v, want [%d]", pids, cmd.Process.Pid)
+	}
+
+	if got, _ := FindVMMByCmdline("definitely-no-such-binary", marker); len(got) != 0 {
+		t.Errorf("wrong-binary scan matched: %v", got)
+	}
+	if got, _ := FindVMMByCmdline("sleep", "no-such-marker"); len(got) != 0 {
+		t.Errorf("wrong-marker scan matched: %v", got)
+	}
 }
 
 func TestTerminateProcess_ContextCancelled(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `utils.FindVMMByCmdline` /proc scan as a fallback when the pidfile-based stop path can't see a live VMM.
- Hardens `WithRunningVM` (recover the pid) and `DeleteAll` (post-stop sweep for workers/siblings).
- Repro: pidfile + api.sock removed before the VMM exits — current code declares the VM dead, wipes the rundir, deletes the DB record, but the VMM keeps running as a PPID=1 orphan.

## Background

PR #50 added the socket-probe tiebreaker, which only catches orphans whose `api.sock` is still listening. The GKE prod scan today turned up 3 orphan VMMs whose api.sock had been wiped along with the rundir — the chain was:

```
CH snapshot save → InvalidStateTransition(Paused, Paused)
  → vm rm --force triggered
  → WithRunningVM (pidfile gone) → ErrNotRunning
  → socket-probe (api.sock also gone) → false
  → RemoveVMDirs + DB delete
  → VMM process still alive, now PPID=1 orphan
```

`InvalidStateTransition(Paused, Paused)` is a separate upstream CH bug (non-idempotent `Vm::pause()` in `vmm/src/vm.rs:3239` — `valid_transition` rejects `Paused → Paused`); investigating separately. This PR closes the orphan-leak hole on the cocoon side regardless of what triggers it.

## Reproduction (testbed `35.240.182.52`)

```
cocoon vm run --nics 0 --memory 512M ghcr.io/cocoonstack/cocoon/ubuntu:24.04
rm /var/lib/cocoon/run/cloudhypervisor/$VMID/ch.pid
rm /var/lib/cocoon/run/cloudhypervisor/$VMID/api.sock
cocoon vm rm --force $VMID
# Before fix: deleted VM, but `ps | grep cloud-hypervisor` still shows the process
# After fix:  WARN "recovered live pids ... via cmdline scan", process is gone
```

## Test plan

- [x] `make lint` passes on both `GOOS=linux` and `GOOS=darwin` (0 issues)
- [x] `go test ./utils/ ./hypervisor/` passes; new `TestFindVMMByCmdline` covers the happy path + binary/marker negatives
- [x] testbed repro: pidfile-only sabotage → killed (socket-probe path) + pidfile+socket sabotage → killed (cmdline-scan fallback) + normal `vm rm` path still works
- [ ] deploy to GKE prod, re-scan for orphans after next e2e run