### PR TITLE
feat: add --isolated to fence same-node VMs at the bridge

### DIFF
--- a/cmd/core/helpers.go
+++ b/cmd/core/helpers.go
@@ -292,6 +292,7 @@ func VMConfigFromFlags(cmd *cobra.Command, image string) (*types.VMConfig, error
 	noDirectIO, _ := cmd.Flags().GetBool("no-direct-io")
 	windows, _ := cmd.Flags().GetBool("windows")
 	sharedMemory, _ := cmd.Flags().GetBool("shared-memory")
+	isolated, _ := cmd.Flags().GetBool("isolated")
 	dataDiskRaw, _ := cmd.Flags().GetStringArray("data-disk")
 
 	if vmName == "" {
@@ -325,6 +326,7 @@ func VMConfigFromFlags(cmd *cobra.Command, image string) (*types.VMConfig, error
 			NoDirectIO:    noDirectIO,
 			Windows:       windows,
 			SharedMemory:  sharedMemory,
+			Isolated:      isolated,
 		},
 		User:      user,
 		Password:  password,
@@ -350,6 +352,7 @@ func CloneVMConfigFromFlags(cmd *cobra.Command, snapCfg types.SnapshotConfig) (*
 	}
 
 	onDemand, _ := cmd.Flags().GetBool("on-demand")
+	isolated, _ := cmd.Flags().GetBool("isolated")
 
 	return &types.VMConfig{
 		Name: vmName,
@@ -366,6 +369,7 @@ func CloneVMConfigFromFlags(cmd *cobra.Command, snapCfg types.SnapshotConfig) (*
 			NoDirectIO:    noDirectIO,
 			Windows:       snapCfg.Windows,
 			SharedMemory:  snapCfg.SharedMemory,
+			Isolated:      isolated,
 		},
 		OnDemand: onDemand,
 	}, nil

--- a/cmd/vm/commands.go
+++ b/cmd/vm/commands.go
@@ -287,6 +287,7 @@ func addVMFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("no-direct-io", false, "disable O_DIRECT on writable disks (use page cache instead; CH only)")
 	cmd.Flags().Bool("windows", false, "Windows guest (UEFI boot, kvm_hyperv=on, no cidata)")
 	cmd.Flags().Bool("shared-memory", false, "enable CH memory shared=on; required to attach vhost-user-fs later (CH only, fixed for VM lifetime)")
+	cmd.Flags().Bool("isolated", false, "isolate this VM's host bridge port so same-node VMs cannot reach each other (egress/gateway unaffected)")
 	cmd.Flags().StringArray("data-disk", nil, "extra data disk: size=20G[,name=...][,fstype=ext4|none][,mount=/mnt/x][,directio=on|off|auto]; repeatable")
 }
 
@@ -299,6 +300,7 @@ func addCloneFlags(cmd *cobra.Command) {
 	cmd.Flags().String("bridge", "", "use TAP-on-bridge instead of CNI (value is bridge device, e.g. cni0)")
 	cmd.Flags().Bool("no-direct-io", false, "disable O_DIRECT on writable disks (inherit from snapshot if not set)")
 	cmd.Flags().Bool("on-demand", false, "use UFFD on-demand memory loading for faster clone (CH only; snapshot file must remain on disk)")
+	cmd.Flags().Bool("isolated", false, "isolate this VM's host bridge port so same-node VMs cannot reach each other (egress/gateway unaffected)")
 	cmd.Flags().Bool("pull", false, "auto-pull base image if not found locally (for cross-node clone)")
 	cmd.Flags().String("from-dir", "", "clone from a snapshot directory (must contain snapshot.json) instead of the local snapshot DB; mutually exclusive with positional SNAPSHOT")
 }

--- a/network/bridge/bridge_linux.go
+++ b/network/bridge/bridge_linux.go
@@ -105,6 +105,12 @@ func (b *Bridge) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, sp
 			return nil, fmt.Errorf("add %s to %s: %w", name, b.bridgeDev, mErr)
 		}
 
+		if vmCfg.Isolated {
+			if iErr := netlink.LinkSetIsolated(tap, true); iErr != nil {
+				return nil, fmt.Errorf("isolate %s: %w", name, iErr)
+			}
+		}
+
 		_ = netlink.LinkSetLearning(tap, false)
 		if mtu := br.Attrs().MTU; mtu > 0 {
 			_ = netlink.LinkSetMTU(tap, mtu)

--- a/network/cni/lifecycle.go
+++ b/network/cni/lifecycle.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"strings"
 
 	"github.com/containernetworking/cni/libcni"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
@@ -104,6 +105,16 @@ func (c *CNI) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs
 		netInfo, parseErr := extractNetworkInfo(cniResult)
 		if parseErr != nil {
 			return nil, fmt.Errorf("parse CNI result: %w", parseErr)
+		}
+
+		if vmCfg.Isolated {
+			hostVeth, vErr := hostVethFromResult(cniResult)
+			if vErr != nil {
+				return nil, fmt.Errorf("isolate %s: %w", vmID, vErr)
+			}
+			if iErr := setPortIsolated(hostVeth); iErr != nil {
+				return nil, fmt.Errorf("isolate %s port %s: %w", vmID, hostVeth, iErr)
+			}
 		}
 
 		var overrideMAC string
@@ -209,6 +220,22 @@ func ensureNetns(name, nsPath string) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+// hostVethFromResult returns the host-side veth name the bridge CNI plugin
+// created. The bridge plugin reports it with an empty Sandbox and a "veth"
+// name prefix (the bridge device itself, e.g. cni0, also has an empty Sandbox).
+func hostVethFromResult(result cnitypes.Result) (string, error) {
+	r, err := current.NewResultFromResult(result)
+	if err != nil {
+		return "", fmt.Errorf("convert CNI result: %w", err)
+	}
+	for _, iface := range r.Interfaces {
+		if iface.Sandbox == "" && strings.HasPrefix(iface.Name, "veth") {
+			return iface.Name, nil
+		}
+	}
+	return "", errors.New("no host veth in CNI result")
 }
 
 // extractNetworkInfo converts a CNI ADD result into types.Network.

--- a/network/cni/lifecycle_darwin.go
+++ b/network/cni/lifecycle_darwin.go
@@ -22,3 +22,7 @@ func setupTCRedirect(_, _, _ string, _ int, _ string) (string, error) {
 func deleteTAPInNetns(_, _ string) error {
 	return errNotSupported
 }
+
+func setPortIsolated(_ string) error {
+	return errNotSupported
+}

--- a/network/cni/lifecycle_linux.go
+++ b/network/cni/lifecycle_linux.go
@@ -52,6 +52,16 @@ func deleteNetns(ctx context.Context, name string) error {
 	})
 }
 
