### PR TITLE
feat(vm): signal guest CRNG reseed after clone/restore

### DIFF
--- a/cmd/vm/commands.go
+++ b/cmd/vm/commands.go
@@ -28,6 +28,7 @@ type Actions interface {
 	DeviceAttach(cmd *cobra.Command, args []string) error
 	DeviceDetach(cmd *cobra.Command, args []string) error
 	NetResize(cmd *cobra.Command, args []string) error
+	Reseed(cmd *cobra.Command, args []string) error
 }
 
 func Command(h Actions) *cobra.Command {
@@ -112,6 +113,14 @@ func Command(h Actions) *cobra.Command {
 	}
 	execCmd.Flags().StringArrayP("env", "e", nil, "extra env var KEY=VALUE (repeatable)")
 
+	reseedCmd := &cobra.Command{
+		Use:   "reseed VM",
+		Short: "Force a CRNG reseed inside the guest (fresh entropy over vsock)",
+		Args:  cobra.ExactArgs(1),
+		RunE:  h.Reseed,
+	}
+	reseedCmd.Flags().Bool("machine-id", false, "also regenerate /etc/machine-id (use after clone, not restore)")
+
 	logsCmd := &cobra.Command{
 		Use:   "logs [flags] VM",
 		Short: "Print the per-VM hypervisor log file",
@@ -181,6 +190,7 @@ func Command(h Actions) *cobra.Command {
 		inspectCmd,
 		consoleCmd,
 		execCmd,
+		reseedCmd,
 		logsCmd,
 		rmCmd,
 		restoreCmd,

--- a/cmd/vm/exec.go
+++ b/cmd/vm/exec.go
@@ -12,9 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cocoonstack/cocoon-agent/client"
-	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
 	"github.com/cocoonstack/cocoon/hypervisor"
-	"github.com/cocoonstack/cocoon/types"
 )
 
 const hybridVsockReplyMax = 256
@@ -40,16 +38,9 @@ func (h Handler) Exec(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("exec: no command given")
 	}
 
-	hyper, err := cmdcore.FindHypervisor(ctx, conf, ref)
+	info, err := h.resolveRunningVM(ctx, conf, "exec", ref)
 	if err != nil {
-		return fmt.Errorf("exec: %w", err)
-	}
-	info, err := hyper.Inspect(ctx, ref)
-	if err != nil {
-		return fmt.Errorf("exec: inspect: %w", err)
-	}
-	if info.State != types.VMStateRunning {
-		return fmt.Errorf("exec: %w", hypervisor.ErrNotRunning)
+		return err
 	}
 	if info.VsockSocket == "" {
 		return fmt.Errorf("exec: %w (recreate the VM to enable agent exec)", ErrVsockNotConfigured)

--- a/cmd/vm/handler.go
+++ b/cmd/vm/handler.go
@@ -1,7 +1,32 @@
 package vm
 
-import cmdcore "github.com/cocoonstack/cocoon/cmd/core"
+import (
+	"context"
+	"fmt"
+
+	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
+	"github.com/cocoonstack/cocoon/config"
+	"github.com/cocoonstack/cocoon/hypervisor"
+	"github.com/cocoonstack/cocoon/types"
+)
 
 type Handler struct {
 	cmdcore.BaseHandler
+}
+
+// resolveRunningVM finds ref's hypervisor, inspects it, and requires a running VM.
+// op prefixes the wrapped errors (e.g. "exec", "reseed").
+func (h Handler) resolveRunningVM(ctx context.Context, conf *config.Config, op, ref string) (*types.VM, error) {
+	hyper, err := cmdcore.FindHypervisor(ctx, conf, ref)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	info, err := hyper.Inspect(ctx, ref)
+	if err != nil {
+		return nil, fmt.Errorf("%s: inspect: %w", op, err)
+	}
+	if info.State != types.VMStateRunning {
+		return nil, fmt.Errorf("%s: %w", op, hypervisor.ErrNotRunning)
+	}
+	return info, nil
 }

--- a/cmd/vm/reseed.go
+++ b/cmd/vm/reseed.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cocoonstack/cocoon-agent/client"
-	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
 	"github.com/cocoonstack/cocoon/hypervisor"
 	"github.com/cocoonstack/cocoon/types"
 )
@@ -30,16 +29,9 @@ func (h Handler) Reseed(cmd *cobra.Command, args []string) error {
 	ref := args[0]
 	regenMachineID, _ := cmd.Flags().GetBool("machine-id")
 
-	hyper, err := cmdcore.FindHypervisor(ctx, conf, ref)
+	vm, err := h.resolveRunningVM(ctx, conf, "reseed", ref)
 	if err != nil {
-		return fmt.Errorf("reseed: %w", err)
-	}
-	vm, err := hyper.Inspect(ctx, ref)
-	if err != nil {
-		return fmt.Errorf("reseed: inspect: %w", err)
-	}
-	if vm.State != types.VMStateRunning {
-		return fmt.Errorf("reseed: %w", hypervisor.ErrNotRunning)
+		return err
 	}
 	return reseedVM(ctx, vm, regenMachineID)
 }

--- a/cmd/vm/reseed.go
+++ b/cmd/vm/reseed.go
@@ -1,0 +1,98 @@
+package vm
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/projecteru2/core/log"
+	"github.com/spf13/cobra"
+
+	"github.com/cocoonstack/cocoon-agent/client"
+	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
+	"github.com/cocoonstack/cocoon/hypervisor"
+	"github.com/cocoonstack/cocoon/types"
+)
+
+const (
+	reseedEntropyBytes = 32
+	reseedMaxAttempts  = 3
+	reseedRetryDelay   = 2 * time.Second
+)
+
+func (h Handler) Reseed(cmd *cobra.Command, args []string) error {
+	ctx, conf, err := h.Init(cmd)
+	if err != nil {
+		return err
+	}
+	ref := args[0]
+	regenMachineID, _ := cmd.Flags().GetBool("machine-id")
+
+	hyper, err := cmdcore.FindHypervisor(ctx, conf, ref)
+	if err != nil {
+		return fmt.Errorf("reseed: %w", err)
+	}
+	vm, err := hyper.Inspect(ctx, ref)
+	if err != nil {
+		return fmt.Errorf("reseed: inspect: %w", err)
+	}
+	if vm.State != types.VMStateRunning {
+		return fmt.Errorf("reseed: %w", hypervisor.ErrNotRunning)
+	}
+	return reseedVM(ctx, vm, regenMachineID)
+}
+
+// reseedVM pushes fresh entropy and a CRNG reseed order over vsock, retrying because the
+// guest agent re-listens shortly after a clone/restore resume.
+func reseedVM(ctx context.Context, vm *types.VM, regenMachineID bool) error {
+	if vm.VsockSocket == "" {
+		return fmt.Errorf("reseed: %w (recreate the VM to enable agent reseed)", ErrVsockNotConfigured)
+	}
+	entropy := make([]byte, reseedEntropyBytes)
+	if _, err := rand.Read(entropy); err != nil {
+		return fmt.Errorf("reseed: generate entropy: %w", err)
+	}
+
+	var err error
+	for attempt := 1; attempt <= reseedMaxAttempts; attempt++ {
+		if err = ctx.Err(); err != nil {
+			return err
+		}
+		var conn io.ReadWriteCloser
+		if conn, err = dialHybridVsock(ctx, vm.VsockSocket, hypervisor.VsockAgentPort); err == nil {
+			err = client.Reseed(ctx, conn, entropy, regenMachineID)
+			conn.Close() //nolint:errcheck,gosec
+			if err == nil {
+				return nil
+			}
+		}
+		if attempt < reseedMaxAttempts {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(reseedRetryDelay):
+			}
+		}
+	}
+	return fmt.Errorf("reseed: %w", err)
+}
+
+// signalReseed is the non-fatal wrapper called from clone/restore paths: skips silently on
+// Windows guests (agent verb is Linux-only) or legacy VMs without vsock, and never fails the
+// calling command on agent version skew.
+func signalReseed(ctx context.Context, vm *types.VM, regenMachineID bool) {
+	logger := log.WithFunc("cmd.vm.reseed")
+	if vm.Config.Windows {
+		logger.Debug(ctx, "skip reseed signal: Windows guest")
+		return
+	}
+	if vm.VsockSocket == "" {
+		logger.Debug(ctx, "skip reseed signal: vsock not configured")
+		return
+	}
+	if err := reseedVM(ctx, vm, regenMachineID); err != nil {
+		logger.Warnf(ctx, "reseed signal failed (agent >= v0.1.6 required): %v; run 'cocoon vm reseed %s' after fixing", err, vm.ID)
+	}
+}

