### PR TITLE
fix(oci): guard scanBootFiles short namePrefix slice (#63)

### DIFF
--- a/images/oci/boot.go
+++ b/images/oci/boot.go
@@ -84,7 +84,7 @@ func recoverBootFiles(ctx context.Context, layer v1.Layer, workDir string, idx i
 	return kp, ip
 }
 
-func scanBootFiles(ctx context.Context, r io.Reader, workDir, digestHex string) (kernelPath, initrdPath string, err error) {
+func scanBootFiles(ctx context.Context, r io.Reader, workDir, namePrefix string) (kernelPath, initrdPath string, err error) {
 	logger := log.WithFunc("oci.scanBootFiles")
 
 	tr := tar.NewReader(r)
@@ -121,9 +121,9 @@ func scanBootFiles(ctx context.Context, r io.Reader, workDir, digestHex string) 
 
 		var dstPath string
 		if isKernel {
-			dstPath = filepath.Join(workDir, digestHex+".vmlinuz")
+			dstPath = filepath.Join(workDir, namePrefix+".vmlinuz")
 		} else {
-			dstPath = filepath.Join(workDir, digestHex+".initrd.img")
+			dstPath = filepath.Join(workDir, namePrefix+".initrd.img")
 		}
 
 		f, createErr := os.Create(dstPath) //nolint:gosec
@@ -141,7 +141,8 @@ func scanBootFiles(ctx context.Context, r io.Reader, workDir, digestHex string) 
 		} else {
 			initrdPath = dstPath
 		}
-		logger.Debugf(ctx, "Layer %s: extracted %s", digestHex[:12], base)
+		// namePrefix is a short placeholder on the import path, not always a digest.
+		logger.Debugf(ctx, "Layer %s: extracted %s", namePrefix[:min(len(namePrefix), 12)], base)
 	}
 	return kernelPath, initrdPath, nil
 }

--- a/images/oci/boot_test.go
+++ b/images/oci/boot_test.go
@@ -1,0 +1,74 @@
+package oci
+
+import (
+	"archive/tar"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Regression for #63: scanBootFiles must not panic on a sub-12-char namePrefix.
+func TestScanBootFilesNamePrefixLengths(t *testing.T) {
+	tests := []struct {
+		name       string
+		namePrefix string
+	}{
+		{"empty prefix", ""},
+		{"import placeholder under 12 chars", "import-0"},
+		{"exactly 12 chars", "twelve_chars"},
+		{"real sha256 hex", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tr := writeBootTar(t, "boot/vmlinuz-6.8.0", "boot/initrd.img-6.8.0")
+			kernel, initrd, err := scanBootFiles(t.Context(), tr, dir, tt.namePrefix)
+			if err != nil {
+				t.Fatalf("scanBootFiles: %v", err)
+			}
+			if want := filepath.Join(dir, tt.namePrefix+".vmlinuz"); kernel != want {
+				t.Errorf("kernel = %q, want %q", kernel, want)
+			}
+			if want := filepath.Join(dir, tt.namePrefix+".initrd.img"); initrd != want {
+				t.Errorf("initrd = %q, want %q", initrd, want)
+			}
+			for _, p := range []string{kernel, initrd} {
+				if _, statErr := os.Stat(p); statErr != nil {
+					t.Errorf("expected extracted file %s: %v", p, statErr)
+				}
+			}
+		})
+	}
+}
+
+func TestScanBootFilesSkipsNonBoot(t *testing.T) {
+	dir := t.TempDir()
+	tr := writeBootTar(t, "usr/bin/vmlinuz-decoy", "boot/vmlinuz-6.8.0.old", "etc/initrd.img")
+	kernel, initrd, err := scanBootFiles(t.Context(), tr, dir, "import-0")
+	if err != nil {
+		t.Fatalf("scanBootFiles: %v", err)
+	}
+	if kernel != "" || initrd != "" {
+		t.Errorf("expected no boot files extracted, got kernel=%q initrd=%q", kernel, initrd)
+	}
+}
+
+func writeBootTar(t *testing.T, paths ...string) *bytes.Reader {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for _, p := range paths {
+		body := []byte("payload:" + p)
+		if err := tw.WriteHeader(&tar.Header{Name: p, Typeflag: tar.TypeReg, Mode: 0o644, Size: int64(len(body))}); err != nil {
+			t.Fatalf("write header %s: %v", p, err)
+		}
+		if _, err := tw.Write(body); err != nil {
+			t.Fatalf("write body %s: %v", p, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	return bytes.NewReader(buf.Bytes())
+}


### PR DESCRIPTION
Closes #63.

## Problem

`cocoon image import` panics on any tar layer containing `/boot/vmlinuz*` or `/boot/initrd.img*`:

```
panic: runtime error: slice bounds out of range [:12] with length 8
  images/oci.scanBootFiles  boot.go:144
  images/oci.processTarReader import.go:145
```

`scanBootFiles` logged `digestHex[:12]`, assuming a 64-char sha256. But the import path (`import.go:145`) passes a short placeholder `fmt.Sprintf("import-%d", j.idx)` — the real layer digest isn't known until the stream is fully hashed, and `renameBootFiles` relabels the extracted files to the real digest afterward. `"import-0"` is 8 bytes → `[:12]` panics, but only once a layer actually carries a boot file (the extract-log is the first slice reached).

## Fix

- Rename the param `digestHex` → `namePrefix` to reflect its real contract: a filename prefix that is a digest on the heal path but a short placeholder on import.
- Bound the log slice with `min(len(namePrefix), 12)`.

Scope is correct: every other `[:12]` in `images/oci` (`import.go:166/176`, `process.go:47/88/94/97`, `boot.go:60`) operates on a real 64-char hash (`hex.EncodeToString(...)` / `digest.Hex()`) and cannot receive a short label — verified.

## Test

New `images/oci/boot_test.go`:
- `TestScanBootFilesNamePrefixLengths` — table over empty / 8-char / 12-char / 64-char prefixes; asserts no panic + correct `<prefix>.{vmlinuz,initrd.img}` extraction. Reverting the slice guard reproduces the exact `[:12] length 8` panic on the 8-char case.
- `TestScanBootFilesSkipsNonBoot` — confirms non-`boot/` dirs and `.old` suffixes are skipped.

## Test plan

- [x] `go test -race ./...` — 24/24 packages green
- [x] `make fmt-check && make lint` (darwin + linux) — 0 issues
- [x] AST layout audit — 0 violations
- [x] Verified the new test panics pre-fix, passes post-fix

## Follow-up (not in this PR)

The `[:12]` short-prefix idiom repeats ~11× across `images/oci` and `images/cloudimg` (all currently safe, fed real digests). A shared `utils.ShortHex(s)` would make the whole class panic-proof — worth a separate cleanup PR if desired.