### PR TITLE
feat(vm): add --cold clone and --vm-id for disk-only cold migration

### DIFF
--- a/cmd/vm/commands.go
+++ b/cmd/vm/commands.go
@@ -299,6 +299,8 @@ func addCloneFlags(cmd *cobra.Command) {
 	cmd.Flags().String("bridge", "", "use TAP-on-bridge instead of CNI (value is bridge device, e.g. cni0)")
 	cmd.Flags().Bool("no-direct-io", false, "disable O_DIRECT on writable disks (inherit from snapshot if not set)")
 	cmd.Flags().Bool("on-demand", false, "use UFFD on-demand memory loading for faster clone (CH only; snapshot file must remain on disk)")
+	cmd.Flags().Bool("cold", false, "clone the disk only and cold-boot the guest, discarding saved memory/vCPU state (CH only; survives hypervisor-version/CPUID changes that block warm restore)")
+	cmd.Flags().String("vm-id", "", "reuse this VM ID instead of generating one (preserves identity for controller re-adoption after a cold migration)")
 	cmd.Flags().Bool("pull", false, "auto-pull base image if not found locally (for cross-node clone)")
 	cmd.Flags().String("from-dir", "", "clone from a snapshot directory (must contain snapshot.json) instead of the local snapshot DB; mutually exclusive with positional SNAPSHOT")
 }

--- a/cmd/vm/run.go
+++ b/cmd/vm/run.go
@@ -299,11 +299,24 @@ func (h Handler) prepareClone(ctx context.Context, cmd *cobra.Command, conf *con
 		return nil, "", nil, types.NetSetup{}, err
 	}
 	vmID := utils.GenerateID()