--- a/cmd/vm/reseed.go
+++ b/cmd/vm/reseed.go
@@ -35,6 +35,13 @@ func (h Handler) Reseed(cmd *cobra.Command, args []string) error {
 	return reseedVM(ctx, vm, regenMachineID)
 }
 
+// reseedAfterResume re-inspects then fires the best-effort reseed. Clone/Restore return a
+// *types.VM built in-process that never passed through ToVM, so its VsockSocket is zero;
+// pairing refresh with signal keeps a caller from silently no-op-ing on a stale value.
+func (h Handler) reseedAfterResume(ctx context.Context, hyper hypervisor.Hypervisor, vm *types.VM, regenMachineID bool) {
+	signalReseed(ctx, refreshVM(ctx, hyper, vm), regenMachineID)
+}
+
 // reseedVM pushes fresh entropy and a CRNG reseed order over vsock. Only a failed
 // dial is retried — the guest agent re-listens shortly after a clone/restore resume;
 // once a live agent answers, its reply (success, version-skew rejection, or failure)
@@ -73,13 +80,6 @@ func reseedVM(ctx context.Context, vm *types.VM, regenMachineID bool) error {
 		return nil
 	}
 	return fmt.Errorf("reseed: dial agent: %w", dialErr)
-}
-
-// reseedAfterResume re-inspects then fires the best-effort reseed. Clone/Restore return a
-// *types.VM built in-process that never passed through ToVM, so its VsockSocket is zero;
-// pairing refresh with signal keeps a caller from silently no-op-ing on a stale value.
-func (h Handler) reseedAfterResume(ctx context.Context, hyper hypervisor.Hypervisor, vm *types.VM, regenMachineID bool) {
-	signalReseed(ctx, refreshVM(ctx, hyper, vm), regenMachineID)
 }
 
 // signalReseed is the non-fatal wrapper for clone/restore paths: it reports whether a reseed

