### PR TITLE
chore(deps): bump go directive to 1.26.4 (clears 2 reachable stdlib vulns)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cocoonstack/cocoon
 
-go 1.25.6
+go 1.26.4
 
 require (
 	github.com/cocoonstack/cocoon-agent v0.1.1-0.20260505130343-db13d35d7b13


### PR DESCRIPTION
Follow-up to the grpc bump (#69). `govulncheck` flagged two **reachable** Go standard-library vulnerabilities, both fixed in **go1.26.4**:

| Vuln | Component | Reached via | Severity |
|---|---|---|---|
| GO-2026-5039 | `net/textproto` (unescaped inputs in errors) | `utils.DoAPI → io.ReadAll → textproto.ReadMIMEHeader` (local CH/FC API socket) | low |
| GO-2026-5037 | `crypto/x509` (inefficient hostname parsing) | `snapshot.Handler.Export → io.Copy → x509.Verify/VerifyHostname` (registry TLS) | low |

Both are low practical risk (trusted local hypervisor API peer / registry TLS during export), but the fix is free.

## Change
CI builds via `go-version-file: go.mod`, so the toolchain is pinned by the `go` directive. Bump `go 1.25.6` → `go 1.26.4`. One line; `go mod tidy` left go.sum unchanged.

## Verification (on go1.26.4)
- [x] `go build ./...` + `GOOS=linux go build ./...`
- [x] `go vet` (both platforms)
- [x] `make lint` (darwin + linux, 0 issues)
- [x] `go test -race -count=1 ./...` — 24/24
- [x] `govulncheck ./...` — **0 vulnerabilities** (was 2)