### PR TITLE
feat(types): validate snapshot name length and shape

### DIFF
--- a/cmd/snapshot/handler.go
+++ b/cmd/snapshot/handler.go
@@ -41,6 +41,9 @@ func (h Handler) Save(cmd *cobra.Command, args []string) error {
 	name, _ := cmd.Flags().GetString("name")
 	description, _ := cmd.Flags().GetString("description")
 
+	if err = (&types.SnapshotConfig{Name: name}).Validate(); err != nil {
+		return err
+	}
 	if name != "" {
 		if _, inspectErr := snapBackend.Inspect(ctx, name); inspectErr == nil {
 			return fmt.Errorf("snapshot name %q already exists", name)
@@ -250,6 +253,10 @@ func (h Handler) Import(cmd *cobra.Command, args []string) error {
 
 	name, _ := cmd.Flags().GetString("name")
 	description, _ := cmd.Flags().GetString("description")
+
+	if err = (&types.SnapshotConfig{Name: name}).Validate(); err != nil {
+		return err
+	}
 
 	var r io.Reader
 	if len(args) > 0 {

--- a/snapshot/localfile/import.go
+++ b/snapshot/localfile/import.go
@@ -54,6 +54,10 @@ func (lf *LocalFile) Import(ctx context.Context, r io.Reader, name, description 
 	cfg.Name = cmp.Or(name, cfg.Name)
 	cfg.Description = cmp.Or(description, cfg.Description)
 
+	if err = cfg.Validate(); err != nil {
+		return "", err
+	}
+
 	size, sizeErr := utils.DirSize(dataDir)
 	if sizeErr != nil {
 		return "", fmt.Errorf("compute data dir size: %w", sizeErr)

--- a/snapshot/localfile/localfile.go
+++ b/snapshot/localfile/localfile.go
@@ -86,6 +86,9 @@ func (lf *LocalFile) Create(ctx context.Context, cfg *types.SnapshotConfig, stre
 	if id == "" {
 		return "", fmt.Errorf("snapshot ID is required (must be set by caller)")
 	}
+	if err = cfg.Validate(); err != nil {
+		return "", err
+	}
 
 	dataDir := lf.conf.SnapshotDataDir(id)
 	now := time.Now()

--- a/types/snapshot.go
+++ b/types/snapshot.go
@@ -1,6 +1,9 @@
 package types
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // SnapshotConfig carries the parameters for creating a snapshot.
 // The hypervisor fills ID, Image, ImageBlobIDs, Hypervisor, and resource fields; the CLI adds Name and Description.
@@ -13,6 +16,14 @@ type SnapshotConfig struct {
 	ImageBlobIDs map[string]struct{} `json:"image_blob_ids,omitempty"` // blob hex set for GC pinning
 	Hypervisor   string              `json:"hypervisor,omitempty"`     // originating backend ("cloud-hypervisor" or "firecracker")
 	NICs         int                 `json:"nics,omitempty"`
+}
+
+// Validate checks SnapshotConfig caller-controlled fields. Empty Name is allowed (name is optional).
+func (cfg *SnapshotConfig) Validate() error {
+	if cfg.Name != "" && !validName.MatchString(cfg.Name) {
+		return fmt.Errorf("snapshot name %q is invalid: must match %s (max 63 chars)", cfg.Name, validName.String())
+	}
+	return nil
 }
 
 // Snapshot is the public record for a snapshot.

--- a/types/snapshot_test.go
+++ b/types/snapshot_test.go
@@ -1,0 +1,32 @@
+package types
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSnapshotConfig_Validate(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfgName string
+		wantErr bool
+	}{
+		{"empty allowed", "", false},
+		{"simple", "my-snap", false},
+		{"with dot underscore", "my.snap_v1", false},
+		{"max 63", strings.Repeat("a", 63), false},
+		{"over 63", strings.Repeat("a", 64), true},
+		{"leading hyphen", "-bad", true},
+		{"space", "bad name", true},
+		{"slash", "bad/name", true},
+		{"control char", "bad\x00name", true},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			err := (&SnapshotConfig{Name: tt.cfgName}).Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate(%q): err=%v, wantErr=%v", tt.cfgName, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

\`cocoon snapshot save\`/\`import\` previously accepted any string for \`--name\` — no length cap, no charset check. A snapshot named with 100+ chars or shell-unsafe chars would write straight into the DB, the OCI annotation on push, and any downstream propagation (Linux \`HOST_NAME_MAX=64\`, K8s DNS-1123 labels in pod name concatenation, etc).

This PR closes the gap by mirroring \`VMConfig.Validate\`'s rule on \`SnapshotConfig\`:

\`\`\`go
validName = regexp.MustCompile(\`^[a-zA-Z0-9][a-zA-Z0-9._-]{0,62}$\`)
\`\`\`

(1 leading char + ≤62 trailing = max 63 chars, fitting under Linux's HOST_NAME_MAX boundary.)

## Changes

| File | Change |
|---|---|
| \`types/snapshot.go\` | New \`SnapshotConfig.Validate()\` method (empty Name still allowed) |
| \`types/snapshot_test.go\` | 9 subtests covering empty / valid / over-63 / leading-hyphen / space / slash / control char |
| \`cmd/snapshot/handler.go\` | \`Save\` + \`Import\` validate the \`--name\` flag early — fail before expensive snapshot/import work |
| \`snapshot/localfile/localfile.go\` | \`Create\` runs Validate before insert (defense-in-depth) |
| \`snapshot/localfile/import.go\` | \`Import\` runs Validate after envelope/override merge |

## Behavior

Before:
\`\`\`
$ cocoon snapshot save vm --name \"my-very-very-long-name-that-keeps-going-and-going-and-blows-past-63-chars\"
snapshot saved: ULID...   # silently OK, downstream breaks later
\`\`\`

After:
\`\`\`
$ cocoon snapshot save vm --name \"my-very-very-long-name-...-blows-past-63-chars\"
Error: snapshot name \"my-very...\" is invalid: must match ^[a-zA-Z0-9][a-zA-Z0-9._-]{0,62}$ (max 63 chars)
\`\`\`

Same for \`cocoon snapshot import --name X\`.

Empty \`--name\` is still allowed (name is optional, ID is the fallback identifier).

## Why

Reported by @doge: CH-bound hostname (set via cloud-init cidata or kernel cmdline) hits Linux \`HOST_NAME_MAX=64\` boundary. When vk-cocoon concatenates pod names → \`cocoon snapshot save --name <combined>\`, an overly long name would have been silently accepted, then surface as a downstream failure. \`VMConfig\` already validated this; SnapshotConfig didn't.

## Verification

\`\`\`
✓ go build ./...
✓ make lint   (0 issues × Linux + Darwin)
✓ go test ./... (all green; 9 new SnapshotConfig.Validate subtests pass)
\`\`\`

## Test plan

- [ ] \`cocoon snapshot save vm --name foo\` works
- [ ] \`cocoon snapshot save vm --name \$(python -c 'print(\"a\"*64)')\` rejected with clear error
- [ ] \`cocoon snapshot save vm --name 'has space'\` rejected
- [ ] \`cocoon snapshot save vm\` (no \`--name\`) works (empty allowed)
- [ ] \`cocoon snapshot import file.tar.gz --name bad\$char\` rejected before opening file