### PR TITLE
refactor: clean MED+LOW findings from whole-project /code audit (zero-regression verified)

### DIFF
--- a/cmd/core/helpers.go
+++ b/cmd/core/helpers.go
@@ -130,7 +130,7 @@ func InitAllHypervisors(ctx context.Context, conf *config.Config) ([]hypervisor.
 	for _, f := range hypervisorFactories {
 		h, err := f.ctor(ctx, conf)
 		if err != nil {
-			return nil, fmt.Errorf("init %s for GC: %w", f.typ, err)
+			return nil, fmt.Errorf("init hypervisor %s: %w", f.typ, err)
 		}
 		result = append(result, h)
 	}

--- a/cmd/core/helpers.go
+++ b/cmd/core/helpers.go
@@ -228,7 +228,6 @@ func EnsureImage(ctx context.Context, backends []imagebackend.Images, vmCfg *typ
 	}
 	logger := log.WithFunc("core.EnsureImage")
 
-	// Use digest for lookup when available; fall back to tag/URL.
 	lookupRef := cmp.Or(vmCfg.ImageDigest, vmCfg.Image)
 
 	for _, b := range backends {

--- a/cmd/images/handler.go
+++ b/cmd/images/handler.go
@@ -2,7 +2,6 @@ package images
 
 import cmdcore "github.com/cocoonstack/cocoon/cmd/core"
 
-// imageType identifies the content type detected from a stream.
 type imageType int
 
 type importSourceKind int

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -198,8 +198,6 @@ func (h Handler) RM(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	logger := log.WithFunc("cmd.vm.rm")
-
 	force, _ := cmd.Flags().GetBool("force")
 
 	hypers, err := cmdcore.InitAllHypervisors(ctx, conf)
@@ -211,21 +209,11 @@ func (h Handler) RM(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	wantJSON := cmdcore.WantJSON(cmd)
-	var allDeleted []string
-	var lastErr error
-	for hyper, refs := range routed {
-		deleted, deleteErr := hyper.Delete(ctx, refs, force)
-		if !wantJSON {
-			for _, id := range deleted {
-				logger.Infof(ctx, "deleted VM: %s", id)
-			}
-		}
-		allDeleted = append(allDeleted, deleted...)
-		if deleteErr != nil {
-			lastErr = deleteErr
-		}
-	}
+	const logTag = "cmd.vm.rm"
+	allDeleted, lastErr := runRoutedLoop(ctx, logTag, "deleted", cmdcore.WantJSON(cmd), routed,
+		func(hyper hypervisor.Hypervisor, refs []string) ([]string, error) {
+			return hyper.Delete(ctx, refs, force)
+		})
 
 	if len(allDeleted) > 0 {
 		if netProvider, initErr := cmdcore.InitNetwork(conf); initErr == nil {
@@ -236,16 +224,7 @@ func (h Handler) RM(cmd *cobra.Command, args []string) error {
 		bridgenet.CleanupTAPs(allDeleted)
 	}
 
-	if lastErr != nil {
-		return fmt.Errorf("rm: %w", lastErr)
-	}
-	if done, jsonErr := cmdcore.MaybeOutputJSON(cmd, map[string][]string{"succeeded": allDeleted}); done {
-		return jsonErr
-	}
-	if len(allDeleted) == 0 {
-		logger.Info(ctx, "no VMs deleted")
-	}
-	return nil
+	return finishRoutedCmd(ctx, cmd, logTag, "rm", "deleted", allDeleted, lastErr)
 }
 
 func (h Handler) recoverNetwork(ctx context.Context, conf *config.Config, hyper hypervisor.Hypervisor, refs []string) {
@@ -331,11 +310,9 @@ func providerForVM(conf *config.Config, cniProvider network.Network, bridgeCache
 	return cmdcore.InitNetwork(conf)
 }
 
-func batchRoutedCmd(ctx context.Context, cmd *cobra.Command, name, pastTense string, routed map[hypervisor.Hypervisor][]string, fn func(hypervisor.Hypervisor, []string) ([]string, error)) error {
-	logger := log.WithFunc("cmd." + name)
-	wantJSON := cmdcore.WantJSON(cmd)
-	var allDone []string
-	var lastErr error
+// runRoutedLoop runs fn per routed hypervisor, logging each success under logTag (unless JSON), and returns all done ids plus the last error.
+func runRoutedLoop(ctx context.Context, logTag, pastTense string, wantJSON bool, routed map[hypervisor.Hypervisor][]string, fn func(hypervisor.Hypervisor, []string) ([]string, error)) (allDone []string, lastErr error) {
+	logger := log.WithFunc(logTag)
 	for hyper, refs := range routed {
 		done, err := fn(hyper, refs)
 		if !wantJSON {
@@ -348,6 +325,11 @@ func batchRoutedCmd(ctx context.Context, cmd *cobra.Command, name, pastTense str
 			lastErr = err
 		}
 	}
+	return allDone, lastErr
+}
+
+// finishRoutedCmd is the shared tail for routed batch commands: wrap lastErr, emit JSON, or log the empty-case message.
+func finishRoutedCmd(ctx context.Context, cmd *cobra.Command, logTag, name, pastTense string, allDone []string, lastErr error) error {
 	if lastErr != nil {
 		return fmt.Errorf("%s: %w", name, lastErr)
 	}
@@ -355,9 +337,15 @@ func batchRoutedCmd(ctx context.Context, cmd *cobra.Command, name, pastTense str
 		return jsonErr
 	}
 	if len(allDone) == 0 {
-		logger.Infof(ctx, "no VMs %s", pastTense)
+		log.WithFunc(logTag).Infof(ctx, "no VMs %s", pastTense)
 	}
 	return nil
+}
+
+func batchRoutedCmd(ctx context.Context, cmd *cobra.Command, name, pastTense string, routed map[hypervisor.Hypervisor][]string, fn func(hypervisor.Hypervisor, []string) ([]string, error)) error {
+	logTag := "cmd." + name
+	allDone, lastErr := runRoutedLoop(ctx, logTag, pastTense, cmdcore.WantJSON(cmd), routed, fn)
+	return finishRoutedCmd(ctx, cmd, logTag, name, pastTense, allDone, lastErr)
 }
 
 // collectAttachedDevices reads fs/vfio devices; errors are logged and dropped so inspect tolerates a flaky vm.info.

--- a/config/metering.go
+++ b/config/metering.go
@@ -22,6 +22,7 @@ type FileMeteringConfig struct {
 	Path string `json:"path,omitempty" mapstructure:"path"`
 }
 
+// Validate rejects an unknown metering backend at startup.
 func (m MeteringConfig) Validate() error {
 	switch m.Backend {
 	case "", MeteringFile, MeteringNop, MeteringStderr:

--- a/console/relay.go
+++ b/console/relay.go
@@ -35,6 +35,7 @@ func Relay(rw io.ReadWriter, escapeKeys []byte) error {
 	return err
 }
 
+// FormatEscapeChar renders a control byte as caret notation (e.g. ^] for 0x1D).
 func FormatEscapeChar(b byte) string {
 	if b >= 1 && b <= 0x1F {
 		return "^" + string(rune(b+'@'))

--- a/gc/orchestrator.go
+++ b/gc/orchestrator.go
@@ -73,20 +73,18 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 
 	var errs []error
 	summary := make(map[string]int, len(locked))
-	failures := 0
 	for _, m := range locked {
 		ids := targets[m.getName()]
 		if len(ids) == 0 {
 			continue
 		}
 		if err := m.collect(ctx, ids, snapshots[m.getName()]); err != nil {
-			failures++
 			errs = append(errs, fmt.Errorf("gc %s: %w", m.getName(), err))
 		}
 		summary[m.getName()] = len(ids)
 	}
 	logger.Infof(ctx, "completed: %s (failures: %d, duration: %s)",
-		formatSummary(summary), failures, time.Since(start).Truncate(time.Millisecond))
+		formatSummary(summary), len(errs), time.Since(start).Truncate(time.Millisecond))
 	return errors.Join(errs...)
 }
 

--- a/hypervisor/firecracker/direct.go
+++ b/hypervisor/firecracker/direct.go
@@ -20,17 +20,11 @@ func (fc *Firecracker) DirectRestore(ctx context.Context, vmRef string, vmCfg *t
 		SourceSnapshotID: sourceSnapshotID,
 		Preflight:        fc.preflightRestore,
 		Kill:             fc.killForRestore,
-		// Lock writable disks so recoverStaleBackup heals stale data-*.raw.cocoon-clone-backup
-		// before restore overwrites them; otherwise a future clone renames backup over restored data.
-		Wrap: func(rec *hypervisor.VMRecord, inner func() error) error {
-			return withSourceWritableDisksLocked(rec.StorageConfigs, inner)
-		},
+		Wrap:             fc.wrapSourceLocked,
 		Populate: func(rec *hypervisor.VMRecord, srcDir string) error {
 			return hypervisor.PopulateFromSrc(rec.RunDir, srcDir, cleanSnapshotFiles, cloneSnapshotFiles)
 		},
-		AfterExtract: func(ctx context.Context, vmID string, vmCfg *types.VMConfig, rec *hypervisor.VMRecord) (*types.VM, error) {
-			return fc.restoreAfterExtract(ctx, vmID, vmCfg, rec, fc.conf.COWRawPath(vmID))
-		},
+		AfterExtract: fc.restoreAfterExtractCOW,
 	})
 }
 

--- a/hypervisor/firecracker/relay.go
+++ b/hypervisor/firecracker/relay.go
@@ -82,7 +82,7 @@ func RunRelay(ctx context.Context) {
 	pidStr := os.Getenv(relayPIDEnvKey)
 	fcPID, pidErr := strconv.Atoi(pidStr)
 	if pidErr != nil || fcPID <= 0 {
-		log.WithFunc("firecracker.runRelay").Warnf(ctx, "invalid FC PID %q, skipping relay", pidStr)
+		log.WithFunc("firecracker.RunRelay").Warnf(ctx, "invalid FC PID %q, skipping relay", pidStr)
 		return
 	}
 

--- a/hypervisor/firecracker/restore.go
+++ b/hypervisor/firecracker/restore.go
@@ -21,19 +21,23 @@ func (fc *Firecracker) Restore(ctx context.Context, vmRef string, vmCfg *types.V
 		SourceSnapshotID: sourceSnapshotID,
 		Preflight:        fc.preflightRestore,
 		Kill:             fc.killForRestore,
-		// Lock writable disks so recoverStaleBackup heals stale data-*.raw.cocoon-clone-backup
-		// before restore overwrites them; otherwise a future clone renames backup over restored data.
-		Wrap: func(rec *hypervisor.VMRecord, inner func() error) error {
-			return withSourceWritableDisksLocked(rec.StorageConfigs, inner)
-		},
+		Wrap:             fc.wrapSourceLocked,
 		BeforeMerge: func(rec *hypervisor.VMRecord) error {
 			_ = os.Remove(filepath.Join(rec.RunDir, cowFileName))
 			return nil
 		},
-		AfterExtract: func(ctx context.Context, vmID string, vmCfg *types.VMConfig, rec *hypervisor.VMRecord) (*types.VM, error) {
-			return fc.restoreAfterExtract(ctx, vmID, vmCfg, rec, fc.conf.COWRawPath(vmID))
-		},
+		AfterExtract: fc.restoreAfterExtractCOW,
 	})
+}
+
+// wrapSourceLocked holds the source writable-disk locks across inner so recoverStaleBackup heals stale data-*.raw.cocoon-clone-backup before restore overwrites them; otherwise a future clone renames backup over restored data.
+func (fc *Firecracker) wrapSourceLocked(rec *hypervisor.VMRecord, inner func() error) error {
+	return withSourceWritableDisksLocked(rec.StorageConfigs, inner)
+}
+
+// restoreAfterExtractCOW adapts restoreAfterExtract to the RestoreSpec/DirectRestoreSpec AfterExtract signature using the VM's default COW path.
+func (fc *Firecracker) restoreAfterExtractCOW(ctx context.Context, vmID string, vmCfg *types.VMConfig, rec *hypervisor.VMRecord) (*types.VM, error) {
+	return fc.restoreAfterExtract(ctx, vmID, vmCfg, rec, fc.conf.COWRawPath(vmID))
 }
 
 func (fc *Firecracker) killForRestore(ctx context.Context, vmID string, rec *hypervisor.VMRecord) error {

--- a/hypervisor/inspect.go
+++ b/hypervisor/inspect.go
@@ -46,13 +46,13 @@ func (b *Backend) List(ctx context.Context) ([]*types.VM, error) {
 }
 
 func (b *Backend) ToVM(rec *VMRecord) *types.VM {
-	info := rec.VM // value copy
+	info := rec.VM
 	info.Hypervisor = b.Typ
 	if info.State == types.VMStateRunning {
 		info.SocketPath = SocketPath(rec.RunDir)
 		info.PID, _ = utils.ReadPIDFile(b.PIDFilePath(rec.RunDir))
 		// Empty for legacy VMs whose UDS isn't bound.
-		if p := VsockSockPath(rec.RunDir); vsockBound(p) {
+		if p := VsockSockPath(rec.RunDir); isVsockBound(p) {
 			info.VsockSocket = p
 		}
 	}
@@ -106,7 +106,7 @@ func (b *Backend) ResolveAndLoad(ctx context.Context, ref string) (string, VMRec
 	})
 }
 
-func vsockBound(path string) bool {
+func isVsockBound(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
 }

--- a/hypervisor/utils.go
+++ b/hypervisor/utils.go
@@ -382,7 +382,6 @@ func CloneSnapshotFiles(dstDir, srcDir string, classify func(name string) Snapsh
 				return fmt.Errorf("copy %s: %w", name, err)
 			}
 		case SnapshotFileSkip:
-			// do nothing
 		}
 	}
 	return nil

--- a/images/cloudimg/pull.go
+++ b/images/cloudimg/pull.go
@@ -25,7 +25,7 @@ const (
 	// maxDownloadBytes is the maximum allowed download size (20 GiB).
 	maxDownloadBytes int64 = 20 << 30
 
-	// report every 1 MiB
+	// progressInterval is how often download progress is reported (1 MiB).
 	progressInterval = 1 << 20
 )
 
@@ -114,7 +114,7 @@ func withDownload(
 func downloadToFile(ctx context.Context, url string, dst *os.File, tracker progress.Tracker) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return "", fmt.Errorf("create HTTP request: %w", err)
+		return "", fmt.Errorf("create http request: %w", err)
 	}
 
 	client := &http.Client{Timeout: urlDownloadTimeout}

--- a/images/oci/commit.go
+++ b/images/oci/commit.go
@@ -90,18 +90,18 @@ func commitAndRecord(conf *Config, idx *imageIndex, ref string, manifestDigest i
 	for _, le := range layerEntries {
 		size, err := validFileSize(conf.BlobPath(le.Digest.Hex()))
 		if err != nil {
-			return fmt.Errorf("blob missing for layer %s (concurrent GC?)", le.Digest)
+			return fmt.Errorf("blob missing for layer %s (concurrent GC?): %w", le.Digest, err)
 		}
 		totalSize += size
 	}
 	size, err := validFileSize(conf.KernelPath(kernelLayer.Hex()))
 	if err != nil {
-		return fmt.Errorf("kernel missing for %s (concurrent GC?)", kernelLayer)
+		return fmt.Errorf("kernel missing for %s (concurrent GC?): %w", kernelLayer, err)
 	}
 	totalSize += size
 	size, err = validFileSize(conf.InitrdPath(initrdLayer.Hex()))
 	if err != nil {
-		return fmt.Errorf("initrd missing for %s (concurrent GC?)", initrdLayer)
+		return fmt.Errorf("initrd missing for %s (concurrent GC?): %w", initrdLayer, err)
 	}
 	totalSize += size
 

--- a/images/oci/erofs.go
+++ b/images/oci/erofs.go
@@ -39,3 +39,30 @@ func startErofsConversion(ctx context.Context, uuid, outputPath string) (cmd *ex
 	}
 	return cmd, stdin, output, nil
 }
+
+// runErofsConversion streams src into mkfs.erofs at outPath while scanning for boot files under scanDir.
+// The scan→drain→close→wait order is load-bearing: mkfs.erofs (and any hasher upstream of src) must
+// see the full stream before Wait, and stdin must close before Wait or mkfs.erofs blocks.
+func runErofsConversion(ctx context.Context, src io.Reader, scanDir, namePrefix, uuid, outPath string) (kernelPath, initrdPath string, err error) {
+	cmd, stdin, output, err := startErofsConversion(ctx, uuid, outPath)
+	if err != nil {
+		return "", "", fmt.Errorf("start erofs conversion: %w", err)
+	}
+
+	tee := io.TeeReader(src, stdin)
+	kernelPath, initrdPath, scanErr := scanBootFiles(ctx, tee, scanDir, namePrefix)
+	if scanErr == nil {
+		if _, drainErr := io.Copy(io.Discard, tee); drainErr != nil {
+			scanErr = fmt.Errorf("drain layer stream: %w", drainErr)
+		}
+	}
+	_ = stdin.Close()
+
+	if waitErr := cmd.Wait(); waitErr != nil {
+		return "", "", fmt.Errorf("mkfs.erofs failed: %w (output: %s)", waitErr, output.String())
+	}
+	if scanErr != nil {
+		return "", "", fmt.Errorf("scan boot files: %w", scanErr)
+	}
+	return kernelPath, initrdPath, nil
+}

--- a/images/oci/import.go
+++ b/images/oci/import.go
@@ -135,28 +135,9 @@ func processTarReader(ctx context.Context, j tarImportJob, r io.Reader) error {
 	tmpErofsPath := filepath.Join(layerDir, fmt.Sprintf("layer-%d.erofs", j.idx))
 	tmpUUID := utils.UUIDv5(fmt.Sprintf("import-%s-%d", j.label, j.idx))
 
-	cmd, erofsStdin, output, err := startErofsConversion(ctx, tmpUUID, tmpErofsPath)
+	kernelPath, initrdPath, err := runErofsConversion(ctx, teeForHash, layerDir, fmt.Sprintf("import-%d", j.idx), tmpUUID, tmpErofsPath)
 	if err != nil {
-		return fmt.Errorf("start erofs conversion: %w", err)
-	}
-
-	teeForErofs := io.TeeReader(teeForHash, erofsStdin)
-
-	kernelPath, initrdPath, scanErr := scanBootFiles(ctx, teeForErofs, layerDir, fmt.Sprintf("import-%d", j.idx))
-
-	// Drain the rest so the hasher and mkfs.erofs see the full stream.
-	if scanErr == nil {
-		if _, drainErr := io.Copy(io.Discard, teeForErofs); drainErr != nil {
-			scanErr = fmt.Errorf("drain tar stream: %w", drainErr)
-		}
-	}
-	_ = erofsStdin.Close()
-
-	if waitErr := cmd.Wait(); waitErr != nil {
-		return fmt.Errorf("mkfs.erofs failed: %w (output: %s)", waitErr, output.String())
-	}
-	if scanErr != nil {
-		return fmt.Errorf("scan boot files: %w", scanErr)
+		return err
 	}
 
 	digestHex := hex.EncodeToString(hasher.Sum(nil))

--- a/images/oci/process.go
+++ b/images/oci/process.go
@@ -3,7 +3,6 @@ package oci
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 
@@ -60,26 +59,9 @@ func processLayer(ctx context.Context, j layerJob) error {
 	erofsPath := filepath.Join(layerDir, digestHex+".erofs")
 	layerUUID := utils.UUIDv5(digestHex)
 
-	cmd, erofsStdin, output, err := startErofsConversion(ctx, layerUUID, erofsPath)
+	kernelPath, initrdPath, err := runErofsConversion(ctx, rc, layerDir, digestHex, layerUUID, erofsPath)
 	if err != nil {
-		return fmt.Errorf("start erofs conversion: %w", err)
-	}
-
-	tee := io.TeeReader(rc, erofsStdin)
-	kernelPath, initrdPath, scanErr := scanBootFiles(ctx, tee, layerDir, digestHex)
-
-	if scanErr == nil {
-		if _, drainErr := io.Copy(io.Discard, tee); drainErr != nil {
-			scanErr = fmt.Errorf("drain layer stream: %w", drainErr)
-		}
-	}
-	_ = erofsStdin.Close()
-
-	if waitErr := cmd.Wait(); waitErr != nil {
-		return fmt.Errorf("mkfs.erofs failed: %w (output: %s)", waitErr, output.String())
-	}
-	if scanErr != nil {
-		return fmt.Errorf("scan boot files: %w", scanErr)
+		return err
 	}
 
 	j.result.kernelPath = kernelPath

--- a/metadata/fat12.go
+++ b/metadata/fat12.go
@@ -221,13 +221,7 @@ func setFATEntry(fat []byte, cluster int, val uint16) {
 // needsLFN reports whether name requires VFAT long-filename entries.
 func needsLFN(name string) bool {
 	upper := strings.ToUpper(name)
-	var base, ext string
-	if dot := strings.LastIndex(upper, "."); dot >= 0 {
-		base = upper[:dot]
-		ext = upper[dot+1:]
-	} else {
-		base = upper
-	}
+	base, ext := splitName(upper)
 	return len(base) > 8 || len(ext) > 3 || name != upper || strings.Count(name, ".") > 1 //nolint:mnd
 }
 
@@ -240,16 +234,20 @@ func blankSFN() [11]byte {
 	return b
 }
 
+// splitName splits an uppercased name into base and extension at the last dot; ext is "" when there is no dot.
+func splitName(upper string) (base, ext string) {
+	if dot := strings.LastIndex(upper, "."); dot >= 0 {
+		return upper[:dot], upper[dot+1:]
+	}
+	return upper, ""
+}
+
 // toShortName pads a simple name (already fits 8.3, uppercase) into an 11-byte SFN.
 func toShortName(name string) [11]byte {
 	result := blankSFN()
-	upper := strings.ToUpper(name)
-	if dot := strings.LastIndex(upper, "."); dot >= 0 {
-		copy(result[:8], upper[:dot])   //nolint:mnd
-		copy(result[8:], upper[dot+1:]) //nolint:mnd
-	} else {
-		copy(result[:8], upper) //nolint:mnd
-	}
+	base, ext := splitName(strings.ToUpper(name))
+	copy(result[:8], base) //nolint:mnd
+	copy(result[8:], ext)  //nolint:mnd
 	return result
 }
 
@@ -257,14 +255,8 @@ func toShortName(name string) [11]byte {
 func generateShortName(name string, seq int) [11]byte {
 	result := blankSFN()
 
-	upper := strings.ToUpper(name)
-	var base, ext string
-	if dot := strings.LastIndex(upper, "."); dot >= 0 {
-		base = strings.ReplaceAll(upper[:dot], ".", "")
-		ext = upper[dot+1:]
-	} else {
-		base = upper
-	}
+	base, ext := splitName(strings.ToUpper(name))
+	base = strings.ReplaceAll(base, ".", "")
 
 	tail := fmt.Sprintf("~%d", seq)
 	maxBase := 8 - len(tail) //nolint:mnd

--- a/metadata/fat12.go
+++ b/metadata/fat12.go
@@ -231,12 +231,18 @@ func needsLFN(name string) bool {
 	return len(base) > 8 || len(ext) > 3 || name != upper || strings.Count(name, ".") > 1 //nolint:mnd
 }
 
+// blankSFN returns an 11-byte SFN buffer space-padded per the FAT 8.3 layout.
+func blankSFN() [11]byte {
+	var b [11]byte
+	for i := range b {
+		b[i] = ' '
+	}
+	return b
+}
+
 // toShortName pads a simple name (already fits 8.3, uppercase) into an 11-byte SFN.
 func toShortName(name string) [11]byte {
-	var result [11]byte
-	for i := range result {
-		result[i] = ' '
-	}
+	result := blankSFN()
 	upper := strings.ToUpper(name)
 	if dot := strings.LastIndex(upper, "."); dot >= 0 {
 		copy(result[:8], upper[:dot])   //nolint:mnd
@@ -249,10 +255,7 @@ func toShortName(name string) [11]byte {
 
 // generateShortName builds an 8.3 name with numeric tail (e.g. "META-D~1   ").
 func generateShortName(name string, seq int) [11]byte {
-	var result [11]byte
-	for i := range result {
-		result[i] = ' '
-	}
+	result := blankSFN()
 
 	upper := strings.ToUpper(name)
 	var base, ext string
@@ -331,10 +334,7 @@ func lfnChecksum(shortName [11]byte) byte {
 }
 
 func padLabel(label string) [11]byte {
-	var result [11]byte
-	for i := range result {
-		result[i] = ' '
-	}
+	result := blankSFN()
 	copy(result[:], strings.ToUpper(label))
 	return result
 }

--- a/metering/capture/capture.go
+++ b/metering/capture/capture.go
@@ -3,6 +3,7 @@ package capture
 
 import (
 	"context"
+	"slices"
 	"sync"
 
 	"github.com/cocoonstack/cocoon/metering"
@@ -27,9 +28,7 @@ func (r *Recorder) Emit(_ context.Context, e metering.Entry) {
 func (r *Recorder) Entries() []metering.Entry {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	out := make([]metering.Entry, len(r.entries))
-	copy(out, r.entries)
-	return out
+	return slices.Clone(r.entries)
 }
 
 func (r *Recorder) Reset() {

--- a/network/bridge/bridge_linux.go
+++ b/network/bridge/bridge_linux.go
@@ -91,8 +91,8 @@ func (b *Bridge) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, sp
 			mac = spec.Existing.MAC
 		}
 		queues := network.NetNumQueues(vmCfg.CPU)
-		if cErr := createTAP(name, queues); cErr != nil {
-			return nil, fmt.Errorf("create tap %s: %w", name, cErr)
+		if cErr := network.CreateTAP(name, queues); cErr != nil {
+			return nil, cErr
 		}
 		added = append(added, spec.Index)
 
@@ -184,30 +184,6 @@ func tearDownTAPs(vmID string, indices []int, bestEffort bool) error {
 			}
 			return fmt.Errorf("delete tap %s: %w", name, err)
 		}
-	}
-	return nil
-}
-
-func createTAP(name string, numQueues int) error {
-	// queue_pairs = num_queues / 2 (TX+RX); multi-queue needs >1, and IFF_MULTI_QUEUE must match CH's expectation.
-	queuePairs := max(1, numQueues/2) //nolint:mnd
-	flags := netlink.TUNTAP_VNET_HDR | netlink.TUNTAP_NO_PI
-	if queuePairs <= 1 {
-		flags |= netlink.TUNTAP_ONE_QUEUE
-	} else {
-		flags |= netlink.TUNTAP_MULTI_QUEUE_DEFAULTS
-	}
-	tap := &netlink.Tuntap{
-		LinkAttrs: netlink.LinkAttrs{Name: name},
-		Mode:      netlink.TUNTAP_MODE_TAP,
-		Queues:    queuePairs,
-		Flags:     flags,
-	}
-	if err := netlink.LinkAdd(tap); err != nil {
-		return err
-	}
-	for _, fd := range tap.Fds {
-		_ = fd.Close()
 	}
 	return nil
 }

--- a/network/cni/lifecycle_linux.go
+++ b/network/cni/lifecycle_linux.go
@@ -106,26 +106,8 @@ func tcRedirectInNS(ifName, tapName string, queues int, overrideMAC string) (str
 		}
 	}
 
-	// queue_pairs = num_queues / 2 (TX+RX pair per queue).
-	// Multi-queue requires queue_pairs > 1.
-	queuePairs := max(1, queues/2) //nolint:mnd
-	flags := netlink.TUNTAP_VNET_HDR | netlink.TUNTAP_NO_PI
-	if queuePairs <= 1 {
-		flags |= netlink.TUNTAP_ONE_QUEUE
-	} else {
-		flags |= netlink.TUNTAP_MULTI_QUEUE_DEFAULTS
-	}
-	tap := &netlink.Tuntap{
-		LinkAttrs: netlink.LinkAttrs{Name: tapName},
-		Mode:      netlink.TUNTAP_MODE_TAP,
-		Queues:    queuePairs,
-		Flags:     flags,
-	}
-	if addErr := netlink.LinkAdd(tap); addErr != nil {
-		return "", fmt.Errorf("add tap %s: %w", tapName, addErr)
-	}
-	for _, fd := range tap.Fds {
-		_ = fd.Close()
+	if tapErr := network.CreateTAP(tapName, queues); tapErr != nil {
+		return "", tapErr
 	}
 	tapLink, err := netlink.LinkByName(tapName)
 	if err != nil {

--- a/network/tap_linux.go
+++ b/network/tap_linux.go
@@ -3,6 +3,8 @@
 package network
 
 import (
+	"fmt"
+
 	"github.com/vishvananda/netlink"
 )
 
@@ -15,6 +17,31 @@ const (
 	// the kernel to aggregate inbound packets before CH reads them.
 	groMaxSize = 65536
 )
+
+// CreateTAP adds a multi-queue TAP sized for numQueues virtio-net queues, then closes the kernel fds (CH/QEMU reopen it by name).
+func CreateTAP(name string, numQueues int) error {
+	// queue_pairs = num_queues / 2 (TX+RX pair); multi-queue needs >1 and must match the VMM's IFF_MULTI_QUEUE expectation.
+	queuePairs := max(1, numQueues/2) //nolint:mnd
+	flags := netlink.TUNTAP_VNET_HDR | netlink.TUNTAP_NO_PI
+	if queuePairs <= 1 {
+		flags |= netlink.TUNTAP_ONE_QUEUE
+	} else {
+		flags |= netlink.TUNTAP_MULTI_QUEUE_DEFAULTS
+	}
+	tap := &netlink.Tuntap{
+		LinkAttrs: netlink.LinkAttrs{Name: name},
+		Mode:      netlink.TUNTAP_MODE_TAP,
+		Queues:    queuePairs,
+		Flags:     flags,
+	}
+	if err := netlink.LinkAdd(tap); err != nil {
+		return fmt.Errorf("add tap %s: %w", name, err)
+	}
+	for _, fd := range tap.Fds {
+		_ = fd.Close()
+	}
+	return nil
+}
 
 // TuneTAP applies best-effort performance tuning to a TAP device.
 func TuneTAP(link netlink.Link) error {

--- a/snapshot/localfile/localfile.go
+++ b/snapshot/localfile/localfile.go
@@ -145,7 +145,7 @@ func (lf *LocalFile) List(ctx context.Context) ([]*types.Snapshot, error) {
 			if rec == nil || rec.Pending {
 				continue
 			}
-			s := rec.Snapshot // value copy
+			s := rec.Snapshot
 			result = append(result, &s)
 		}
 		return nil

--- a/utils/file.go
+++ b/utils/file.go
@@ -149,3 +149,27 @@ func scanDir(dir string, fn func(os.DirEntry) (string, bool)) ([]string, error) 
 	}
 	return result, nil
 }
+
+// copyWithCleanup opens src and creates dst, runs fn to copy the bytes, and removes dst if fn or the final close fails. fn must not close dst.
+func copyWithCleanup(dst, src string, fn func(srcFile, dstFile *os.File) error) (err error) {
+	srcFile, err := os.Open(src) //nolint:gosec // caller-controlled internal path
+	if err != nil {
+		return fmt.Errorf("open src: %w", err)
+	}
+	defer srcFile.Close() //nolint:errcheck
+
+	dstFile, err := os.Create(dst) //nolint:gosec // caller-controlled internal path
+	if err != nil {
+		return fmt.Errorf("create dst: %w", err)
+	}
+	defer func() {
+		closeErr := dstFile.Close()
+		if err != nil { // fn failed: drop the partial dst, keep fn's error
+			_ = os.Remove(dst)
+			return
+		}
+		err = closeErr // fn succeeded: surface a close failure but keep dst
+	}()
+
+	return fn(srcFile, dstFile)
+}

--- a/utils/reflink_linux.go
+++ b/utils/reflink_linux.go
@@ -20,27 +20,10 @@ func ReflinkCopy(dst, src string) error {
 }
 
 func tryFiclone(dst, src string) error {
-	srcFile, err := os.Open(src) //nolint:gosec
-	if err != nil {
-		return err
-	}
-	defer srcFile.Close() //nolint:errcheck
-
-	dstFile, err := os.Create(dst) //nolint:gosec
-	if err != nil {
-		return err
-	}
-	defer func() {
-		dstFile.Close() //nolint:errcheck,gosec
-		if err != nil {
-			os.Remove(dst) //nolint:errcheck,gosec
+	return copyWithCleanup(dst, src, func(srcFile, dstFile *os.File) error {
+		if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, dstFile.Fd(), ficlone, srcFile.Fd()); errno != 0 {
+			return fmt.Errorf("ficlone: %w", errno)
 		}
-	}()
-
-	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, dstFile.Fd(), ficlone, srcFile.Fd())
-	if errno != 0 {
-		err = fmt.Errorf("ficlone: %w", errno)
-		return err
-	}
-	return nil
+		return nil
+	})
 }

--- a/utils/sparse_linux.go
+++ b/utils/sparse_linux.go
@@ -59,7 +59,6 @@ func scanDataSegments(fd int, size int64) ([]sparseSegment, error) {
 	offset := int64(0)
 
 	for offset < size {
-		// Find next data start.
 		dataStart, err := syscall.Seek(fd, offset, seekData)
 		if err != nil {
 			// ENXIO means no more data after offset — rest is hole.
@@ -69,7 +68,6 @@ func scanDataSegments(fd int, size int64) ([]sparseSegment, error) {
 			return nil, fmt.Errorf("seek_data at %d: %w", offset, err)
 		}
 
-		// Find the end of this data segment (start of next hole).
 		holeStart, err := syscall.Seek(fd, dataStart, seekHole)
 		if err != nil {
 			if errors.Is(err, syscall.ENXIO) {

--- a/utils/sparse_linux.go
+++ b/utils/sparse_linux.go
@@ -18,58 +18,39 @@ const (
 // SparseCopy copies src to dst preserving sparsity via SEEK_HOLE/SEEK_DATA.
 // dst is created as a new file (truncated to src size, then only data segments written).
 func SparseCopy(dst, src string) error {
-	srcFile, err := os.Open(src) //nolint:gosec
-	if err != nil {
-		return fmt.Errorf("open src: %w", err)
-	}
-	defer srcFile.Close() //nolint:errcheck
-
-	fi, err := srcFile.Stat()
-	if err != nil {
-		return fmt.Errorf("stat src: %w", err)
-	}
-	size := fi.Size()
-
-	dstFile, err := os.Create(dst) //nolint:gosec
-	if err != nil {
-		return fmt.Errorf("create dst: %w", err)
-	}
-	cleanup := true
-	defer func() {
-		if cleanup {
-			dstFile.Close() //nolint:errcheck,gosec
-			os.Remove(dst)  //nolint:errcheck,gosec
+	return copyWithCleanup(dst, src, func(srcFile, dstFile *os.File) error {
+		fi, err := srcFile.Stat()
+		if err != nil {
+			return fmt.Errorf("stat src: %w", err)
 		}
-	}()
-
-	if size > 0 {
-		if truncErr := dstFile.Truncate(size); truncErr != nil {
-			return fmt.Errorf("truncate dst: %w", truncErr)
+		size := fi.Size()
+		if size > 0 {
+			if truncErr := dstFile.Truncate(size); truncErr != nil {
+				return fmt.Errorf("truncate dst: %w", truncErr)
+			}
 		}
-	}
 
-	segments, err := scanDataSegments(int(srcFile.Fd()), size)
-	if err != nil {
-		return err
-	}
+		segments, err := scanDataSegments(int(srcFile.Fd()), size)
+		if err != nil {
+			return err
+		}
+		for _, seg := range segments {
+			if _, err := srcFile.Seek(seg.Offset, io.SeekStart); err != nil {
+				return fmt.Errorf("seek src to %d: %w", seg.Offset, err)
+			}
+			if _, err := dstFile.Seek(seg.Offset, io.SeekStart); err != nil {
+				return fmt.Errorf("seek dst to %d: %w", seg.Offset, err)
+			}
+			if _, err := io.CopyN(dstFile, srcFile, seg.Length); err != nil {
+				return fmt.Errorf("copy segment at %d len %d: %w", seg.Offset, seg.Length, err)
+			}
+		}
 
-	for _, seg := range segments {
-		if _, err := srcFile.Seek(seg.Offset, io.SeekStart); err != nil {
-			return fmt.Errorf("seek src to %d: %w", seg.Offset, err)
+		if err := dstFile.Sync(); err != nil {
+			return fmt.Errorf("sync dst: %w", err)
 		}
-		if _, err := dstFile.Seek(seg.Offset, io.SeekStart); err != nil {
-			return fmt.Errorf("seek dst to %d: %w", seg.Offset, err)
-		}
-		if _, err := io.CopyN(dstFile, srcFile, seg.Length); err != nil {
-			return fmt.Errorf("copy segment at %d len %d: %w", seg.Offset, seg.Length, err)
-		}
-	}
-
-	if err := dstFile.Sync(); err != nil {
-		return fmt.Errorf("sync dst: %w", err)
-	}
-	cleanup = false
-	return dstFile.Close()
+		return nil
+	})
 }
 
 // scanDataSegments uses SEEK_DATA/SEEK_HOLE to find all data regions in f.

--- a/utils/sparse_other.go
+++ b/utils/sparse_other.go
@@ -3,34 +3,14 @@
 package utils
 
 import (
-	"fmt"
 	"io"
 	"os"
 )
 
 // SparseCopy copies src to dst. On non-Linux platforms, sparsity is not preserved.
 func SparseCopy(dst, src string) error {
-	srcFile, err := os.Open(src) //nolint:gosec
-	if err != nil {
-		return fmt.Errorf("open src: %w", err)
-	}
-	defer srcFile.Close() //nolint:errcheck
-
-	dstFile, err := os.Create(dst) //nolint:gosec
-	if err != nil {
-		return fmt.Errorf("create dst: %w", err)
-	}
-	cleanup := true
-	defer func() {
-		if cleanup {
-			dstFile.Close() //nolint:errcheck,gosec
-			os.Remove(dst)  //nolint:errcheck,gosec
-		}
-	}()
-
-	if _, err := io.Copy(dstFile, srcFile); err != nil {
+	return copyWithCleanup(dst, src, func(srcFile, dstFile *os.File) error {
+		_, err := io.Copy(dstFile, srcFile)
 		return err
-	}
-	cleanup = false
-	return dstFile.Close()
+	})
 }


### PR DESCRIPTION
Whole-project `/code` regression audit + cleanup. Two commits: MED-tier reuse dedup, then LOW-tier nits. **Zero behavior regressions** — verified by a closed-loop re-audit + full mechanical gates.

## What this is

A full `/code` SKILL audit of the codebase surfaced 25 confirmed findings (0 high / 8 med / 17 low) after adversarial verification (23 false-positives dropped). This PR fixes them, minus 3 deliberately skipped as overdesign.

Net **-85 LOC** (197+ / 282-), 26 files.

## Commit 1 — MED (reuse dedup)

- **cmd/core**: `InitAllHypervisors` error drops the misleading `for GC` context (6 of 7 callers are not GC paths) → `init hypervisor %s: %w`.
- **metadata/fat12**: `blankSFN()` replaces three identical `[11]byte` space-pad loops.
- **network**: `CreateTAP()` (in `tap_linux.go`, beside `TuneTAP`) replaces the duplicated Tuntap/queue-pairs/LinkAdd/fd-close block in both cni and bridge.
- **hypervisor/firecracker**: hoist the byte-identical `Wrap`/`AfterExtract` restore closures to `wrapSourceLocked`/`restoreAfterExtractCOW` methods (matches the existing `Preflight`/`Kill` method-value style); both `Restore` + `DirectRestore` use them.
- **images/oci**: `runErofsConversion()` (in `erofs.go`) captures the load-bearing scan→drain→close→wait ordering shared by `process.go` and `import.go`.
- **cmd/vm**: split `batchRoutedCmd` into `runRoutedLoop` + `finishRoutedCmd` so `RM` reuses both halves with its TAP/network cleanup injected at the seam. (Per-id log wording `deleted VM: X` → `deleted: X`, consistent with start/stop.)
- **utils**: `copyWithCleanup()` (`file.go`) shares the open-src/create-dst/remove-on-error scaffold across both `SparseCopy` variants and `tryFiclone`. Preserves `SparseCopy` success-path semantics (close error surfaced, dst kept); `tryFiclone` now also surfaces a post-ficlone close error (safe: `ReflinkCopy` falls back to `SparseCopy`).

## Commit 2 — LOW (nits)

- godoc added to exported `MeteringConfig.Validate`, `console.FormatEscapeChar`.
- WHAT-restating comments removed (`cmp.Or`, `imageType`, `// do nothing`, `// value copy` ×2, SEEK narration); `progressInterval` comment made godoc-form.
- `hypervisor`: `vsockBound` → `isVsockBound` (package `IsX/isX` convention).
- `firecracker`: log tag `firecracker.runRelay` → `RunRelay` (matches func name).
- `images/oci/commit`: 3 `validFileSize` errors now wrap the `os.Stat` cause (`%w`).
- `images/cloudimg`: `create HTTP request` → lowercase.
- `gc`: drop redundant `failures` counter (`== len(errs)`).
- `metering/capture`: `Entries` uses `slices.Clone`.
- `metadata/fat12`: `splitName()` shares the base/ext dot-split across `needsLFN`, `toShortName`, `generateShortName`.

## Deliberately skipped (overdesign)

1. **`restore.go` `RestoreSequence`/`DirectRestoreSequence` unify** — ~18-line shared skeleton, but the staging-dir lifecycle + differing materialization force a 7-param/4-closure helper on a critical low-coverage path → net readability loss.
2. **`cmd/images/import.go` tracker-builder extraction** — 2×2 phase grid, oci double-callback.
3. **`cmd/vm/run.go` clone-tail `finishClone`** — would change JSON-mode progress-log gating (behavior delta).

## Verification (zero-regression)

- **Per-file static analysis**: a deterministic AST style-linter over all **232 .go files** — private-sandwiched-between-public, standalone-funcs-in-method-groups, public-after-private methods, multi const/var blocks → **232 OK / 0 violations** (linter proven to flag a synthetic bad file).
- **Closed-loop re-audit**: per-touched-package regression hunt + adversarial verify → **0 regressions, loop CLOSED**. (Caught + fixed one missed `// value copy` twin.)
- **Mechanical gates**: build + vet (darwin+linux), `make fmt-check`, `make lint` (darwin+linux, 0 issues), `go test -race -count=1 ./...` (24/24), AST layout audit (0).
- `/simplify` run before each commit (reuse/quality/efficiency/altitude) — findings folded in (bridge double-wrap fix, `tryFiclone` fold).

## Test plan

- [x] `go build ./...` + `GOOS=linux go build ./...`
- [x] `go vet ./...` (both platforms)
- [x] `make fmt-check && make lint` (darwin + linux, 0 issues)
- [x] `go test -race -count=1 ./...` — 24/24
- [x] AST layout + per-file style audit — 0 violations across 232 files