+	// Reuse the source VM's ID to preserve identity across a cold migration, so
+	// the managing controller (e.g. vk-cocoon) re-adopts the clone by its stored
+	// VMID instead of treating it as an orphan.
+	if id, _ := cmd.Flags().GetString("vm-id"); id != "" {
+		vmID = id
+	}
 	if vmCfg.Name == "" {
 		vmCfg.Name = "cocoon-clone-" + network.VMIDPrefix(vmID)
 	}
 	if err = vmCfg.Validate(); err != nil {
 		return nil, "", nil, types.NetSetup{}, err
+	}
+
+	if cold, _ := cmd.Flags().GetBool("cold"); cold {
+		if conf.UseFirecracker {
+			return nil, "", nil, types.NetSetup{}, fmt.Errorf("--cold clone is Cloud Hypervisor only")
+		}
+		vmCfg.ColdBoot = true
 	}
 
 	if pull, _ := cmd.Flags().GetBool("pull"); pull && vmCfg.Image != "" && vmCfg.ImageType != "" {

--- a/hypervisor/cloudhypervisor/clone.go
+++ b/hypervisor/cloudhypervisor/clone.go
@@ -65,8 +65,6 @@ func (ch *CloudHypervisor) cloneAfterExtract(ctx context.Context, vmID string, v
 		return nil, fmt.Errorf("verify base files: %w", err)
 	}
 
-	stateReplacements := buildStateReplacements(chCfg, storageConfigs)
-
 	storageConfigs, err = ch.ensureCloneCidata(vmID, vmCfg, networkConfigs, storageConfigs, directBoot)
 	if err != nil {
 		return nil, err
@@ -75,6 +73,11 @@ func (ch *CloudHypervisor) cloneAfterExtract(ctx context.Context, vmID string, v
 		return nil, fmt.Errorf("validate post-cidata storage: %w", vErr)
 	}
 
+	if vmCfg.ColdBoot {
+		return ch.coldBootClone(ctx, vmID, vmCfg, net, runDir, logDir, now, bootCfg, storageConfigs, sourceSnapshotID)
+	}
+
+	stateReplacements := buildStateReplacements(chCfg, storageConfigs)
 	patchStorageConfigs := restorePatchStorageConfigs(storageConfigs, directBoot, vmCfg.Windows, hadCidataInSnapshot)
 
 	consoleSock := hypervisor.ConsoleSockPath(runDir)
@@ -138,6 +141,54 @@ func (ch *CloudHypervisor) cloneAfterExtract(ctx context.Context, vmID string, v
 	}
 
 	logger.Infof(ctx, "VM %s cloned from snapshot", vmID)
+	return info, nil
+}
+
+// coldBootClone boots a fresh VM from the cloned disk, discarding the snapshot's
+// saved CH state (state.json + memory ranges). The guest re-evaluates CPUID at
+// boot, so the clone survives hypervisor-version / CPUID changes that would fail
+// a warm vm.restore — at the cost of losing in-memory runtime state. The disk
+// (COW overlay) is a standard guest-owned image and stays valid across versions.
+func (ch *CloudHypervisor) coldBootClone(ctx context.Context, vmID string, vmCfg *types.VMConfig, net types.NetSetup, runDir, logDir string, now time.Time, bootCfg *types.BootConfig, storageConfigs []*types.StorageConfig, sourceSnapshotID string) (_ *types.VM, err error) {
+	logger := log.WithFunc("cloudhypervisor.coldBootClone")
+
+	rec := &hypervisor.VMRecord{
+		VM: types.VM{
+			ID: vmID, Hypervisor: typ, State: types.VMStateRunning,
+			Config: *vmCfg, StorageConfigs: storageConfigs, NetSetup: net,
+			// FirstBooted suppresses cidata re-attach for an already-provisioned
+			// disk (see activeDisks) and meters this as a restart, not a boot.
+			FirstBooted: true,
+		},
+		BootConfig: bootCfg,
+		RunDir:     runDir,
+		LogDir:     logDir,
+	}
+
+	// Clone reassigns NIC MACs and disk serials, so a kernel cmdline baked at
+	// snapshot time is stale; rebuild it for direct-boot guests.
+	if isDirectBoot(bootCfg) {
+		dns, dnsErr := ch.conf.DNSServers()
+		if dnsErr != nil {
+			return nil, fmt.Errorf("parse DNS servers: %w", dnsErr)
+		}
+		bootCfg.Cmdline = buildCmdline(storageConfigs, net.NetworkConfigs, vmCfg.Name, dns)
+	}
+
+	pid, err := ch.launchFresh(ctx, rec, hypervisor.SocketPath(runDir))
+	if err != nil {
+		ch.MarkError(ctx, vmID)
+		return nil, fmt.Errorf("launch CH: %w", err)
+	}
+
+	info := &rec.VM
+	info.CreatedAt, info.UpdatedAt, info.StartedAt = now, now, &now
+	if err = ch.FinalizeClone(ctx, vmID, info, bootCfg, nil, sourceSnapshotID); err != nil {
+		ch.AbortLaunch(ctx, pid, hypervisor.SocketPath(runDir), runDir, runtimeFiles)
+		return nil, fmt.Errorf("finalize VM record: %w", err)
+	}
+
+	logger.Infof(ctx, "VM %s cold-cloned from snapshot (disk only)", vmID)
 	return info, nil
 }
 

--- a/hypervisor/cloudhypervisor/start.go
+++ b/hypervisor/cloudhypervisor/start.go
@@ -19,12 +19,18 @@ func (ch *CloudHypervisor) startOne(ctx context.Context, id string) (bool, error
 	return ch.StartSequence(ctx, id, hypervisor.StartSpec{
 		RuntimeFiles: runtimeFiles,
 		Launch: func(ctx context.Context, rec *hypervisor.VMRecord, sockPath string) (int, error) {
-			vmCfg := buildVMConfig(ctx, rec, hypervisor.ConsoleSockPath(rec.RunDir))
-			args := buildCLIArgs(vmCfg, sockPath)
-			ch.saveCmdline(ctx, rec, args)
-			return ch.launchProcess(ctx, rec, sockPath, args, rec.ResolvedNetnsPath())
+			return ch.launchFresh(ctx, rec, sockPath)
 		},
 	})
+}
+
+// launchFresh cold-boots a VM from its record: builds the CH config from the
+// record, persists the cmdline, and starts the process. Shared by normal start
+// and cold clone — both boot from disk with no saved CH state to restore.
+func (ch *CloudHypervisor) launchFresh(ctx context.Context, rec *hypervisor.VMRecord, sockPath string) (int, error) {
+	args := buildCLIArgs(buildVMConfig(ctx, rec, hypervisor.ConsoleSockPath(rec.RunDir)), sockPath)
+	ch.saveCmdline(ctx, rec, args)
+	return ch.launchProcess(ctx, rec, sockPath, args, rec.ResolvedNetnsPath())
 }
 
 func (ch *CloudHypervisor) launchProcess(ctx context.Context, rec *hypervisor.VMRecord, socketPath string, args []string, netnsPath string) (int, error) {

--- a/types/vm.go
+++ b/types/vm.go
@@ -31,6 +31,7 @@ type VMConfig struct {
 	Name string `json:"name"`
 
 	OnDemand  bool           `json:"-"` // use UFFD on-demand memory restore (CH only); transient, not persisted
+	ColdBoot  bool           `json:"-"` // clone disk only and cold-boot, discarding saved memory/vCPU state; transient
 	User      string         `json:"-"`
 	Password  string         `json:"-"`
 	DataDisks []DataDiskSpec `json:"-"` // populated from --data-disk; consumed by Create


### PR DESCRIPTION
## What

Adds two flags to `cocoon vm clone`:

- `--cold` — boot a fresh VM from the snapshot's **disk only**, discarding the saved CH state (`state.json` + memory ranges). Equivalent to a cold reboot of the snapshot's disk rather than a warm resume.
- `--vm-id <id>` — reuse a specific VM ID instead of generating one, so a managing controller re-adopts the clone instead of treating it as an orphan.

## Why `--cold`

Today `cocoon vm clone` always does a warm `vm.restore` (memory + vCPU state). That has two problems for migration / maintenance:

1. **It breaks across hypervisor changes.** The saved vCPU state includes the CPUID layout captured at snapshot time. Restoring it on a cloud-hypervisor build with different CPUID (a version bump, or — in our case — a Hyper-V enlightenment fix) fails `CpuidCheckCompatibility`:

   ```
   vm.restore → 500: Error checking cpu feature compatibility: CpuidCheckCompatibility
   ```

   The COW disk overlay, by contrast, is a standard guest-owned qcow2 — it is **not** coupled to the hypervisor version. Only the memory/vCPU dump is.

2. **Even when restore succeeds, the guest never re-evaluates hardware.** A Windows guest that decided at boot time not to use a given enlightenment keeps that decision frozen in the restored memory image. A cold boot makes it re-read CPUID and re-negotiate.

`--cold` keeps the disk (all user data, installed software, filesystem state) and throws away only the in-memory runtime state. The guest cold-boots, re-evaluates CPUID, and comes up on whatever the current hypervisor advertises. This is the right primitive for:

- migrating a VM onto a host running an **incompatible cloud-hypervisor build**, and
- rolling out a CPUID-affecting hypervisor change while preserving user disk data.

The trade-off is explicit: in-memory state (open sessions, unsaved work, running processes) is lost — the guest restarts. Disk survives.

## Why `--vm-id`

A cold clone produces a *new* VM with a *new* generated ID. When the VM is managed by a controller that keys on VM identity (vk-cocoon adopts a pod's VM by its stored VMID, and `OrphanPolicy` defaults to `OrphanDestroy`), a fresh ID means the controller does not recognise the clone — it treats it as an orphan and may destroy it, then re-clones from the base image.

`--vm-id <old-id>` makes the clone inherit the source VM's identity, so the controller's stored VMID still matches and it re-adopts the migrated VM in place. `ReserveVM` rejects the ID if a VM with it still exists, so the old VM must be removed first (the migration ordering enforces this).

## How they combine — cold migration for a maintenance / hypervisor-upgrade window

With downtime (controller paused, no reconcile races):

```bash
# 1. stop the controller's reconcile + swap the hypervisor binary
systemctl stop vk-cocoon
install -m755 cloud-hypervisor-new /usr/local/bin/cloud-hypervisor

# 2. per VM: snapshot the live disk, remove it, cold-clone with the SAME id + name
cocoon snapshot save  <OLD_ID> --tag migrate-<OLD_ID>
cocoon vm rm --force  <OLD_ID>
cocoon vm clone --cold --vm-id <OLD_ID> --name <OLD_NAME> --network <net> migrate-<OLD_ID>

# 3. resume the controller — it re-adopts each VM by its unchanged VMID
systemctl start vk-cocoon
```

Result: user disk data preserved, guest cold-booted on the new hypervisor (re-evaluates CPUID), controller re-adopts the VM in place. Memory state is intentionally lost.

## Implementation notes

- Threaded via a transient `VMConfig.ColdBoot` flag, mirroring the existing `OnDemand` pattern (`json:"-"`, set in `prepareClone`, read in the CH backend). Not persisted.
- Gated to Cloud Hypervisor at the CLI boundary (Firecracker returns an error).
- The cold path branches inside `cloneAfterExtract` after all shared snapshot-extraction / disk-path-rewrite / cidata prep; it skips `state.json` patching and `vm.restore`/`vm.resume`, and instead cold-boots via the existing start primitive. That primitive (`buildVMConfig → buildCLIArgs → launchProcess`) was extracted from `startOne` into a shared `launchFresh` method.
- `FirstBooted: true` on the cold-boot record suppresses cidata re-attach for the already-provisioned disk (via `activeDisks`) and meters the event as a restart — both correct for a cold reboot of an existing disk.
- Guest classes handled: Windows (firmware boot, no cidata), OCI direct-boot (kernel cmdline rebuilt for the new MACs/serials), cloudimg-UEFI (cidata suppressed post-first-boot, matching normal restart semantics).

## Testing

`make lint` clean on linux + darwin. End-to-end cold-migration validation (snapshot → cold-clone same-id → controller re-adopt → verify disk data + guest comes up on new hypervisor) pending on a maintenance VM.
