### PR TITLE
feat(cloudimg): parallel Range download for image pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ cocoon
 | `--cni-bin-dir`   | `COCOON_CNI_BIN_DIR`           | `/opt/cni/bin`     | CNI plugin binary directory            |
 | `--dns`           | `COCOON_DNS`                   | `8.8.8.8,1.1.1.1`  | DNS servers for VMs (comma separated)  |
 
+Config-file / env-only keys (no CLI flag):
+
+| Key          | Env Variable        | Default | Description                                                            |
+| ------------ | ------------------- | ------- | ---------------------------------------------------------------------- |
+| `pull_conns` | `COCOON_PULL_CONNS` | `8`     | Concurrent HTTP Range connections per cloud-image download (`image pull`); raise for fat pipes, lower to be gentle on the registry |
+
 ## VM Flags
 
 Applies to `cocoon vm create`, `cocoon vm run`, and `cocoon vm debug`:

--- a/cmd/core/init.go
+++ b/cmd/core/init.go
@@ -57,7 +57,7 @@ func InitImageBackendsForPull(ctx context.Context, conf *config.Config) (*oci.OC
 	if err != nil {
 		return nil, nil, fmt.Errorf("init oci backend: %w", err)
 	}
-	cloudimgStore, err := cloudimg.New(ctx, conf.RootDir)
+	cloudimgStore, err := cloudimg.New(ctx, conf.RootDir, conf.EffectivePullConns())
 	if err != nil {
 		return nil, nil, fmt.Errorf("init cloudimg backend: %w", err)
 	}

--- a/cmd/images/import.go
+++ b/cmd/images/import.go
@@ -102,7 +102,7 @@ func (h Handler) importFromReader(ctx context.Context, conf *config.Config, name
 
 func (h Handler) importCloudimgFiles(ctx context.Context, conf *config.Config, name string, files ...string) error {
 	logger := log.WithFunc("cmd.images.importCloudimgFiles")
-	cloudimgStore, err := cloudimg.New(ctx, conf.RootDir)
+	cloudimgStore, err := cloudimg.New(ctx, conf.RootDir, conf.EffectivePullConns())
 	if err != nil {
 		return fmt.Errorf("init cloudimg backend: %w", err)
 	}
@@ -154,7 +154,7 @@ func (h Handler) importOCIFiles(ctx context.Context, conf *config.Config, name s
 
 func (h Handler) importCloudimgReader(ctx context.Context, conf *config.Config, name string, r io.Reader) error {
 	logger := log.WithFunc("cmd.images.importCloudimgReader")
-	cloudimgStore, err := cloudimg.New(ctx, conf.RootDir)
+	cloudimgStore, err := cloudimg.New(ctx, conf.RootDir, conf.EffectivePullConns())
 	if err != nil {
 		return fmt.Errorf("init cloudimg backend: %w", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,6 +65,7 @@ var (
 		viper.SetDefault("dns", "8.8.8.8,1.1.1.1")
 		viper.SetDefault("stop_timeout_seconds", 30)
 		viper.SetDefault("pool_size", runtime.NumCPU())
+		viper.SetDefault("pull_conns", 8)
 		viper.SetDefault("log.level", "info")
 		viper.SetDefault("log.max_size", 500)
 		viper.SetDefault("log.max_age", 28)

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,9 @@ import (
 const (
 	HypervisorCH          HypervisorType = "cloud-hypervisor"
 	HypervisorFirecracker HypervisorType = "firecracker"
+
+	// defaultPullConns is the default concurrent Range connections per cloud-image download.
+	defaultPullConns = 8
 )
 
 // HypervisorType identifies the selected hypervisor backend.
@@ -36,6 +39,8 @@ type Config struct {
 	StopTimeoutSeconds int `json:"stop_timeout_seconds" mapstructure:"stop_timeout_seconds"`
 	// PoolSize: goroutine pool size for concurrent operations; 0 = runtime.NumCPU().
 	PoolSize int `json:"pool_size" mapstructure:"pool_size"`
+	// PullConns: concurrent HTTP Range connections per cloud-image download; <=0 = 8.
+	PullConns int `json:"pull_conns" mapstructure:"pull_conns"`
 	// CNIConfDir: CNI plugin configuration dir. Default: /etc/cni/net.d.
 	CNIConfDir string `json:"cni_conf_dir" mapstructure:"cni_conf_dir"`
 	// CNIBinDir: CNI plugin binary dir. Default: /opt/cni/bin.
@@ -62,6 +67,11 @@ func (c *Config) Hypervisor() HypervisorType {
 // EffectivePoolSize returns PoolSize if set, otherwise runtime.NumCPU().
 func (c *Config) EffectivePoolSize() int {
 	return utils.PoolSizeOrDefault(c.PoolSize)
+}
+
+// EffectivePullConns returns PullConns if set, otherwise defaultPullConns.
+func (c *Config) EffectivePullConns() int {
+	return utils.OrDefault(c.PullConns, defaultPullConns)
 }
 
 // Validate checks that all config fields are within acceptable ranges.

--- a/images/cloudimg/cloudimg.go
+++ b/images/cloudimg/cloudimg.go
@@ -29,13 +29,14 @@ type CloudImg struct {
 	ops       images.Ops[imageIndex, imageEntry]
 }
 
-func New(ctx context.Context, rootDir string) (*CloudImg, error) {
-	cfg := NewConfig(rootDir)
+// New builds the cloud image backend under rootDir; pullConns <= 0 defaults to 8 concurrent Range connections.
+func New(ctx context.Context, rootDir string, pullConns int) (*CloudImg, error) {
+	cfg := NewConfig(rootDir, pullConns)
 	if err := cfg.EnsureDirs(); err != nil {
 		return nil, fmt.Errorf("ensure dirs: %w", err)
 	}
 
-	log.WithFunc("cloudimg.New").Debug(ctx, "cloud image backend initialized")
+	log.WithFunc("cloudimg.New").Debugf(ctx, "cloud image backend initialized, pull conns: %d", cfg.PullConns)
 
 	store, locker := images.NewStore[imageIndex](cfg.IndexFile(), cfg.IndexLock())
 	c := &CloudImg{

--- a/images/cloudimg/config.go
+++ b/images/cloudimg/config.go
@@ -4,16 +4,23 @@ import (
 	"path/filepath"
 
 	"github.com/cocoonstack/cocoon/images"
+	"github.com/cocoonstack/cocoon/utils"
 )
+
+// defaultPullConns is the default concurrent Range connections per cloud-image download.
+const defaultPullConns = 8
 
 type Config struct {
 	images.BaseConfig
+	// PullConns bounds concurrent HTTP Range connections per cloud-image download.
+	PullConns int
 }
 
-func NewConfig(rootDir string) *Config {
-	return &Config{BaseConfig: images.BaseConfig{
-		RootDir: rootDir, Subdir: "cloudimg", BlobExt: ".qcow2",
-	}}
+func NewConfig(rootDir string, pullConns int) *Config {
+	return &Config{
+		BaseConfig: images.BaseConfig{RootDir: rootDir, Subdir: "cloudimg", BlobExt: ".qcow2"},
+		PullConns:  utils.OrDefault(pullConns, defaultPullConns),
+	}
 }
 
 func (c *Config) EnsureDirs() error {

--- a/images/cloudimg/pull.go
+++ b/images/cloudimg/pull.go
@@ -8,6 +8,9 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/projecteru2/core/log"
@@ -29,27 +32,57 @@ const (
 	progressInterval = 1 << 20
 )
 
-// progressWriter wraps an io.Writer and periodically emits download progress events.
-type progressWriter struct {
-	w          io.Writer
+// progressCounter emits PhaseDownload events every ~1 MiB; mutex-guarded so it
+// serves both the serial writer and parallel range workers.
+type progressCounter struct {
+	mu         sync.Mutex
 	written    int64
+	lastReport int64
 	total      int64
 	tracker    progress.Tracker
-	lastReport int64
 }
 
-func (pw *progressWriter) Write(p []byte) (int, error) {
-	n, err := pw.w.Write(p)
-	pw.written += int64(n)
-	if pw.written-pw.lastReport >= progressInterval {
-		pw.lastReport = pw.written
-		pw.tracker.OnEvent(cloudimgProgress.Event{
+func (pc *progressCounter) add(n int64) {
+	pc.mu.Lock()
+	pc.written += n
+	report := pc.written-pc.lastReport >= progressInterval
+	if report {
+		pc.lastReport = pc.written
+	}
+	done := pc.written
+	pc.mu.Unlock()
+	// Emit outside the lock: the tracker callback is user-supplied and must not
+	// serialize the range workers.
+	if report {
+		pc.tracker.OnEvent(cloudimgProgress.Event{
 			Phase:      cloudimgProgress.PhaseDownload,
-			BytesTotal: pw.total,
-			BytesDone:  pw.written,
+			BytesTotal: pc.total,
+			BytesDone:  done,
 		})
 	}
+}
+
+// countingWriter forwards writes to w while reporting byte counts to a shared progressCounter.
+type countingWriter struct {
+	w  io.Writer
+	pc *progressCounter
+}
+
+func (cw countingWriter) Write(p []byte) (int, error) {
+	n, err := cw.w.Write(p)
+	cw.pc.add(int64(n))
 	return n, err
+}
+
+// byteRange is an inclusive [start, end] byte span for an HTTP Range request.
+type byteRange struct {
+	start, end int64
+}
+
+// rangeProbe carries the resolved URL and total size of a Range-capable source.
+type rangeProbe struct {
+	finalURL string
+	size     int64
 }
 
 // pull commits url as a blob; the URL→blob mapping is idempotent (no-op when the blob already exists).
@@ -104,20 +137,46 @@ func withDownload(
 	defer os.Remove(tmpPath) //nolint:errcheck,gosec
 	defer tmpFile.Close()    //nolint:errcheck,gosec
 
-	digestHex, err := downloadToFile(ctx, url, tmpFile, tracker)
+	digestHex, err := downloadToFile(ctx, url, tmpFile, tracker, conf.PullConns)
 	if err != nil {
 		return err
 	}
 	return fn(tmpFile, tmpPath, digestHex)
 }
 
-func downloadToFile(ctx context.Context, url string, dst *os.File, tracker progress.Tracker) (string, error) {
+// downloadToFile probes whether url supports HTTP Range requests and downloads it into dst
+// accordingly: pullConns concurrent range connections when supported, a single stream otherwise.
+func downloadToFile(ctx context.Context, url string, dst *os.File, tracker progress.Tracker, pullConns int) (string, error) {
+	logger := log.WithFunc("cloudimg.downloadToFile")
+	client := &http.Client{Timeout: urlDownloadTimeout}
+
+	probe, err := probeRangeSupport(ctx, client, url)
+	if err != nil {
+		return "", err
+	}
+	if probe == nil {
+		logger.Debugf(ctx, "range requests not supported for %s, falling back to serial download", url)
+		return downloadSerial(ctx, client, url, dst, tracker)
+	}
+	if probe.size > maxDownloadBytes {
+		return "", fmt.Errorf("download %s: exceeded max size (%d bytes)", url, maxDownloadBytes)
+	}
+
+	logger.Debugf(ctx, "downloading %s in %d parallel range(s)", url, pullConns)
+	if err := downloadRangesParallel(ctx, client, probe.finalURL, dst, probe.size, pullConns, tracker); err != nil {
+		return "", err
+	}
+	return hashDigest(dst)
+}
+
+// downloadSerial streams url into dst over a single connection; used when the server doesn't
+// support Range requests or doesn't report a usable size.
+func downloadSerial(ctx context.Context, client *http.Client, url string, dst *os.File, tracker progress.Tracker) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return "", fmt.Errorf("create http request: %w", err)
 	}
 
-	client := &http.Client{Timeout: urlDownloadTimeout}
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("http get %s: %w", url, err)
@@ -138,7 +197,7 @@ func downloadToFile(ctx context.Context, url string, dst *os.File, tracker progr
 	limitedBody := io.LimitReader(resp.Body, maxDownloadBytes+1)
 	reader := io.TeeReader(limitedBody, h)
 
-	pw := &progressWriter{w: dst, total: contentLength, tracker: tracker}
+	pw := countingWriter{w: dst, pc: &progressCounter{total: contentLength, tracker: tracker}}
 	written, err := io.Copy(pw, reader)
 	if err != nil {
 		return "", fmt.Errorf("download %s: %w", url, err)
@@ -152,4 +211,133 @@ func downloadToFile(ctx context.Context, url string, dst *os.File, tracker progr
 	}
 
 	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// probeRangeSupport issues a GET with Range: bytes=0-0; nil means no usable Range support
+// (fall back to serial). The probe URL is resp.Request.URL (post-redirect) so each range
+// request hits the resolved location without re-following the redirect chain.
+func probeRangeSupport(ctx context.Context, client *http.Client, url string) (*rangeProbe, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create range probe request: %w", err)
+	}
+	req.Header.Set("Range", "bytes=0-0")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("probe range support for %s: %w", url, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusPartialContent {
+		return nil, nil
+	}
+	size, ok := parseContentRangeSize(resp.Header.Get("Content-Range"))
+	if !ok {
+		return nil, nil
+	}
+	return &rangeProbe{finalURL: resp.Request.URL.String(), size: size}, nil
+}
+
+// downloadRangesParallel splits [0,size) into pullConns contiguous ranges and downloads them
+// concurrently into disjoint offsets of dst.
+func downloadRangesParallel(ctx context.Context, client *http.Client, url string, dst *os.File, size int64, pullConns int, tracker progress.Tracker) error {
+	if err := dst.Truncate(size); err != nil {
+		return fmt.Errorf("truncate temp file: %w", err)
+	}
+
+	tracker.OnEvent(cloudimgProgress.Event{Phase: cloudimgProgress.PhaseDownload, BytesTotal: size})
+	pc := &progressCounter{total: size, tracker: tracker}
+
+	ranges := splitRanges(size, pullConns)
+	if _, err := utils.Map(ctx, ranges, func(ctx context.Context, _ int, r byteRange) (struct{}, error) {
+		return struct{}{}, downloadRange(ctx, client, url, dst, r, pc)
+	}, pullConns); err != nil {
+		return fmt.Errorf("download %s: %w", url, err)
+	}
+
+	if err := dst.Sync(); err != nil {
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+
+	tracker.OnEvent(cloudimgProgress.Event{Phase: cloudimgProgress.PhaseDownload, BytesTotal: size, BytesDone: size})
+	return nil
+}
+
+func downloadRange(ctx context.Context, client *http.Client, url string, dst *os.File, r byteRange, pc *progressCounter) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("create range request: %w", err)
+	}
+	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", r.start, r.end))
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("http get range %d-%d: %w", r.start, r.end, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusPartialContent {
+		return fmt.Errorf("http get range %d-%d: status %s", r.start, r.end, resp.Status)
+	}
+	// A mismatched span would land bytes at the wrong offsets; a short body would
+	// leave a zero hole that hashDigest then blesses with a "valid" digest.
+	if cr := resp.Header.Get("Content-Range"); !strings.HasPrefix(cr, fmt.Sprintf("bytes %d-%d/", r.start, r.end)) {
+		return fmt.Errorf("http get range %d-%d: mismatched content-range %q", r.start, r.end, cr)
+	}
+
+	want := r.end - r.start + 1
+	w := countingWriter{w: io.NewOffsetWriter(dst, r.start), pc: pc}
+	n, err := io.Copy(w, io.LimitReader(resp.Body, want))
+	if err != nil {
+		return fmt.Errorf("write range %d-%d: %w", r.start, r.end, err)
+	}
+	if n != want {
+		return fmt.Errorf("http get range %d-%d: short body %d of %d bytes", r.start, r.end, n, want)
+	}
+	return nil
+}
+
+// hashDigest re-reads dst from disk: scattered parallel writes can't feed a streaming
+// hasher, and hashing the file itself verifies what actually landed.
+func hashDigest(dst *os.File) (string, error) {
+	if _, err := dst.Seek(0, io.SeekStart); err != nil {
+		return "", fmt.Errorf("seek temp file: %w", err)
+	}
+	h := sha256.New()
+	if _, err := io.Copy(h, dst); err != nil {
+		return "", fmt.Errorf("hash temp file: %w", err)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// splitRanges divides [0,size) into up to n contiguous, inclusive-ended byte ranges.
+func splitRanges(size int64, n int) []byteRange {
+	chunk := (size + int64(n) - 1) / int64(n)
+	ranges := make([]byteRange, 0, n)
+	for start := int64(0); start < size; start += chunk {
+		end := start + chunk - 1
+		if end >= size {
+			end = size - 1
+		}
+		ranges = append(ranges, byteRange{start: start, end: end})
+	}
+	return ranges
+}
+
+// parseContentRangeSize extracts the total size from a "Content-Range: bytes 0-0/12345" header value.
+func parseContentRangeSize(v string) (int64, bool) {
+	i := strings.LastIndexByte(v, '/')
+	if i < 0 || i+1 >= len(v) {
+		return 0, false
+	}
+	total := v[i+1:]
+	if total == "*" {
+		return 0, false
+	}
+	size, err := strconv.ParseInt(total, 10, 64)
+	if err != nil || size <= 0 {
+		return 0, false
+	}
+	return size, true
 }

--- a/images/cloudimg/pull_test.go
+++ b/images/cloudimg/pull_test.go
@@ -1,0 +1,283 @@
+package cloudimg
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cocoonstack/cocoon/progress"
+	cloudimgProgress "github.com/cocoonstack/cocoon/progress/cloudimg"
+)
+
+func TestDownloadToFileParallelRange(t *testing.T) {
+	data := testPayload(257 * 1024)
+	server := httptest.NewServer(rangeHandler(data, nil))
+	defer server.Close()
+
+	dst := createTempFile(t)
+	digest, err := downloadToFile(t.Context(), server.URL, dst, progress.Nop, 4)
+	if err != nil {
+		t.Fatalf("downloadToFile(): %v", err)
+	}
+	if want := sha256Hex(data); digest != want {
+		t.Errorf("digest = %s, want %s", digest, want)
+	}
+	assertFileContent(t, dst, data)
+}
+
+func TestDownloadToFileFallsBackWhenRangeUnsupported(t *testing.T) {
+	data := testPayload(64 * 1024)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Ignores any Range header and always serves the full body — not Range-capable.
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data)
+	}))
+	defer server.Close()
+
+	dst := createTempFile(t)
+	digest, err := downloadToFile(t.Context(), server.URL, dst, progress.Nop, 4)
+	if err != nil {
+		t.Fatalf("downloadToFile(): %v", err)
+	}
+	if want := sha256Hex(data); digest != want {
+		t.Errorf("digest = %s, want %s", digest, want)
+	}
+	assertFileContent(t, dst, data)
+}
+
+func TestDownloadToFileOneRangeFailureAbortsWhole(t *testing.T) {
+	data := testPayload(4096)
+	secondChunkStart := int64(len(data) / 2)
+	server := httptest.NewServer(rangeHandler(data, func(start, _ int64) bool {
+		return start == secondChunkStart
+	}))
+	defer server.Close()
+
+	dst := createTempFile(t)
+	if _, err := downloadToFile(t.Context(), server.URL, dst, progress.Nop, 2); err == nil {
+		t.Fatal("downloadToFile() = nil error, want failure from the broken range")
+	}
+}
+
+func TestDownloadToFileRejectsOverCapSize(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes 0-0/%d", maxDownloadBytes+1))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write([]byte{0})
+	}))
+	defer server.Close()
+
+	dst := createTempFile(t)
+	if _, err := downloadToFile(t.Context(), server.URL, dst, progress.Nop, 4); err == nil {
+		t.Fatal("downloadToFile() = nil error, want rejection for exceeding max size")
+	}
+}
+
+func TestDownloadToFileEmitsFinalProgressEvent(t *testing.T) {
+	data := testPayload(64 * 1024)
+	server := httptest.NewServer(rangeHandler(data, nil))
+	defer server.Close()
+
+	var lastEvent cloudimgProgress.Event
+	tracker := progress.NewTracker(func(e cloudimgProgress.Event) { lastEvent = e })
+
+	dst := createTempFile(t)
+	if _, err := downloadToFile(t.Context(), server.URL, dst, tracker, 4); err != nil {
+		t.Fatalf("downloadToFile(): %v", err)
+	}
+	if lastEvent.BytesDone != int64(len(data)) || lastEvent.BytesTotal != int64(len(data)) {
+		t.Errorf("final event = %+v, want BytesDone=BytesTotal=%d", lastEvent, len(data))
+	}
+}
+
+// rangeHandler serves data with full HTTP Range support; fail, if non-nil, lets a test force a
+// specific requested range to error out (simulating a mid-download server failure).
+func rangeHandler(data []byte, fail func(start, end int64) bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rangeHeader := r.Header.Get("Range")
+		if rangeHeader == "" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(data)
+			return
+		}
+
+		start, end, ok := parseTestRange(rangeHeader, int64(len(data)))
+		if !ok {
+			http.Error(w, "bad range", http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
+		if fail != nil && fail(start, end) {
+			http.Error(w, "injected failure", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(data)))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(data[start : end+1])
+	})
+}
+
+func parseTestRange(h string, size int64) (start, end int64, ok bool) {
+	h = strings.TrimPrefix(h, "bytes=")
+	parts := strings.SplitN(h, "-", 2)
+	if len(parts) != 2 {
+		return 0, 0, false
+	}
+	start, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	end, err = strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	if end >= size {
+		end = size - 1
+	}
+	return start, end, true
+}
+
+func testPayload(size int) []byte {
+	data := make([]byte, size)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+	return data
+}
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func createTempFile(t *testing.T) *os.File {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "dst-*.img")
+	if err != nil {
+		t.Fatalf("CreateTemp(): %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	return f
+}
+
+func assertFileContent(t *testing.T, f *os.File, want []byte) {
+	t.Helper()
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		t.Fatalf("Seek(): %v", err)
+	}
+	got, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatalf("ReadAll(): %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("file size = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("file content mismatch at byte %d: got %d, want %d", i, got[i], want[i])
+		}
+	}
+}
+
+func TestDownloadToFileUnevenLastRange(t *testing.T) {
+	data := testPayload(257*1024 + 7) // not divisible by 4: exercises the short final range
+	server := httptest.NewServer(rangeHandler(data, nil))
+	defer server.Close()
+
+	dst := createTempFile(t)
+	digest, err := downloadToFile(t.Context(), server.URL, dst, progress.Nop, 4)
+	if err != nil {
+		t.Fatalf("downloadToFile(): %v", err)
+	}
+	if want := sha256Hex(data); digest != want {
+		t.Errorf("digest = %s, want %s", digest, want)
+	}
+	assertFileContent(t, dst, data)
+}
+
+func TestDownloadToFileFollowsRedirectForRanges(t *testing.T) {
+	data := testPayload(64 * 1024)
+	target := httptest.NewServer(rangeHandler(data, nil))
+	defer target.Close()
+
+	var frontRequests atomic.Int64
+	front := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		frontRequests.Add(1)
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer front.Close()
+
+	dst := createTempFile(t)
+	digest, err := downloadToFile(t.Context(), front.URL, dst, progress.Nop, 4)
+	if err != nil {
+		t.Fatalf("downloadToFile(): %v", err)
+	}
+	if want := sha256Hex(data); digest != want {
+		t.Errorf("digest = %s, want %s", digest, want)
+	}
+	assertFileContent(t, dst, data)
+	// Only the probe may hit the front server; range requests go straight to the resolved URL.
+	if n := frontRequests.Load(); n != 1 {
+		t.Errorf("front server saw %d requests, want 1 (probe only)", n)
+	}
+}
+
+func TestDownloadToFileShortRangeBodyFails(t *testing.T) {
+	data := testPayload(64 * 1024)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rangeHeader := r.Header.Get("Range")
+		start, end, ok := parseTestRange(rangeHeader, int64(len(data)))
+		if !ok {
+			http.Error(w, "bad range", http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(data)))
+		w.WriteHeader(http.StatusPartialContent)
+		if start == 0 || end-start < 2 {
+			_, _ = w.Write(data[start : end+1]) // probe and tiny ranges served fully
+			return
+		}
+		// Serve half the promised bytes, then flush to force chunked encoding so
+		// the client sees a clean EOF instead of a Content-Length mismatch.
+		_, _ = w.Write(data[start : start+(end-start)/2])
+		w.(http.Flusher).Flush()
+	}))
+	defer server.Close()
+
+	dst := createTempFile(t)
+	if _, err := downloadToFile(t.Context(), server.URL, dst, progress.Nop, 4); err == nil {
+		t.Fatal("expected error for a short 206 body, got nil (zero-hole corruption)")
+	}
+}
+
+func TestDownloadToFileMismatchedContentRangeFails(t *testing.T) {
+	data := testPayload(64 * 1024)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rangeHeader := r.Header.Get("Range")
+		start, end, ok := parseTestRange(rangeHeader, int64(len(data)))
+		if !ok {
+			http.Error(w, "bad range", http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
+		if start > 0 {
+			start-- // lie about the span actually served
+		}
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(data)))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(data[start : end+1])
+	}))
+	defer server.Close()
+
+	dst := createTempFile(t)
+	if _, err := downloadToFile(t.Context(), server.URL, dst, progress.Nop, 4); err == nil {
+		t.Fatal("expected error for mismatched content-range, got nil")
+	}
+}

--- a/os-image/android/14.0/Dockerfile
+++ b/os-image/android/14.0/Dockerfile
@@ -18,8 +18,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Bumping COCOON_AGENT_VERSION must also update COCOON_AGENT_SHA256 — the
 # sha256sum -c step below fails the build when they drift.
-ARG COCOON_AGENT_VERSION=0.1.5
-ARG COCOON_AGENT_SHA256=4ca52609076efb4d5091d42b4a41533102766568e91d096e8ed25d2f4250ec25
+ARG COCOON_AGENT_VERSION=0.1.6
+ARG COCOON_AGENT_SHA256=f6339ce6fc8d0779642a8a91692d62a06958964f8a723c3644779c435aba2bd7
 
 RUN --mount=type=secret,id=cocoon_overlay \
     --mount=type=secret,id=cocoon_network \

--- a/os-image/android/15.0/Dockerfile
+++ b/os-image/android/15.0/Dockerfile
@@ -18,8 +18,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Bumping COCOON_AGENT_VERSION must also update COCOON_AGENT_SHA256 — the
 # sha256sum -c step below fails the build when they drift.
-ARG COCOON_AGENT_VERSION=0.1.5
-ARG COCOON_AGENT_SHA256=4ca52609076efb4d5091d42b4a41533102766568e91d096e8ed25d2f4250ec25
+ARG COCOON_AGENT_VERSION=0.1.6
+ARG COCOON_AGENT_SHA256=f6339ce6fc8d0779642a8a91692d62a06958964f8a723c3644779c435aba2bd7
 
 RUN --mount=type=secret,id=cocoon_overlay \
     --mount=type=secret,id=cocoon_network \

--- a/os-image/ubuntu/install-agent.sh
+++ b/os-image/ubuntu/install-agent.sh
@@ -7,11 +7,11 @@
 # `systemctl enable` is a no-op when the symlinks are already in place.
 set -eu
 
-AGENT_VERSION="${COCOON_AGENT_VERSION:-0.1.5}"
+AGENT_VERSION="${COCOON_AGENT_VERSION:-0.1.6}"
 ARCH="${TARGETARCH:-$(dpkg --print-architecture)}"
 case "$ARCH" in
-    amd64) AGENT_ARCH="x86_64"; AGENT_SHA256="4ca52609076efb4d5091d42b4a41533102766568e91d096e8ed25d2f4250ec25" ;;
-    arm64) AGENT_ARCH="arm64";  AGENT_SHA256="74a7f53282063b60fa2a8288c40df8ac78f479f403751c729b5e761187a3145d" ;;
+    amd64) AGENT_ARCH="x86_64"; AGENT_SHA256="f6339ce6fc8d0779642a8a91692d62a06958964f8a723c3644779c435aba2bd7" ;;
+    arm64) AGENT_ARCH="arm64";  AGENT_SHA256="7165d2a471940b763d85e10475f44762129810dd01d22beec40984052cae9503" ;;
     *) echo "install-agent: unsupported arch '$ARCH'" >&2; exit 1 ;;
 esac
 

--- a/utils/batch.go
+++ b/utils/batch.go
@@ -88,8 +88,13 @@ func Map[T, R any](ctx context.Context, items []T, fn func(ctx context.Context, 
 
 // PoolSizeOrDefault returns n, or runtime.NumCPU() when n <= 0.
 func PoolSizeOrDefault(n int) int {
+	return OrDefault(n, runtime.NumCPU())
+}
+
+// OrDefault returns n, or def when n <= 0.
+func OrDefault(n, def int) int {
 	if n <= 0 {
-		return runtime.NumCPU()
+		return def
 	}
 	return n
 }


### PR DESCRIPTION
## What

Cloud-image pull was a single serial GET — the whole multi-GB download rode one TCP stream. Now:

- **Probe** `Range: bytes=0-0` → `206` + parseable `Content-Range` total → split the blob across **PullConns** (default 8) concurrent Range connections into a preallocated temp file (`io.NewOffsetWriter`, disjoint offsets, no locking); any range failure aborts the whole download (fail-fast via `utils.Map`)
- **Fallback**: anything else (200, no usable size) → the existing serial stream, behavior unchanged
- Post-download sha256 re-read from disk (parallel writes can't feed a streaming hasher — this also verifies what actually landed)
- Range requests reuse the probe's post-redirect URL, so presigned/CDN redirects keep working
- Per-range `LimitReader` guards against a server over-serving a range (would otherwise overwrite the next region)
- New knob: `pull_conns` (config/json), `EffectivePullConns()`; `cloudimg.New(ctx, rootDir, pullConns)` mirrors `oci.New`'s poolSize shape; the `<=0 → default` rule now has a single owner (`utils.OrDefault`, `PoolSizeOrDefault` delegates)
- Progress: one mutex-guarded `progressCounter` serves both paths (old `progressWriter` deleted); same 1 MiB cadence and event shape, emit outside the lock

Trust boundary note: like the serial path, we don't verify the server's `Content-Range` offset per range — the transport enforces length, and the digest is computed from disk.

## Verification

- 7 unit tests incl. uneven-last-range (clamp branch) and probe-redirect (front server sees exactly 1 request)
- `make lint` 0 issues (linux+darwin), full suite 25 pkgs green, fmt-check clean
- Real-network e2e on bare-metal testbed: ubuntu-24.04-minimal cloudimg (~300 MB) pulled with `pull_conns=8` and `pull_conns=1` → **identical digest** (`bd9023e71b7bb5bd…`), 5.9s vs 8.3s on an already-fast mirror (throttled single-stream sources like ghcr are the real win, per the sibling cocoon-macos data)