--- a/cmd/vm/reseed.go
+++ b/cmd/vm/reseed.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/projecteru2/core/log"
@@ -36,8 +35,10 @@ func (h Handler) Reseed(cmd *cobra.Command, args []string) error {
 	return reseedVM(ctx, vm, regenMachineID)
 }
 
-// reseedVM pushes fresh entropy and a CRNG reseed order over vsock, retrying because the
-// guest agent re-listens shortly after a clone/restore resume.
+// reseedVM pushes fresh entropy and a CRNG reseed order over vsock. Only a failed
+// dial is retried — the guest agent re-listens shortly after a clone/restore resume;
+// once a live agent answers, its reply (success, version-skew rejection, or failure)
+// is final, so an old agent isn't billed the whole retry budget.
 func reseedVM(ctx context.Context, vm *types.VM, regenMachineID bool) error {
 	if vm.VsockSocket == "" {
 		return fmt.Errorf("reseed: %w (recreate the VM to enable agent reseed)", ErrVsockNotConfigured)
@@ -47,44 +48,66 @@ func reseedVM(ctx context.Context, vm *types.VM, regenMachineID bool) error {
 		return fmt.Errorf("reseed: generate entropy: %w", err)
 	}
 
-	var err error
+	var dialErr error
 	for attempt := 1; attempt <= reseedMaxAttempts; attempt++ {
-		if err = ctx.Err(); err != nil {
+		if err := ctx.Err(); err != nil {
 			return err
 		}
-		var conn io.ReadWriteCloser
-		if conn, err = dialHybridVsock(ctx, vm.VsockSocket, hypervisor.VsockAgentPort); err == nil {
-			err = client.Reseed(ctx, conn, entropy, regenMachineID)
-			conn.Close() //nolint:errcheck,gosec
-			if err == nil {
-				return nil
+		conn, err := dialHybridVsock(ctx, vm.VsockSocket, hypervisor.VsockAgentPort)
+		if err != nil {
+			dialErr = err
+			if attempt < reseedMaxAttempts {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(reseedRetryDelay):
+				}
 			}
+			continue
 		}
-		if attempt < reseedMaxAttempts {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(reseedRetryDelay):
-			}
+		err = client.Reseed(ctx, conn, entropy, regenMachineID)
+		conn.Close() //nolint:errcheck,gosec
+		if err != nil {
+			return fmt.Errorf("reseed: %w", err)
 		}
+		return nil
 	}
-	return fmt.Errorf("reseed: %w", err)
+	return fmt.Errorf("reseed: dial agent: %w", dialErr)
 }
 
-// signalReseed is the non-fatal wrapper called from clone/restore paths: skips silently on
-// Windows guests (agent verb is Linux-only) or legacy VMs without vsock, and never fails the
-// calling command on agent version skew.
-func signalReseed(ctx context.Context, vm *types.VM, regenMachineID bool) {
+// reseedAfterResume re-inspects then fires the best-effort reseed. Clone/Restore return a
+// *types.VM built in-process that never passed through ToVM, so its VsockSocket is zero;
+// pairing refresh with signal keeps a caller from silently no-op-ing on a stale value.
+func (h Handler) reseedAfterResume(ctx context.Context, hyper hypervisor.Hypervisor, vm *types.VM, regenMachineID bool) {
+	signalReseed(ctx, refreshVM(ctx, hyper, vm), regenMachineID)
+}
+
+// signalReseed is the non-fatal wrapper for clone/restore paths: it reports whether a reseed
+// was attempted (false = skipped for a Windows guest or a legacy VM without vsock) and never
+// fails the calling command on agent version skew.
+func signalReseed(ctx context.Context, vm *types.VM, regenMachineID bool) bool {
 	logger := log.WithFunc("cmd.vm.reseed")
 	if vm.Config.Windows {
 		logger.Debug(ctx, "skip reseed signal: Windows guest")
-		return
+		return false
 	}
 	if vm.VsockSocket == "" {
 		logger.Debug(ctx, "skip reseed signal: vsock not configured")
-		return
+		return false
 	}
 	if err := reseedVM(ctx, vm, regenMachineID); err != nil {
 		logger.Warnf(ctx, "reseed signal failed (agent >= v0.1.6 required): %v; run 'cocoon vm reseed %s' after fixing", err, vm.ID)
 	}
+	return true
+}
+
+// refreshVM re-inspects to recover runtime-only fields (VsockSocket, PID, SocketPath) that
+// ToVM sets but Clone/Restore's in-process return value lacks; keeps the original on error.
+func refreshVM(ctx context.Context, hyper hypervisor.Hypervisor, vm *types.VM) *types.VM {
+	info, err := hyper.Inspect(ctx, vm.ID)
+	if err != nil {
+		log.WithFunc("cmd.vm.reseed").Debugf(ctx, "refresh VM %s before reseed: %v", vm.ID, err)
+		return vm
+	}
+	return info
 }

--- a/cmd/vm/reseed_test.go
+++ b/cmd/vm/reseed_test.go
@@ -1,0 +1,36 @@
+package vm
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/cocoonstack/cocoon/types"
+)
+
+func TestSignalReseed_SkipsWindows(t *testing.T) {
+	vm := &types.VM{ID: "vm1", Config: types.VMConfig{Config: types.Config{Windows: true}}, VsockSocket: "/tmp/whatever.sock"}
+	signalReseed(t.Context(), vm, true)
+}
+
+func TestSignalReseed_SkipsNoVsock(t *testing.T) {
+	vm := &types.VM{ID: "vm1"}
+	signalReseed(t.Context(), vm, true)
+}
+
+func TestReseedVM_NoVsock(t *testing.T) {
+	vm := &types.VM{ID: "vm1"}
+	err := reseedVM(t.Context(), vm, false)
+	if !errors.Is(err, ErrVsockNotConfigured) {
+		t.Fatalf("got err=%v, want ErrVsockNotConfigured", err)
+	}
+}
+
+func TestReseedVM_CtxCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	vm := &types.VM{ID: "vm1", VsockSocket: "/tmp/does-not-matter.sock"}
+	if err := reseedVM(ctx, vm, false); !errors.Is(err, context.Canceled) {
+		t.Fatalf("got err=%v, want context.Canceled", err)
+	}
+}

--- a/cmd/vm/reseed_test.go
+++ b/cmd/vm/reseed_test.go
@@ -9,13 +9,18 @@ import (
 )
 
 func TestSignalReseed_SkipsWindows(t *testing.T) {
+	// VsockSocket is set: a regressed Windows guard would fall through to a dial instead of skipping.
 	vm := &types.VM{ID: "vm1", Config: types.VMConfig{Config: types.Config{Windows: true}}, VsockSocket: "/tmp/whatever.sock"}
-	signalReseed(t.Context(), vm, true)
+	if signalReseed(t.Context(), vm, true) {
+		t.Error("attempted reseed on a Windows guest, want skip")
+	}
 }
 
 func TestSignalReseed_SkipsNoVsock(t *testing.T) {
 	vm := &types.VM{ID: "vm1"}
-	signalReseed(t.Context(), vm, true)
+	if signalReseed(t.Context(), vm, true) {
+		t.Error("attempted reseed with no vsock, want skip")
+	}
 }
 
 func TestReseedVM_NoVsock(t *testing.T) {

--- a/cmd/vm/run.go
+++ b/cmd/vm/run.go
@@ -104,7 +104,7 @@ func (h Handler) Clone(cmd *cobra.Command, args []string) error {
 
 	if da, ok := snapBackend.(snapshot.Direct); ok {
 		if dcr, ok := hyper.(hypervisor.Direct); ok {
-			return h.cloneDirect(ctx, cmd, conf, dcr, da, snapRef, logger)
+			return h.cloneDirect(ctx, cmd, conf, hyper, dcr, da, snapRef, logger)
 		}
 	}
 
@@ -127,7 +127,7 @@ func (h Handler) Clone(cmd *cobra.Command, args []string) error {
 		rollbackNetwork(ctx, netProvider, vmID)
 		return fmt.Errorf("clone VM: %w", cloneErr)
 	}
-	signalReseed(ctx, vm, true)
+	signalReseed(ctx, refreshVM(ctx, hyper, vm), true)
 
 	if done, jsonErr := cliutil.MaybeOutputJSON(cmd, vm); done {
 		return jsonErr
@@ -197,7 +197,7 @@ func (h Handler) Restore(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("restore: %w", err)
 	}
-	signalReseed(ctx, result, false)
+	signalReseed(ctx, refreshVM(ctx, hyper, result), false)
 
 	if done, jsonErr := cliutil.MaybeOutputJSON(cmd, result); done {
 		return jsonErr
@@ -235,16 +235,16 @@ func (h Handler) restoreFromDir(ctx context.Context, cmd *cobra.Command, conf *c
 	if err != nil {
 		return err
 	}
-	return h.runDirectRestore(ctx, cmd, dcr, vmRef, vmCfg, dir, cfg.ID,
+	return h.runDirectRestore(ctx, cmd, hyper, dcr, vmRef, vmCfg, dir, cfg.ID,
 		fmt.Sprintf("dir %s", dir), logger)
 }
 
-func (h Handler) cloneDirect(ctx context.Context, cmd *cobra.Command, conf *config.Config, dcr hypervisor.Direct, da snapshot.Direct, snapRef string, logger *log.Fields) error {
+func (h Handler) cloneDirect(ctx context.Context, cmd *cobra.Command, conf *config.Config, hyper hypervisor.Hypervisor, dcr hypervisor.Direct, da snapshot.Direct, snapRef string, logger *log.Fields) error {
 	dataDir, cfg, err := da.DataDir(ctx, snapRef)
 	if err != nil {
 		return fmt.Errorf("open snapshot %s: %w", snapRef, err)
 	}
-	return h.cloneFromSrcDir(ctx, cmd, conf, dcr, cfg, dataDir,
+	return h.cloneFromSrcDir(ctx, cmd, conf, hyper, dcr, cfg, dataDir,
 		fmt.Sprintf("snapshot %s (direct)", snapRef), logger)
 }
 
@@ -270,11 +270,11 @@ func (h Handler) cloneFromDir(ctx context.Context, cmd *cobra.Command, conf *con
 	if !ok {
 		return fmt.Errorf("backend %s does not support direct clone", hyper.Type())
 	}
-	return h.cloneFromSrcDir(ctx, cmd, &localConf, dcr, cfg, dir,
+	return h.cloneFromSrcDir(ctx, cmd, &localConf, hyper, dcr, cfg, dir,
 		fmt.Sprintf("dir %s", dir), logger)
 }
 
-func (h Handler) cloneFromSrcDir(ctx context.Context, cmd *cobra.Command, conf *config.Config, dcr hypervisor.Direct, cfg types.SnapshotConfig, srcDir, sourceLabel string, logger *log.Fields) error {
+func (h Handler) cloneFromSrcDir(ctx context.Context, cmd *cobra.Command, conf *config.Config, hyper hypervisor.Hypervisor, dcr hypervisor.Direct, cfg types.SnapshotConfig, srcDir, sourceLabel string, logger *log.Fields) error {
 	vmCfg, vmID, netProvider, netSetup, err := h.prepareClone(ctx, cmd, conf, cfg)
 	if err != nil {
 		return err
@@ -290,7 +290,7 @@ func (h Handler) cloneFromSrcDir(ctx context.Context, cmd *cobra.Command, conf *
 		rollbackNetwork(ctx, netProvider, vmID)
 		return fmt.Errorf("clone VM: %w", cloneErr)
 	}
-	signalReseed(ctx, vm, true)
+	signalReseed(ctx, refreshVM(ctx, hyper, vm), true)
 
 	if wantJSON {
 		return cliutil.OutputJSON(vm)
@@ -350,12 +350,12 @@ func (h Handler) restoreDirect(ctx context.Context, cmd *cobra.Command, snapRef,
 	if err != nil {
 		return true, fmt.Errorf("open snapshot: %w", err)
 	}
-	return true, h.runDirectRestore(ctx, cmd, dcr, vmRef, vmCfg, dataDir, snapCfg.ID,
+	return true, h.runDirectRestore(ctx, cmd, hyper, dcr, vmRef, vmCfg, dataDir, snapCfg.ID,
 		fmt.Sprintf("snapshot %s", snapRef), logger)
 }
 
 // runDirectRestore is the shared tail for the snapshot-DB and --from-dir restore paths: log, DirectRestore, output.
-func (h Handler) runDirectRestore(ctx context.Context, cmd *cobra.Command, dcr hypervisor.Direct, vmRef string, vmCfg *types.VMConfig, srcDir, sourceSnapshotID, sourceLabel string, logger *log.Fields) error {
+func (h Handler) runDirectRestore(ctx context.Context, cmd *cobra.Command, hyper hypervisor.Hypervisor, dcr hypervisor.Direct, vmRef string, vmCfg *types.VMConfig, srcDir, sourceSnapshotID, sourceLabel string, logger *log.Fields) error {
 	wantJSON := cliutil.WantJSON(cmd)
 	if !wantJSON {
 		logger.Infof(ctx, "restoring VM %s from %s (direct) ...", vmRef, sourceLabel)
@@ -364,7 +364,7 @@ func (h Handler) runDirectRestore(ctx context.Context, cmd *cobra.Command, dcr h
 	if err != nil {
 		return fmt.Errorf("restore: %w", err)
 	}
-	signalReseed(ctx, result, false)
+	signalReseed(ctx, refreshVM(ctx, hyper, result), false)
 	if wantJSON {
 		return cliutil.OutputJSON(result)
 	}
@@ -499,6 +499,16 @@ func rollbackNetwork(ctx context.Context, netProvider network.Network, vmID stri
 	if _, delErr := netProvider.Delete(ctx, []string{vmID}); delErr != nil {
 		log.WithFunc("cmd.vm.rollbackNetwork").Warnf(ctx, "rollback network for %s: %v", vmID, delErr)
 	}
+}
+
+// refreshVM re-inspects after clone/restore: the value Clone/Restore return is built in-process and
+// never passes through ToVM, so runtime-only fields (VsockSocket, PID, SocketPath) are still zero.
+// Falls back to the original value if inspect fails.
+func refreshVM(ctx context.Context, hyper hypervisor.Hypervisor, vm *types.VM) *types.VM {
+	if info, err := hyper.Inspect(ctx, vm.ID); err == nil {
+		return info
+	}
+	return vm
 }
 
 func printPostCloneHints(vm *types.VM) {

--- a/cmd/vm/run.go
+++ b/cmd/vm/run.go
@@ -127,7 +127,7 @@ func (h Handler) Clone(cmd *cobra.Command, args []string) error {
 		rollbackNetwork(ctx, netProvider, vmID)
 		return fmt.Errorf("clone VM: %w", cloneErr)
 	}
-	signalReseed(ctx, refreshVM(ctx, hyper, vm), true)
+	h.reseedAfterResume(ctx, hyper, vm, true)
 
 	if done, jsonErr := cliutil.MaybeOutputJSON(cmd, vm); done {
 		return jsonErr
@@ -197,7 +197,7 @@ func (h Handler) Restore(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("restore: %w", err)
 	}
-	signalReseed(ctx, refreshVM(ctx, hyper, result), false)
+	h.reseedAfterResume(ctx, hyper, result, false)
 
 	if done, jsonErr := cliutil.MaybeOutputJSON(cmd, result); done {
 		return jsonErr
@@ -290,7 +290,7 @@ func (h Handler) cloneFromSrcDir(ctx context.Context, cmd *cobra.Command, conf *
 		rollbackNetwork(ctx, netProvider, vmID)
 		return fmt.Errorf("clone VM: %w", cloneErr)
 	}
-	signalReseed(ctx, refreshVM(ctx, hyper, vm), true)
+	h.reseedAfterResume(ctx, hyper, vm, true)
 
 	if wantJSON {
 		return cliutil.OutputJSON(vm)
@@ -364,7 +364,7 @@ func (h Handler) runDirectRestore(ctx context.Context, cmd *cobra.Command, hyper
 	if err != nil {
 		return fmt.Errorf("restore: %w", err)
 	}
-	signalReseed(ctx, refreshVM(ctx, hyper, result), false)
+	h.reseedAfterResume(ctx, hyper, result, false)
 	if wantJSON {
 		return cliutil.OutputJSON(result)
 	}
@@ -499,16 +499,6 @@ func rollbackNetwork(ctx context.Context, netProvider network.Network, vmID stri
 	if _, delErr := netProvider.Delete(ctx, []string{vmID}); delErr != nil {
 		log.WithFunc("cmd.vm.rollbackNetwork").Warnf(ctx, "rollback network for %s: %v", vmID, delErr)
 	}
-}
-
-// refreshVM re-inspects after clone/restore: the value Clone/Restore return is built in-process and
-// never passes through ToVM, so runtime-only fields (VsockSocket, PID, SocketPath) are still zero.
-// Falls back to the original value if inspect fails.
-func refreshVM(ctx context.Context, hyper hypervisor.Hypervisor, vm *types.VM) *types.VM {
-	if info, err := hyper.Inspect(ctx, vm.ID); err == nil {
-		return info
-	}
-	return vm
 }
 
 func printPostCloneHints(vm *types.VM) {

--- a/cmd/vm/run.go
+++ b/cmd/vm/run.go
@@ -127,6 +127,7 @@ func (h Handler) Clone(cmd *cobra.Command, args []string) error {
 		rollbackNetwork(ctx, netProvider, vmID)
 		return fmt.Errorf("clone VM: %w", cloneErr)
 	}
+	signalReseed(ctx, vm, true)
 
 	if done, jsonErr := cliutil.MaybeOutputJSON(cmd, vm); done {
 		return jsonErr
@@ -196,6 +197,7 @@ func (h Handler) Restore(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("restore: %w", err)
 	}
+	signalReseed(ctx, result, false)
 
 	if done, jsonErr := cliutil.MaybeOutputJSON(cmd, result); done {
 		return jsonErr
@@ -288,6 +290,7 @@ func (h Handler) cloneFromSrcDir(ctx context.Context, cmd *cobra.Command, conf *
 		rollbackNetwork(ctx, netProvider, vmID)
 		return fmt.Errorf("clone VM: %w", cloneErr)
 	}
+	signalReseed(ctx, vm, true)
 
 	if wantJSON {
 		return cliutil.OutputJSON(vm)
@@ -361,6 +364,7 @@ func (h Handler) runDirectRestore(ctx context.Context, cmd *cobra.Command, dcr h
 	if err != nil {
 		return fmt.Errorf("restore: %w", err)
 	}
+	signalReseed(ctx, result, false)
 	if wantJSON {
 		return cliutil.OutputJSON(result)
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cocoonstack/cocoon
 go 1.26.4
 
 require (
-	github.com/cocoonstack/cocoon-agent v0.1.6
+	github.com/cocoonstack/cocoon-agent v0.1.7
 	github.com/containernetworking/cni v1.3.0
 	github.com/containernetworking/plugins v1.9.0
 	github.com/creack/pty v1.1.24

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cocoonstack/cocoon
 go 1.26.4
 
 require (
-	github.com/cocoonstack/cocoon-agent v0.1.1-0.20260505130343-db13d35d7b13
+	github.com/cocoonstack/cocoon-agent v0.1.6
 	github.com/containernetworking/cni v1.3.0
 	github.com/containernetworking/plugins v1.9.0
 	github.com/creack/pty v1.1.24

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b h1:r6VH0faHjZe
 github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b/go.mod h1:Vz9DsVWQQhf3vs21MhPMZpMGSht7O/2vFW2xusFUVOs=
 github.com/cockroachdb/redact v1.1.5 h1:u1PMllDkdFfPWaNGMyLD1+so+aq3uUItthCFqzwPJ30=
 github.com/cockroachdb/redact v1.1.5/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
-github.com/cocoonstack/cocoon-agent v0.1.1-0.20260505130343-db13d35d7b13 h1:/hJYLC0uOuK6umFiWVXxwH9BbmTUUsx57neYQCP5WqE=
-github.com/cocoonstack/cocoon-agent v0.1.1-0.20260505130343-db13d35d7b13/go.mod h1:s2pwhiZASfKOsJdsoLeIoZ8dxV6PrzNZfCsTSHWvCjM=
+github.com/cocoonstack/cocoon-agent v0.1.6 h1:HVSYdtmYjCVd6qlUJfpD/nnd5VUYs2aX51If78xEMTc=
+github.com/cocoonstack/cocoon-agent v0.1.6/go.mod h1:gKIfL2r6VvHHo2z6OpLb8qxwupFX6ApIGNwfP0ltrs8=
 github.com/containerd/stargz-snapshotter/estargz v0.18.2 h1:yXkZFYIzz3eoLwlTUZKz2iQ4MrckBxJjkmD16ynUTrw=
 github.com/containerd/stargz-snapshotter/estargz v0.18.2/go.mod h1:XyVU5tcJ3PRpkA9XS2T5us6Eg35yM0214Y+wvrZTBrY=
 github.com/containernetworking/cni v1.3.0 h1:v6EpN8RznAZj9765HhXQrtXgX+ECGebEYEmnuFjskwo=

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b h1:r6VH0faHjZe
 github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b/go.mod h1:Vz9DsVWQQhf3vs21MhPMZpMGSht7O/2vFW2xusFUVOs=
 github.com/cockroachdb/redact v1.1.5 h1:u1PMllDkdFfPWaNGMyLD1+so+aq3uUItthCFqzwPJ30=
 github.com/cockroachdb/redact v1.1.5/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
-github.com/cocoonstack/cocoon-agent v0.1.6 h1:HVSYdtmYjCVd6qlUJfpD/nnd5VUYs2aX51If78xEMTc=
-github.com/cocoonstack/cocoon-agent v0.1.6/go.mod h1:gKIfL2r6VvHHo2z6OpLb8qxwupFX6ApIGNwfP0ltrs8=
+github.com/cocoonstack/cocoon-agent v0.1.7 h1:lPoN/IBEJUdWph030qkyRUc9MY64DhuJ5XrYNjdoUKk=
+github.com/cocoonstack/cocoon-agent v0.1.7/go.mod h1:gKIfL2r6VvHHo2z6OpLb8qxwupFX6ApIGNwfP0ltrs8=
 github.com/containerd/stargz-snapshotter/estargz v0.18.2 h1:yXkZFYIzz3eoLwlTUZKz2iQ4MrckBxJjkmD16ynUTrw=
 github.com/containerd/stargz-snapshotter/estargz v0.18.2/go.mod h1:XyVU5tcJ3PRpkA9XS2T5us6Eg35yM0214Y+wvrZTBrY=
 github.com/containernetworking/cni v1.3.0 h1:v6EpN8RznAZj9765HhXQrtXgX+ECGebEYEmnuFjskwo=

--- a/os-image/android/14.0/Dockerfile
+++ b/os-image/android/14.0/Dockerfile
@@ -19,7 +19,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Bumping COCOON_AGENT_VERSION must also update COCOON_AGENT_SHA256 — the
 # sha256sum -c step below fails the build when they drift.
 ARG COCOON_AGENT_VERSION=0.1.6
-ARG COCOON_AGENT_SHA256=f6339ce6fc8d0779642a8a91692d62a06958964f8a723c3644779c435aba2bd7
+ARG COCOON_AGENT_SHA256=7b4f80c6f66fdb31437670ac11cc5cbe64b7e9b48e88f37eb75275acb6ceda69
 
 RUN --mount=type=secret,id=cocoon_overlay \
     --mount=type=secret,id=cocoon_network \

--- a/os-image/android/14.0/Dockerfile
+++ b/os-image/android/14.0/Dockerfile
@@ -18,8 +18,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Bumping COCOON_AGENT_VERSION must also update COCOON_AGENT_SHA256 — the
 # sha256sum -c step below fails the build when they drift.
-ARG COCOON_AGENT_VERSION=0.1.6
-ARG COCOON_AGENT_SHA256=7b4f80c6f66fdb31437670ac11cc5cbe64b7e9b48e88f37eb75275acb6ceda69
+ARG COCOON_AGENT_VERSION=0.1.7
+ARG COCOON_AGENT_SHA256=210f34043d1def6f06f7b4a3722feb1bc6e46368d6419d264b7bb03bfc22cda0
 
 RUN --mount=type=secret,id=cocoon_overlay \
     --mount=type=secret,id=cocoon_network \

--- a/os-image/android/15.0/Dockerfile
+++ b/os-image/android/15.0/Dockerfile
@@ -19,7 +19,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Bumping COCOON_AGENT_VERSION must also update COCOON_AGENT_SHA256 — the
 # sha256sum -c step below fails the build when they drift.
 ARG COCOON_AGENT_VERSION=0.1.6
-ARG COCOON_AGENT_SHA256=f6339ce6fc8d0779642a8a91692d62a06958964f8a723c3644779c435aba2bd7
+ARG COCOON_AGENT_SHA256=7b4f80c6f66fdb31437670ac11cc5cbe64b7e9b48e88f37eb75275acb6ceda69
 
 RUN --mount=type=secret,id=cocoon_overlay \
     --mount=type=secret,id=cocoon_network \

--- a/os-image/android/15.0/Dockerfile
+++ b/os-image/android/15.0/Dockerfile
@@ -18,8 +18,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Bumping COCOON_AGENT_VERSION must also update COCOON_AGENT_SHA256 — the
 # sha256sum -c step below fails the build when they drift.
-ARG COCOON_AGENT_VERSION=0.1.6
-ARG COCOON_AGENT_SHA256=7b4f80c6f66fdb31437670ac11cc5cbe64b7e9b48e88f37eb75275acb6ceda69
+ARG COCOON_AGENT_VERSION=0.1.7
+ARG COCOON_AGENT_SHA256=210f34043d1def6f06f7b4a3722feb1bc6e46368d6419d264b7bb03bfc22cda0
 
 RUN --mount=type=secret,id=cocoon_overlay \
     --mount=type=secret,id=cocoon_network \

--- a/os-image/ubuntu/install-agent.sh
+++ b/os-image/ubuntu/install-agent.sh
@@ -10,8 +10,8 @@ set -eu
 AGENT_VERSION="${COCOON_AGENT_VERSION:-0.1.6}"
 ARCH="${TARGETARCH:-$(dpkg --print-architecture)}"
 case "$ARCH" in
-    amd64) AGENT_ARCH="x86_64"; AGENT_SHA256="f6339ce6fc8d0779642a8a91692d62a06958964f8a723c3644779c435aba2bd7" ;;
-    arm64) AGENT_ARCH="arm64";  AGENT_SHA256="7165d2a471940b763d85e10475f44762129810dd01d22beec40984052cae9503" ;;
+    amd64) AGENT_ARCH="x86_64"; AGENT_SHA256="7b4f80c6f66fdb31437670ac11cc5cbe64b7e9b48e88f37eb75275acb6ceda69" ;;
+    arm64) AGENT_ARCH="arm64";  AGENT_SHA256="27aaa08b9b75f5f8851e1dae7be332cec18f729ea2e05408ef5485c3f9bc452d" ;;
     *) echo "install-agent: unsupported arch '$ARCH'" >&2; exit 1 ;;
 esac
 

--- a/os-image/ubuntu/install-agent.sh
+++ b/os-image/ubuntu/install-agent.sh
@@ -7,11 +7,11 @@
 # `systemctl enable` is a no-op when the symlinks are already in place.
 set -eu
 
-AGENT_VERSION="${COCOON_AGENT_VERSION:-0.1.6}"
+AGENT_VERSION="${COCOON_AGENT_VERSION:-0.1.7}"
 ARCH="${TARGETARCH:-$(dpkg --print-architecture)}"
 case "$ARCH" in
-    amd64) AGENT_ARCH="x86_64"; AGENT_SHA256="7b4f80c6f66fdb31437670ac11cc5cbe64b7e9b48e88f37eb75275acb6ceda69" ;;
-    arm64) AGENT_ARCH="arm64";  AGENT_SHA256="27aaa08b9b75f5f8851e1dae7be332cec18f729ea2e05408ef5485c3f9bc452d" ;;
+    amd64) AGENT_ARCH="x86_64"; AGENT_SHA256="210f34043d1def6f06f7b4a3722feb1bc6e46368d6419d264b7bb03bfc22cda0" ;;
+    arm64) AGENT_ARCH="arm64";  AGENT_SHA256="4728ca3d3221ed27cfa08b6e8c497fbfee45b8c0f509778a7bf7291a18206111" ;;
     *) echo "install-agent: unsupported arch '$ARCH'" >&2; exit 1 ;;
 esac
 


### PR DESCRIPTION
## What

Closes the host side of M1 reseed. After clone/restore, N guests share byte-identical snapshot memory → byte-identical CRNG state (colliding TLS keys/UUIDs). cocoon now sends 32 bytes of `crypto/rand` entropy + a reseed order to cocoon-agent (v0.1.6, `client.Reseed`) over the existing hybrid-vsock channel.

- **`cocoon vm reseed VM [--machine-id]`** — manual verb (fails loudly)
- **Auto-signal** wired into every clone success path (`regen_machine_id=true`) and restore (`false` — same VM identity, only CRNG rotates), as a **non-fatal** `signalReseed`: skips Windows (agent verb is Linux-only) and legacy no-vsock VMs; on agent version skew logs exactly one WARN pointing at the manual verb, never fails the command
- **`refreshVM`**: the `*types.VM` that `Clone`/`Restore` return is built in-process and never passes through `ToVM`, so `VsockSocket` was always zero → `signalReseed` would silently skip on every real clone. Re-Inspect before signaling. (Bug found during e2e.)
- `resolveRunningVM` extracted — `exec` and `reseed` shared the resolve+inspect+running-check ceremony verbatim
- go.mod: cocoon-agent → v0.1.6

FC guests also carry VMGenID (kernel auto-reseed on resume) so this is belt-and-suspenders there; on CH it's the only reseed.

## Verification (e2e on bare-metal 79, isolated store, audit-logged)

- **Clone (CNI)**: reseed fired silently, clone healthy, exec OK
- **Restore (in-place)**: no signal-induced change — `/etc/machine-id` byte+mtime identical (regen=false correctly skips machine-id)
- **Degradation**: guest downgraded to agent v0.1.5 → exactly one WARN (`expected first frame type "exec", got "reseed"`), clone otherwise healthy
- **Manual verb**: exit 0 both ways; mtime confirms `--machine-id` threads through
- `make lint` 0×2, 25 pkgs green, `make fmt-check` clean

## Known follow-up (not this PR)

The CRNG entropy/reseed ioctls (the security-critical mechanism) work with agent **v0.1.6**. But `--machine-id` regen does **not** yet change the id end-to-end: agent v0.1.6 truncates `/etc/machine-id` but not the baked `/var/lib/dbus/machine-id`, so `systemd-machine-id-setup` re-adopts the stale copy. Fixed separately in cocoon-agent (dbus copy removal) → needs a v0.1.7 bump. This PR's host plumbing is correct and version-independent; machine-id regen lights up once the agent is bumped.