### PR TITLE
refactor: slim dependency closures — images stores take rootDir; extract cmd/cliutil

### DIFF
--- a/cmd/cliutil/cliutil.go
+++ b/cmd/cliutil/cliutil.go
@@ -1,28 +1,22 @@
-package core
+// Package cliutil holds dependency-free CLI helpers (flags, table/JSON output) shared by cocoon and downstream CLIs.
+package cliutil
 
 import (
+	"context"
 	"encoding/json"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/docker/go-units"
 	"github.com/spf13/cobra"
-
-	"github.com/cocoonstack/cocoon/types"
-	"github.com/cocoonstack/cocoon/utils"
 )
 
-func ReconcileState(vm *types.VM) string {
-	if vm.State == types.VMStateRunning && !utils.IsProcessAlive(vm.PID) {
-		return "stopped (stale)"
+func CommandContext(cmd *cobra.Command) context.Context {
+	if cmd != nil && cmd.Context() != nil {
+		return cmd.Context()
 	}
-	return string(vm.State)
-}
-
-func OutputJSON(v any) error {
-	enc := json.NewEncoder(os.Stdout)
-	enc.SetIndent("", "  ")
-	return enc.Encode(v)
+	return context.Background()
 }
 
 func AddFormatFlag(cmd *cobra.Command) {
@@ -36,6 +30,12 @@ func AddOutputFlag(cmd *cobra.Command) {
 func WantJSON(cmd *cobra.Command) bool {
 	out, _ := cmd.Flags().GetString("output")
 	return out == "json"
+}
+
+func OutputJSON(v any) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
 }
 
 // MaybeOutputJSON emits JSON iff --output=json; (true, _) means caller should stop logging.
@@ -58,4 +58,8 @@ func OutputFormatted(cmd *cobra.Command, data any, tableFn func(w *tabwriter.Wri
 
 func FormatSize(bytes int64) string {
 	return units.HumanSize(float64(bytes))
+}
+
+func IsURL(ref string) bool {
+	return strings.HasPrefix(ref, "http://") || strings.HasPrefix(ref, "https://")
 }

--- a/cmd/core/handler.go
+++ b/cmd/core/handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/cocoonstack/cocoon/cmd/cliutil"
 	"github.com/cocoonstack/cocoon/config"
 )
 
@@ -18,7 +19,7 @@ func (h BaseHandler) Init(cmd *cobra.Command) (context.Context, *config.Config, 
 	if err != nil {
 		return nil, nil, err
 	}
-	return CommandContext(cmd), conf, nil
+	return cliutil.CommandContext(cmd), conf, nil
 }
 
 func (h BaseHandler) Conf() (*config.Config, error) {
@@ -30,11 +31,4 @@ func (h BaseHandler) Conf() (*config.Config, error) {
 		return nil, fmt.Errorf("config not initialized")
 	}
 	return conf, nil
-}
-
-func CommandContext(cmd *cobra.Command) context.Context {
-	if cmd != nil && cmd.Context() != nil {
-		return cmd.Context()
-	}
-	return context.Background()
 }

--- a/cmd/core/helpers.go
+++ b/cmd/core/helpers.go
@@ -11,11 +11,13 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/projecteru2/core/log"
 
+	"github.com/cocoonstack/cocoon/cmd/cliutil"
 	"github.com/cocoonstack/cocoon/config"
 	"github.com/cocoonstack/cocoon/hypervisor"
 	imagebackend "github.com/cocoonstack/cocoon/images"
 	"github.com/cocoonstack/cocoon/progress"
 	"github.com/cocoonstack/cocoon/types"
+	"github.com/cocoonstack/cocoon/utils"
 )
 
 func FindHypervisor(ctx context.Context, conf *config.Config, ref string) (hypervisor.Hypervisor, error) {
@@ -134,8 +136,11 @@ func ResolveImageOwner(ctx context.Context, backends []imagebackend.Images, ref 
 	)
 }
 
-func IsURL(ref string) bool {
-	return strings.HasPrefix(ref, "http://") || strings.HasPrefix(ref, "https://")
+func ReconcileState(vm *types.VM) string {
+	if vm.State == types.VMStateRunning && !utils.IsProcessAlive(vm.PID) {
+		return "stopped (stale)"
+	}
+	return string(vm.State)
 }
 
 // CloseOnCancel closes c when ctx is canceled; callers `defer CloseOnCancel(ctx, c)()` to stop the watcher on return.
@@ -176,7 +181,7 @@ func resolveOwner[T interface{ Type() string }](backends []T, ref string, found 
 func validateRefShape(ref, imageType string) error {
 	switch imageType {
 	case types.ImageTypeCloudImg:
-		if !IsURL(ref) {
+		if !cliutil.IsURL(ref) {
 			return fmt.Errorf("cloudimg ref %q is not an http(s) URL (imported or bare OCI ref?)", ref)
 		}
 	case types.ImageTypeOCI:

--- a/cmd/core/init.go
+++ b/cmd/core/init.go
@@ -53,11 +53,11 @@ func InitImageBackends(ctx context.Context, conf *config.Config) ([]imagebackend
 }
 
 func InitImageBackendsForPull(ctx context.Context, conf *config.Config) (*oci.OCI, *cloudimg.CloudImg, error) {
-	ociStore, err := oci.New(ctx, conf)
+	ociStore, err := oci.New(ctx, conf.RootDir, conf.EffectivePoolSize())
 	if err != nil {
 		return nil, nil, fmt.Errorf("init oci backend: %w", err)
 	}
-	cloudimgStore, err := cloudimg.New(ctx, conf)
+	cloudimgStore, err := cloudimg.New(ctx, conf.RootDir)
 	if err != nil {
 		return nil, nil, fmt.Errorf("init cloudimg backend: %w", err)
 	}

--- a/cmd/core/vmconfig.go
+++ b/cmd/core/vmconfig.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/cocoonstack/cocoon/config"
 	"github.com/cocoonstack/cocoon/hypervisor"
-	"github.com/cocoonstack/cocoon/images/cloudimg"
+	"github.com/cocoonstack/cocoon/images"
 	"github.com/cocoonstack/cocoon/types"
 )
 
@@ -129,7 +129,7 @@ func RestoreVMConfigFromFlags(cmd *cobra.Command, vm *types.VM, snapCfg types.Sn
 
 func EnsureFirmwarePath(conf *config.Config, bootCfg *types.BootConfig) {
 	if bootCfg != nil && bootCfg.KernelPath == "" && bootCfg.FirmwarePath == "" {
-		bootCfg.FirmwarePath = cloudimg.NewConfig(conf).FirmwarePath()
+		bootCfg.FirmwarePath = images.FirmwarePath(conf.RootDir)
 	}
 }
 

--- a/cmd/images/commands.go
+++ b/cmd/images/commands.go
@@ -3,7 +3,7 @@ package images
 import (
 	"github.com/spf13/cobra"
 
-	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
+	"github.com/cocoonstack/cocoon/cmd/cliutil"
 )
 
 type Actions interface {
@@ -25,7 +25,7 @@ func Command(h Actions) *cobra.Command {
 		Short:   "List locally stored images (all backends)",
 		RunE:    h.List,
 	}
-	cmdcore.AddFormatFlag(listCmd)
+	cliutil.AddFormatFlag(listCmd)
 
 	importCmd := &cobra.Command{
 		Use:   "import NAME [FILE...]",

--- a/cmd/images/import.go
+++ b/cmd/images/import.go
@@ -102,7 +102,7 @@ func (h Handler) importFromReader(ctx context.Context, conf *config.Config, name
 
 func (h Handler) importCloudimgFiles(ctx context.Context, conf *config.Config, name string, files ...string) error {
 	logger := log.WithFunc("cmd.images.importCloudimgFiles")
-	cloudimgStore, err := cloudimg.New(ctx, conf)
+	cloudimgStore, err := cloudimg.New(ctx, conf.RootDir)
 	if err != nil {
 		return fmt.Errorf("init cloudimg backend: %w", err)
 	}
@@ -130,7 +130,7 @@ func (h Handler) importCloudimgFiles(ctx context.Context, conf *config.Config, n
 
 func (h Handler) importOCIFiles(ctx context.Context, conf *config.Config, name string, files ...string) error {
 	logger := log.WithFunc("cmd.images.importOCIFiles")
-	ociStore, err := oci.New(ctx, conf)
+	ociStore, err := oci.New(ctx, conf.RootDir, conf.EffectivePoolSize())
 	if err != nil {
 		return fmt.Errorf("init oci backend: %w", err)
 	}
@@ -154,7 +154,7 @@ func (h Handler) importOCIFiles(ctx context.Context, conf *config.Config, name s
 
 func (h Handler) importCloudimgReader(ctx context.Context, conf *config.Config, name string, r io.Reader) error {
 	logger := log.WithFunc("cmd.images.importCloudimgReader")
-	cloudimgStore, err := cloudimg.New(ctx, conf)
+	cloudimgStore, err := cloudimg.New(ctx, conf.RootDir)
 	if err != nil {
 		return fmt.Errorf("init cloudimg backend: %w", err)
 	}
@@ -178,7 +178,7 @@ func (h Handler) importCloudimgReader(ctx context.Context, conf *config.Config, 
 
 func (h Handler) importOCIReader(ctx context.Context, conf *config.Config, name string, r io.Reader) error {
 	logger := log.WithFunc("cmd.images.importOCIReader")
-	ociStore, err := oci.New(ctx, conf)
+	ociStore, err := oci.New(ctx, conf.RootDir, conf.EffectivePoolSize())
 	if err != nil {
 		return fmt.Errorf("init oci backend: %w", err)
 	}

--- a/cmd/images/manage.go
+++ b/cmd/images/manage.go
@@ -8,6 +8,7 @@ import (
 	"github.com/projecteru2/core/log"
 	"github.com/spf13/cobra"
 
+	"github.com/cocoonstack/cocoon/cmd/cliutil"
 	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
 	imagebackend "github.com/cocoonstack/cocoon/images"
 	"github.com/cocoonstack/cocoon/types"
@@ -36,7 +37,7 @@ func (h Handler) List(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	return cmdcore.OutputFormatted(cmd, all, func(w *tabwriter.Writer) {
+	return cliutil.OutputFormatted(cmd, all, func(w *tabwriter.Writer) {
 		fmt.Fprintln(w, "TYPE\tNAME\tDIGEST\tSIZE\tCREATED") //nolint:errcheck
 		for _, img := range all {
 			digest := img.ID
@@ -45,7 +46,7 @@ func (h Handler) List(cmd *cobra.Command, _ []string) error {
 			}
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", //nolint:errcheck
 				img.Type, img.Name, digest,
-				cmdcore.FormatSize(img.Size),
+				cliutil.FormatSize(img.Size),
 				img.CreatedAt.Local().Format(time.DateTime))
 		}
 	})
@@ -113,5 +114,5 @@ func (h Handler) Inspect(cmd *cobra.Command, args []string) error {
 		// TOCTOU: concurrent rm/GC between resolve and re-probe; fail explicit instead of dumping "null" JSON.
 		return fmt.Errorf("image %q: disappeared during resolve", ref)
 	}
-	return cmdcore.OutputJSON(img)
+	return cliutil.OutputJSON(img)
 }

--- a/cmd/images/pull.go
+++ b/cmd/images/pull.go
@@ -7,6 +7,7 @@ import (
 	"github.com/projecteru2/core/log"
 	"github.com/spf13/cobra"
 
+	"github.com/cocoonstack/cocoon/cmd/cliutil"
 	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
 	"github.com/cocoonstack/cocoon/images/cloudimg"
 	"github.com/cocoonstack/cocoon/images/oci"
@@ -28,7 +29,7 @@ func (h Handler) Pull(cmd *cobra.Command, args []string) error {
 	force, _ := cmd.Flags().GetBool("force")
 
 	for _, image := range args {
-		if cmdcore.IsURL(image) {
+		if cliutil.IsURL(image) {
 			if err := h.pullCloudimg(ctx, cloudimgStore, image, force); err != nil {
 				return err
 			}
@@ -68,14 +69,14 @@ func (h Handler) pullCloudimg(ctx context.Context, store *cloudimg.CloudImg, url
 		case cloudimgProgress.PhaseDownload:
 			switch {
 			case e.BytesDone == 0 && e.BytesTotal > 0:
-				logger.Infof(ctx, "downloading cloud image %s (%s)", url, cmdcore.FormatSize(e.BytesTotal))
+				logger.Infof(ctx, "downloading cloud image %s (%s)", url, cliutil.FormatSize(e.BytesTotal))
 			case e.BytesDone == 0:
 				logger.Infof(ctx, "downloading cloud image %s", url)
 			case e.BytesTotal > 0:
 				pct := float64(e.BytesDone) / float64(e.BytesTotal) * 100
-				fmt.Printf("\r  %s / %s (%.1f%%)", cmdcore.FormatSize(e.BytesDone), cmdcore.FormatSize(e.BytesTotal), pct)
+				fmt.Printf("\r  %s / %s (%.1f%%)", cliutil.FormatSize(e.BytesDone), cliutil.FormatSize(e.BytesTotal), pct)
 			default:
-				fmt.Printf("\r  %s downloaded", cmdcore.FormatSize(e.BytesDone))
+				fmt.Printf("\r  %s downloaded", cliutil.FormatSize(e.BytesDone))
 			}
 		case cloudimgProgress.PhaseConvert:
 			fmt.Println()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/cocoonstack/cocoon/cmd/cliutil"
 	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
 	cmdimages "github.com/cocoonstack/cocoon/cmd/images"
 	cmdothers "github.com/cocoonstack/cocoon/cmd/others"
@@ -31,7 +32,7 @@ var (
 			Short:        "Cocoon - MicroVM Engine",
 			SilenceUsage: true,
 			PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-				return initConfig(cmdcore.CommandContext(cmd))
+				return initConfig(cliutil.CommandContext(cmd))
 			},
 		}
 

--- a/cmd/snapshot/commands.go
+++ b/cmd/snapshot/commands.go
@@ -3,7 +3,7 @@ package snapshot
 import (
 	"github.com/spf13/cobra"
 
-	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
+	"github.com/cocoonstack/cocoon/cmd/cliutil"
 )
 
 type Actions interface {
@@ -36,7 +36,7 @@ func Command(h Actions) *cobra.Command {
 		Short:   "List all snapshots",
 		RunE:    h.List,
 	}
-	cmdcore.AddFormatFlag(listCmd)
+	cliutil.AddFormatFlag(listCmd)
 	listCmd.Flags().String("vm", "", "only show snapshots belonging to this VM")
 
 	inspectCmd := &cobra.Command{

--- a/cmd/snapshot/handler.go
+++ b/cmd/snapshot/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/projecteru2/core/log"
 	"github.com/spf13/cobra"
 
+	"github.com/cocoonstack/cocoon/cmd/cliutil"
 	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
 	"github.com/cocoonstack/cocoon/snapshot"
 	"github.com/cocoonstack/cocoon/types"
@@ -123,12 +124,12 @@ func (h Handler) List(cmd *cobra.Command, _ []string) error {
 
 	slices.SortFunc(snapshots, func(a, b *types.Snapshot) int { return a.CreatedAt.Compare(b.CreatedAt) })
 
-	return cmdcore.OutputFormatted(cmd, snapshots, func(w *tabwriter.Writer) {
+	return cliutil.OutputFormatted(cmd, snapshots, func(w *tabwriter.Writer) {
 		fmt.Fprintln(w, "ID\tNAME\tCPU\tMEMORY\tDESCRIPTION\tCREATED") //nolint:errcheck
 		for _, s := range snapshots {
 			fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%s\n", //nolint:errcheck
 				s.ID, s.Name, s.CPU,
-				cmdcore.FormatSize(s.Memory), s.Description,
+				cliutil.FormatSize(s.Memory), s.Description,
 				s.CreatedAt.Local().Format(time.DateTime))
 		}
 	})
@@ -148,7 +149,7 @@ func (h Handler) Inspect(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("inspect: %w", err)
 	}
-	return cmdcore.OutputJSON(s)
+	return cliutil.OutputJSON(s)
 }
 
 func (h Handler) Export(cmd *cobra.Command, args []string) (err error) {

--- a/cmd/vm/attach.go
+++ b/cmd/vm/attach.go
@@ -8,6 +8,7 @@ import (
 	"github.com/projecteru2/core/log"
 	"github.com/spf13/cobra"
 
+	"github.com/cocoonstack/cocoon/cmd/cliutil"
 	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
 	"github.com/cocoonstack/cocoon/config"
 	"github.com/cocoonstack/cocoon/extend/fs"
@@ -28,7 +29,7 @@ func (h Handler) FsAttach(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return classifyAttachErr(err)
 	}
-	if done, jsonErr := cmdcore.MaybeOutputJSON(cmd, map[string]string{"vm": args[0], "tag": tag, "id": id}); done {
+	if done, jsonErr := cliutil.MaybeOutputJSON(cmd, map[string]string{"vm": args[0], "tag": tag, "id": id}); done {
 		return jsonErr
 	}
 	log.WithFunc("cmd.vm.fs.attach").Infof(ctx, "attached fs tag=%s id=%s vm=%s", tag, id, args[0])
@@ -44,7 +45,7 @@ func (h Handler) FsDetach(cmd *cobra.Command, args []string) error {
 	if err := a.FsDetach(ctx, args[0], tag); err != nil {
 		return classifyAttachErr(err)
 	}
-	if done, jsonErr := cmdcore.MaybeOutputJSON(cmd, map[string]string{"vm": args[0], "tag": tag}); done {
+	if done, jsonErr := cliutil.MaybeOutputJSON(cmd, map[string]string{"vm": args[0], "tag": tag}); done {
 		return jsonErr
 	}
 	log.WithFunc("cmd.vm.fs.detach").Infof(ctx, "detached fs tag=%s vm=%s", tag, args[0])
@@ -62,7 +63,7 @@ func (h Handler) DeviceAttach(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return classifyAttachErr(err)
 	}
-	if done, jsonErr := cmdcore.MaybeOutputJSON(cmd, map[string]string{"vm": args[0], "pci": pci, "id": deviceID}); done {
+	if done, jsonErr := cliutil.MaybeOutputJSON(cmd, map[string]string{"vm": args[0], "pci": pci, "id": deviceID}); done {
 		return jsonErr
 	}
 	log.WithFunc("cmd.vm.device.attach").Infof(ctx, "attached device pci=%s id=%s vm=%s", pci, deviceID, args[0])
@@ -78,7 +79,7 @@ func (h Handler) DeviceDetach(cmd *cobra.Command, args []string) error {
 	if err := a.DeviceDetach(ctx, args[0], id); err != nil {
 		return classifyAttachErr(err)
 	}
-	if done, jsonErr := cmdcore.MaybeOutputJSON(cmd, map[string]string{"vm": args[0], "id": id}); done {
+	if done, jsonErr := cliutil.MaybeOutputJSON(cmd, map[string]string{"vm": args[0], "id": id}); done {
 		return jsonErr
 	}
 	log.WithFunc("cmd.vm.device.detach").Infof(ctx, "detached device id=%s vm=%s", id, args[0])

--- a/cmd/vm/commands.go
+++ b/cmd/vm/commands.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
+	"github.com/cocoonstack/cocoon/cmd/cliutil"
 )
 
 type Actions interface {
@@ -43,7 +43,7 @@ func Command(h Actions) *cobra.Command {
 		RunE:  h.Create,
 	}
 	addVMFlags(createCmd)
-	cmdcore.AddOutputFlag(createCmd)
+	cliutil.AddOutputFlag(createCmd)
 
 	runCmd := &cobra.Command{
 		Use:   "run [flags] IMAGE",
@@ -52,7 +52,7 @@ func Command(h Actions) *cobra.Command {
 		RunE:  h.Run,
 	}
 	addVMFlags(runCmd)
-	cmdcore.AddOutputFlag(runCmd)
+	cliutil.AddOutputFlag(runCmd)
 
 	cloneCmd := &cobra.Command{
 		Use:   "clone [flags] [SNAPSHOT]",
@@ -61,7 +61,7 @@ func Command(h Actions) *cobra.Command {
 		RunE:  h.Clone,
 	}
 	addCloneFlags(cloneCmd)
-	cmdcore.AddOutputFlag(cloneCmd)
+	cliutil.AddOutputFlag(cloneCmd)
 
 	startCmd := &cobra.Command{
 		Use:   "start VM [VM...]",
@@ -69,7 +69,7 @@ func Command(h Actions) *cobra.Command {
 		Args:  cobra.MinimumNArgs(1),
 		RunE:  h.Start,
 	}
-	cmdcore.AddOutputFlag(startCmd)
+	cliutil.AddOutputFlag(startCmd)
 
 	stopCmd := &cobra.Command{
 		Use:   "stop VM [VM...]",
@@ -79,7 +79,7 @@ func Command(h Actions) *cobra.Command {
 	}
 	stopCmd.Flags().Bool("force", false, "force stop (skip graceful shutdown, immediate SIGTERM/SIGKILL)")
 	stopCmd.Flags().Int("timeout", 0, "ACPI shutdown timeout in seconds (0 = use config default)")
-	cmdcore.AddOutputFlag(stopCmd)
+	cliutil.AddOutputFlag(stopCmd)
 
 	listCmd := &cobra.Command{
 		Use:     "list",
@@ -87,7 +87,7 @@ func Command(h Actions) *cobra.Command {
 		Short:   "List VMs with status",
 		RunE:    h.List,
 	}
-	cmdcore.AddFormatFlag(listCmd)
+	cliutil.AddFormatFlag(listCmd)
 
 	inspectCmd := &cobra.Command{
 		Use:   "inspect VM",
@@ -128,7 +128,7 @@ func Command(h Actions) *cobra.Command {
 		RunE:  h.RM,
 	}
 	rmCmd.Flags().Bool("force", false, "force delete running VMs")
-	cmdcore.AddOutputFlag(rmCmd)
+	cliutil.AddOutputFlag(rmCmd)
 
 	restoreCmd := &cobra.Command{
 		Use:   "restore [flags] VM [SNAPSHOT]",
@@ -147,7 +147,7 @@ func Command(h Actions) *cobra.Command {
 	restoreCmd.Flags().Bool("on-demand", false, "use UFFD on-demand memory loading for faster restore (CH only; snapshot file must remain on disk)")
 	restoreCmd.Flags().String("from-dir", "", "restore from a snapshot directory (must contain snapshot.json) instead of the local snapshot DB; mutually exclusive with positional SNAPSHOT")
 	restoreCmd.Flags().Bool("force", false, "skip the snapshot-belongs-to-VM check (only meaningful with --from-dir; risk of restoring to an unrelated lineage)")
-	cmdcore.AddOutputFlag(restoreCmd)
+	cliutil.AddOutputFlag(restoreCmd)
 
 	debugCmd := &cobra.Command{
 		Use:   "debug [flags] IMAGE",
@@ -202,7 +202,7 @@ func buildNetCommand(h Actions) *cobra.Command {
 	}
 	cmd.Flags().Int("nics", -1, "target NIC count (required, >= 0)")
 	_ = cmd.MarkFlagRequired("nics")
-	cmdcore.AddOutputFlag(cmd)
+	cliutil.AddOutputFlag(cmd)
 	return cmd
 }
 
@@ -224,7 +224,7 @@ func buildFsCommand(h Actions) *cobra.Command {
 	attach.Flags().Int("queue-size", 0, "queue depth (0 = default 1024)") //nolint:mnd
 	_ = attach.MarkFlagRequired("socket")
 	_ = attach.MarkFlagRequired("tag")
-	cmdcore.AddOutputFlag(attach)
+	cliutil.AddOutputFlag(attach)
 
 	detach := &cobra.Command{
 		Use:   "detach VM",
@@ -234,7 +234,7 @@ func buildFsCommand(h Actions) *cobra.Command {
 	}
 	detach.Flags().String("tag", "", "guest mount tag (required)")
 	_ = detach.MarkFlagRequired("tag")
-	cmdcore.AddOutputFlag(detach)
+	cliutil.AddOutputFlag(detach)
 
 	parent.AddCommand(attach, detach)
 	return parent
@@ -255,7 +255,7 @@ func buildDeviceCommand(h Actions) *cobra.Command {
 	attach.Flags().String("pci", "", "BDF (01:00.0 / 0000:01:00.0) or sysfs path /sys/bus/pci/devices/<bdf>")
 	attach.Flags().String("id", "", "optional device id; CH auto-generates if empty (must not start with cocoon-)")
 	_ = attach.MarkFlagRequired("pci")
-	cmdcore.AddOutputFlag(attach)
+	cliutil.AddOutputFlag(attach)
 
 	detach := &cobra.Command{
 		Use:   "detach VM",
@@ -265,7 +265,7 @@ func buildDeviceCommand(h Actions) *cobra.Command {
 	}
 	detach.Flags().String("id", "", "device id returned by attach (required)")
 	_ = detach.MarkFlagRequired("id")
-	cmdcore.AddOutputFlag(detach)
+	cliutil.AddOutputFlag(detach)
 
 	parent.AddCommand(attach, detach)
 	return parent

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -12,6 +12,7 @@ import (
 	"github.com/projecteru2/core/log"
 	"github.com/spf13/cobra"
 
+	"github.com/cocoonstack/cocoon/cmd/cliutil"
 	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
 	"github.com/cocoonstack/cocoon/config"
 	"github.com/cocoonstack/cocoon/console"
@@ -114,7 +115,7 @@ func (h Handler) Inspect(cmd *cobra.Command, args []string) error {
 	if info.State == types.VMStateRunning {
 		out.AttachedDevices = collectAttachedDevices(ctx, hyper, args[0])
 	}
-	return cmdcore.OutputJSON(out)
+	return cliutil.OutputJSON(out)
 }
 
 func (h Handler) Console(cmd *cobra.Command, args []string) error {
@@ -210,7 +211,7 @@ func (h Handler) RM(cmd *cobra.Command, args []string) error {
 	}
 
 	const logTag = "cmd.vm.rm"
-	allDeleted, lastErr := runRoutedLoop(ctx, logTag, "deleted", cmdcore.WantJSON(cmd), routed,
+	allDeleted, lastErr := runRoutedLoop(ctx, logTag, "deleted", cliutil.WantJSON(cmd), routed,
 		func(hyper hypervisor.Hypervisor, refs []string) ([]string, error) {
 			return hyper.Delete(ctx, refs, force)
 		})
@@ -333,7 +334,7 @@ func finishRoutedCmd(ctx context.Context, cmd *cobra.Command, logTag, name, past
 	if lastErr != nil {
 		return fmt.Errorf("%s: %w", name, lastErr)
 	}
-	if done, jsonErr := cmdcore.MaybeOutputJSON(cmd, map[string][]string{"succeeded": allDone}); done {
+	if done, jsonErr := cliutil.MaybeOutputJSON(cmd, map[string][]string{"succeeded": allDone}); done {
 		return jsonErr
 	}
 	if len(allDone) == 0 {
@@ -344,7 +345,7 @@ func finishRoutedCmd(ctx context.Context, cmd *cobra.Command, logTag, name, past
 
 func batchRoutedCmd(ctx context.Context, cmd *cobra.Command, name, pastTense string, routed map[hypervisor.Hypervisor][]string, fn func(hypervisor.Hypervisor, []string) ([]string, error)) error {
 	logTag := "cmd.vm." + name
-	allDone, lastErr := runRoutedLoop(ctx, logTag, pastTense, cmdcore.WantJSON(cmd), routed, fn)
+	allDone, lastErr := runRoutedLoop(ctx, logTag, pastTense, cliutil.WantJSON(cmd), routed, fn)
 	return finishRoutedCmd(ctx, cmd, logTag, name, pastTense, allDone, lastErr)
 }
 

--- a/cmd/vm/netresize.go
+++ b/cmd/vm/netresize.go
@@ -6,7 +6,7 @@ import (
 	"github.com/projecteru2/core/log"
 	"github.com/spf13/cobra"
 
-	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
+	"github.com/cocoonstack/cocoon/cmd/cliutil"
 	"github.com/cocoonstack/cocoon/config"
 	"github.com/cocoonstack/cocoon/extend/netresize"
 	"github.com/cocoonstack/cocoon/network"
@@ -31,7 +31,7 @@ func (h Handler) NetResize(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return classifyAttachErr(err)
 	}
-	if done, jsonErr := cmdcore.MaybeOutputJSON(cmd, res); done {
+	if done, jsonErr := cliutil.MaybeOutputJSON(cmd, res); done {
 		return jsonErr
 	}
 	logger := log.WithFunc("cmd.vm.net")

--- a/cmd/vm/run.go
+++ b/cmd/vm/run.go
@@ -9,6 +9,7 @@ import (
 	"github.com/projecteru2/core/log"
 	"github.com/spf13/cobra"
 
+	"github.com/cocoonstack/cocoon/cmd/cliutil"
 	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
 	"github.com/cocoonstack/cocoon/config"
 	"github.com/cocoonstack/cocoon/hypervisor"
@@ -28,7 +29,7 @@ func (h Handler) Create(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if done, jsonErr := cmdcore.MaybeOutputJSON(cmd, vm); done {
+	if done, jsonErr := cliutil.MaybeOutputJSON(cmd, vm); done {
 		return jsonErr
 	}
 	logger := log.WithFunc("cmd.vm.create")
@@ -43,7 +44,7 @@ func (h Handler) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	logger := log.WithFunc("cmd.vm.run")
-	wantJSON := cmdcore.WantJSON(cmd)
+	wantJSON := cliutil.WantJSON(cmd)
 	if !wantJSON {
 		logger.Infof(ctx, "VM created: %s (name: %s)", vm.ID, vm.Config.Name)
 	}
@@ -60,7 +61,7 @@ func (h Handler) Run(cmd *cobra.Command, args []string) error {
 		case info != nil:
 			vm = info
 		}
-		return cmdcore.OutputJSON(vm)
+		return cliutil.OutputJSON(vm)
 	}
 	for _, id := range started {
 		logger.Infof(ctx, "started: %s", id)
@@ -127,7 +128,7 @@ func (h Handler) Clone(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("clone VM: %w", cloneErr)
 	}
 
-	if done, jsonErr := cmdcore.MaybeOutputJSON(cmd, vm); done {
+	if done, jsonErr := cliutil.MaybeOutputJSON(cmd, vm); done {
 		return jsonErr
 	}
 	logger.Infof(ctx, "VM cloned: %s (name: %s)", vm.ID, vm.Config.Name)
@@ -196,7 +197,7 @@ func (h Handler) Restore(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("restore: %w", err)
 	}
 
-	if done, jsonErr := cmdcore.MaybeOutputJSON(cmd, result); done {
+	if done, jsonErr := cliutil.MaybeOutputJSON(cmd, result); done {
 		return jsonErr
 	}
 	logger.Infof(ctx, "VM %s restored (state: %s)", result.ID, result.State)
@@ -277,7 +278,7 @@ func (h Handler) cloneFromSrcDir(ctx context.Context, cmd *cobra.Command, conf *
 		return err
 	}
 
-	wantJSON := cmdcore.WantJSON(cmd)
+	wantJSON := cliutil.WantJSON(cmd)
 	if !wantJSON {
 		logger.Infof(ctx, "cloning VM from %s ...", sourceLabel)
 	}
@@ -289,7 +290,7 @@ func (h Handler) cloneFromSrcDir(ctx context.Context, cmd *cobra.Command, conf *
 	}
 
 	if wantJSON {
-		return cmdcore.OutputJSON(vm)
+		return cliutil.OutputJSON(vm)
 	}
 	logger.Infof(ctx, "VM cloned: %s (name: %s)", vm.ID, vm.Config.Name)
 	printPostCloneHints(vm)
@@ -352,7 +353,7 @@ func (h Handler) restoreDirect(ctx context.Context, cmd *cobra.Command, snapRef,
 
 // runDirectRestore is the shared tail for the snapshot-DB and --from-dir restore paths: log, DirectRestore, output.
 func (h Handler) runDirectRestore(ctx context.Context, cmd *cobra.Command, dcr hypervisor.Direct, vmRef string, vmCfg *types.VMConfig, srcDir, sourceSnapshotID, sourceLabel string, logger *log.Fields) error {
-	wantJSON := cmdcore.WantJSON(cmd)
+	wantJSON := cliutil.WantJSON(cmd)
 	if !wantJSON {
 		logger.Infof(ctx, "restoring VM %s from %s (direct) ...", vmRef, sourceLabel)
 	}
@@ -361,7 +362,7 @@ func (h Handler) runDirectRestore(ctx context.Context, cmd *cobra.Command, dcr h
 		return fmt.Errorf("restore: %w", err)
 	}
 	if wantJSON {
-		return cmdcore.OutputJSON(result)
+		return cliutil.OutputJSON(result)
 	}
 	logger.Infof(ctx, "VM %s restored (state: %s)", result.ID, result.State)
 	return nil

--- a/cmd/vm/status.go
+++ b/cmd/vm/status.go
@@ -15,6 +15,7 @@ import (
 	"github.com/projecteru2/core/log"
 	"github.com/spf13/cobra"
 
+	"github.com/cocoonstack/cocoon/cmd/cliutil"
 	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
 	"github.com/cocoonstack/cocoon/hypervisor"
 	"github.com/cocoonstack/cocoon/types"
@@ -118,7 +119,7 @@ func renderVMList(vms []*types.VM, format string) error {
 		if vms == nil {
 			vms = []*types.VM{}
 		}
-		return cmdcore.OutputJSON(vms)
+		return cliutil.OutputJSON(vms)
 	}
 	if len(vms) == 0 {
 		fmt.Println("No VMs found.")

--- a/config/config.go
+++ b/config/config.go
@@ -3,10 +3,11 @@ package config
 import (
 	"fmt"
 	"net"
-	"runtime"
 	"strings"
 
 	coretypes "github.com/projecteru2/core/types"
+
+	"github.com/cocoonstack/cocoon/utils"
 )
 
 const (
@@ -60,10 +61,7 @@ func (c *Config) Hypervisor() HypervisorType {
 
 // EffectivePoolSize returns PoolSize if set, otherwise runtime.NumCPU().
 func (c *Config) EffectivePoolSize() int {
-	if c.PoolSize <= 0 {
-		return runtime.NumCPU()
-	}
-	return c.PoolSize
+	return utils.PoolSizeOrDefault(c.PoolSize)
 }
 
 // Validate checks that all config fields are within acceptable ranges.

--- a/images/baseconfig.go
+++ b/images/baseconfig.go
@@ -1,20 +1,20 @@
 package images
 
 import (
+	"fmt"
 	"path/filepath"
 
-	"github.com/cocoonstack/cocoon/config"
 	"github.com/cocoonstack/cocoon/utils"
 )
 
 // BaseConfig is the directory layout shared by all image backends.
 type BaseConfig struct {
-	Root    *config.Config
+	RootDir string
 	Subdir  string
 	BlobExt string
 }
 
-func (c *BaseConfig) BackendDir() string { return filepath.Join(c.Root.RootDir, c.Subdir) }
+func (c *BaseConfig) BackendDir() string { return filepath.Join(c.RootDir, c.Subdir) }
 func (c *BaseConfig) DBDir() string      { return filepath.Join(c.BackendDir(), "db") }
 func (c *BaseConfig) TempDir() string    { return filepath.Join(c.BackendDir(), "temp") }
 func (c *BaseConfig) BlobsDir() string   { return filepath.Join(c.BackendDir(), "blobs") }
@@ -26,5 +26,13 @@ func (c *BaseConfig) BlobPath(hex string) string {
 }
 
 func (c *BaseConfig) EnsureBaseDirs() error {
+	if c.RootDir == "" {
+		return fmt.Errorf("root dir must not be empty")
+	}
 	return utils.EnsureDirs(c.DBDir(), c.TempDir(), c.BlobsDir())
+}
+
+// FirmwarePath returns the UEFI firmware blob (CLOUDHV.fd) under rootDir/firmware.
+func FirmwarePath(rootDir string) string {
+	return filepath.Join(rootDir, "firmware", "CLOUDHV.fd")
 }

--- a/images/cloudimg/cloudimg.go
+++ b/images/cloudimg/cloudimg.go
@@ -8,7 +8,6 @@ import (
 	"github.com/projecteru2/core/log"
 	"golang.org/x/sync/singleflight"
 
-	"github.com/cocoonstack/cocoon/config"
 	"github.com/cocoonstack/cocoon/images"
 	"github.com/cocoonstack/cocoon/lock"
 	"github.com/cocoonstack/cocoon/progress"
@@ -30,11 +29,8 @@ type CloudImg struct {
 	ops       images.Ops[imageIndex, imageEntry]
 }
 
-func New(ctx context.Context, conf *config.Config) (*CloudImg, error) {
-	if conf == nil {
-		return nil, fmt.Errorf("config is nil")
-	}
-	cfg := NewConfig(conf)
+func New(ctx context.Context, rootDir string) (*CloudImg, error) {
+	cfg := NewConfig(rootDir)
 	if err := cfg.EnsureDirs(); err != nil {
 		return nil, fmt.Errorf("ensure dirs: %w", err)
 	}
@@ -115,7 +111,7 @@ func (c *CloudImg) Config(ctx context.Context, vms []*types.VMConfig) (result []
 				Role:   types.StorageRoleLayer,
 			}}
 
-			firmwarePath := c.conf.FirmwarePath()
+			firmwarePath := images.FirmwarePath(c.conf.RootDir)
 			if !utils.ValidFile(firmwarePath) {
 				return fmt.Errorf("firmware not found: %s", firmwarePath)
 			}

--- a/images/cloudimg/config.go
+++ b/images/cloudimg/config.go
@@ -3,7 +3,6 @@ package cloudimg
 import (
 	"path/filepath"
 
-	"github.com/cocoonstack/cocoon/config"
 	"github.com/cocoonstack/cocoon/images"
 )
 
@@ -11,19 +10,14 @@ type Config struct {
 	images.BaseConfig
 }
 
-func NewConfig(conf *config.Config) *Config {
+func NewConfig(rootDir string) *Config {
 	return &Config{BaseConfig: images.BaseConfig{
-		Root: conf, Subdir: "cloudimg", BlobExt: ".qcow2",
+		RootDir: rootDir, Subdir: "cloudimg", BlobExt: ".qcow2",
 	}}
 }
 
 func (c *Config) EnsureDirs() error {
 	return c.EnsureBaseDirs()
-}
-
-// FirmwarePath returns the UEFI firmware blob (CLOUDHV.fd) under conf.RootDir/firmware.
-func (c *Config) FirmwarePath() string {
-	return filepath.Join(c.Root.RootDir, "firmware", "CLOUDHV.fd")
 }
 
 // tmpBlobPath uses a hidden prefix so a partial write is safe under last-writer-wins.

--- a/images/oci/config.go
+++ b/images/oci/config.go
@@ -3,19 +3,21 @@ package oci
 import (
 	"path/filepath"
 
-	"github.com/cocoonstack/cocoon/config"
 	"github.com/cocoonstack/cocoon/images"
 	"github.com/cocoonstack/cocoon/utils"
 )
 
 type Config struct {
 	images.BaseConfig
+	// PoolSize bounds concurrent layer processing.
+	PoolSize int
 }
 
-func NewConfig(conf *config.Config) *Config {
-	return &Config{BaseConfig: images.BaseConfig{
-		Root: conf, Subdir: "oci", BlobExt: ".erofs",
-	}}
+func NewConfig(rootDir string, poolSize int) *Config {
+	return &Config{
+		BaseConfig: images.BaseConfig{RootDir: rootDir, Subdir: "oci", BlobExt: ".erofs"},
+		PoolSize:   utils.PoolSizeOrDefault(poolSize),
+	}
 }
 
 func (c *Config) EnsureDirs() error {

--- a/images/oci/import.go
+++ b/images/oci/import.go
@@ -57,7 +57,7 @@ func importTarLayers(ctx context.Context, conf *Config, store storage.Store[imag
 				label: filePath, workDir: workDir, tracker: tracker, result: &r,
 			}, filePath)
 			return r, err
-		}, conf.Root.EffectivePoolSize())
+		}, conf.PoolSize)
 		if mapErr != nil {
 			return fmt.Errorf("process layers: %w", mapErr)
 		}

--- a/images/oci/oci.go
+++ b/images/oci/oci.go
@@ -9,7 +9,6 @@ import (
 	"github.com/projecteru2/core/log"
 	"golang.org/x/sync/singleflight"
 
-	"github.com/cocoonstack/cocoon/config"
 	"github.com/cocoonstack/cocoon/images"
 	"github.com/cocoonstack/cocoon/lock"
 	"github.com/cocoonstack/cocoon/progress"
@@ -34,16 +33,14 @@ type OCI struct {
 	ops       images.Ops[imageIndex, imageEntry]
 }
 
-func New(ctx context.Context, conf *config.Config) (*OCI, error) {
-	if conf == nil {
-		return nil, fmt.Errorf("config is nil")
-	}
-	cfg := NewConfig(conf)
+// New builds the OCI backend under rootDir; poolSize <= 0 means NumCPU.
+func New(ctx context.Context, rootDir string, poolSize int) (*OCI, error) {
+	cfg := NewConfig(rootDir, poolSize)
 	if err := cfg.EnsureDirs(); err != nil {
 		return nil, fmt.Errorf("ensure dirs: %w", err)
 	}
 
-	log.WithFunc("oci.New").Debugf(ctx, "OCI image backend initialized, pool size: %d", conf.PoolSize)
+	log.WithFunc("oci.New").Debugf(ctx, "OCI image backend initialized, pool size: %d", cfg.PoolSize)
 
 	store, locker := images.NewStore[imageIndex](cfg.IndexFile(), cfg.IndexLock())
 	o := &OCI{

--- a/images/oci/pull.go
+++ b/images/oci/pull.go
@@ -76,7 +76,7 @@ func processLayers(ctx context.Context, conf *Config, layers []v1.Layer, workDir
 			tracker: tracker, result: &r,
 		})
 		return r, err
-	}, conf.Root.EffectivePoolSize())
+	}, conf.PoolSize)
 	if waitErr != nil {
 		return nil, fmt.Errorf("process layers: %w", waitErr)
 	}

--- a/images/oci/pull_test.go
+++ b/images/oci/pull_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cocoonstack/cocoon/config"
 	"github.com/cocoonstack/cocoon/images"
 )
 
@@ -38,7 +37,7 @@ func TestCollectBootHexesAndBootFilesPresent(t *testing.T) {
 
 func TestMoveBootFileAndIsUpToDate(t *testing.T) {
 	root := t.TempDir()
-	conf := NewConfig(&config.Config{RootDir: root})
+	conf := NewConfig(root, 1)
 	if err := conf.EnsureDirs(); err != nil {
 		t.Fatalf("EnsureDirs(): %v", err)
 	}

--- a/utils/batch.go
+++ b/utils/batch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 
 	"golang.org/x/sync/errgroup"
 )
@@ -83,6 +84,14 @@ func Map[T, R any](ctx context.Context, items []T, fn func(ctx context.Context, 
 		return nil, err
 	}
 	return results, nil
+}
+
+// PoolSizeOrDefault returns n, or runtime.NumCPU() when n <= 0.
+func PoolSizeOrDefault(n int) int {
+	if n <= 0 {
+		return runtime.NumCPU()
+	}
+	return n
 }
 
 func pickLimit(concurrency []int) int {


### PR DESCRIPTION
## What

Two dependency-closure refactors, one per commit:

**1. `refactor(images): narrow store constructors to rootDir, drop *config.Config`** — closes #73
- `images.BaseConfig` holds `RootDir string` instead of the whole `*config.Config`; `cloudimg.New(ctx, rootDir)` / `oci.New(ctx, rootDir, poolSize)` are the honest signatures (in-repo callers pass `conf.EffectivePoolSize()`).
- CH firmware path moves to `images.FirmwarePath(rootDir)` — it never used cloudimg layout; exactly one definition repo-wide now.
- The `config` package drops out of the images dependency closure entirely.
- The `<=0 → NumCPU` pool defaulting now has a single owner: `utils.PoolSizeOrDefault`, delegated to by both `config.EffectivePoolSize` and `oci.NewConfig` (was about to become two copies).
- Bonus accuracy fix: oci's init log now prints the resolved pool size instead of a possibly-zero raw `conf.PoolSize`.

**2. `refactor(cmd): extract dependency-free CLI helpers into cmd/cliutil`** — closes #72
- `cmd/cliutil` = stdlib+cobra+go-units only (`CommandContext`, format/output flags, `OutputJSON/Formatted`, `FormatSize`, `IsURL`), so downstream CLIs can reuse the `-o table|json` surface without dragging hypervisor backends / go-containerregistry via `cmd/core`.
- `ReconcileState` stays in `cmd/core` (needs `types` + `utils`).

## Review

- Line-by-line /code walkthrough + 3-lens /simplify pass; the one actionable finding (duplicated pool defaulting) fixed via `utils.PoolSizeOrDefault`; `IsURL` placement nit judged not worth churn.
- Verified `EffectivePoolSize` and the oci default are semantically identical (incl. negatives) — no behavior drift; no stale `cmdcore.*` references remain.
- `make lint` 0 issues (linux+darwin), `make fmt-check` clean, full test suite green (24 pkgs, race+cover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