+// setPortIsolated sets the bridge "isolated" flag on a host port so it cannot
+// forward frames to other isolated ports on the same bridge.
+func setPortIsolated(name string) error {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return fmt.Errorf("find %s: %w", name, err)
+	}
+	return netlink.LinkSetIsolated(link, true)
+}
+
 // deleteTAPInNetns deletes a named TAP device inside target netns.
 func deleteTAPInNetns(nsPath, tapName string) error {
 	return cns.WithNetNSPath(nsPath, func(_ cns.NetNS) error {

--- a/types/config.go
+++ b/types/config.go
@@ -21,4 +21,8 @@ type Config struct {
 	Windows       bool   `json:"windows,omitempty"`      // Windows guest: UEFI boot, kvm_hyperv=on, no cidata
 	// SharedMemory toggles CH memory shared=on (vhost-user-fs prerequisite); fixed at create, persists through clone/restore.
 	SharedMemory bool `json:"shared_memory,omitempty"`
+	// Isolated sets the bridge "isolated" flag on the VM's host port so VMs on
+	// the same node/bridge cannot reach each other (they can still reach the
+	// gateway and route out). Re-applied on NIC recover.
+	Isolated bool `json:"isolated,omitempty"`
 }


### PR DESCRIPTION
> Reference / for discussion — one option for same-node VM isolation. Opening so the approach and its trade-offs are concrete.

## What

`cocoon vm run/clone --isolated` sets the Linux bridge **`isolated`** flag on the VM's host bridge port. Ports that are both isolated cannot forward to each other, so VMs sharing a node/bridge can't reach each other — while the gateway, egress (NAT/internet) and routed (cross-node) traffic are unaffected.

Verified live on a staging node: with the port `isolated`, same-node VM↔VM (RDP/ping) is dropped, while `google.com:443` and the internal `staging.vm-service.simular.cloud` (an internal ILB) stay reachable.

## How

```
--isolated (run/clone)
  -> cmd/core/helpers.go: flag -> vmCfg.Config.Isolated
  -> types/config.go: Isolated bool   (persisted; re-applied on NIC recover)
  -> set at port-attach time:
       TAP-on-bridge  network/bridge/bridge_linux.go : LinkSetMaster -> netlink.LinkSetIsolated(tap, true)
       CNI            network/cni/lifecycle.go        : AddNetworkList -> resolve host veth -> setPortIsolated()
                      (lifecycle_linux.go impl, lifecycle_darwin.go stub)
```

It lives in the **cocoon runtime** because that is where the per-VM port is created and attached to the bridge — `cocoon-net` only owns node-level bits (the bridge, iptables, DHCP) and never touches per-VM ports.

## Why not bridge-nf + iptables

The alternative (`bridge-nf-call-iptables=1` so an iptables `FORWARD -i cni0 -d <pod-cidr> DROP` also catches same-node bridged traffic) was rejected: it is a **node-global** toggle (affects docker0 and every bridge), adds conntrack/perf overhead to all bridged traffic, the `br_netfilter` module is hazardous to manage, and it is **inconsistent across nodes** (observed: node-1 had it on, node-2 off → same-node isolation would silently work on one and fail on the other). Per-port `isolated` is surgical, node-consistent, and needs no extra module.

## Known limitation (bridge-only)

`isolated` is a Linux-bridge port attribute, so this only applies to bridge-backed networking: TAP-on-bridge and the CNI **bridge** plugin (the cocoon-net default, `cni0`). Non-bridge backends — CNI macvlan/ipvlan/ptp/SR-IOV, or macOS vmnet — have no bridge port to isolate; the CNI path currently **fails closed** (host-veth lookup errors) rather than silently running unisolated. A clearer "`--isolated` requires bridge networking" guard could be added if this direction is taken.

## Scope / follow-up

- Same node only. Cross-node and internal/CIDR egress are the separate `--drop-cidr` work in `cocoon-net` (L3, iptables).
- vk-cocoon passthrough (a `VMSpec.Isolated` field forwarded as `--isolated` on clone) is **not** included here — needed before production VMs get the flag.

## Testing

- `go build` + `go vet` clean on linux + darwin.
- `make lint` (GOOS=linux + GOOS=darwin): 0 issues.
- `go test ./types/... ./cmd/... ./network/...`: pass.
- Mechanism verified live (`bridge link set isolated on` equivalent of `netlink.LinkSetIsolated`).
