### PR TITLE
fix(hypervisor): don't warn 'killed orphan VMM' for a just-force-stopped VM

### DIFF
--- a/hypervisor/stop.go
+++ b/hypervisor/stop.go
@@ -97,6 +97,11 @@ func (b *Backend) DeleteAll(ctx context.Context, refs []string, force bool, stop
 			return fmt.Errorf("refuse delete: api socket %s still responsive (suspected orphan vmm; kill the vmm process then retry)", sockPath)
 		}
 		for _, pid := range procScan.Find(sockPath) {
+			// procScan is a pre-stopOne snapshot: a just-force-stopped VM is already gone.
+			// Only a still-live match is a real orphan worth killing and logging.
+			if !utils.IsProcessAlive(pid) {
+				continue
+			}
 			if termErr := utils.TerminateProcess(ctx, pid, b.Conf.BinaryName(), sockPath, b.Conf.TerminateGracePeriod()); termErr != nil {
 				return fmt.Errorf("terminate orphan VMM pid=%d for VM %s: %w", pid, id, termErr)
 			}


### PR DESCRIPTION
## The false positive

`DeleteAll` (hypervisor/stop.go) takes **one `/proc` snapshot up front** (one walk for N VMs), then per VM: force-stops the process via `stopOne` (which `TerminateProcess` SIGTERM→wait→SIGKILLs to completion), then scans that **stale** snapshot for leftover VMMs. So a `vm rm --force` of a *running* VM re-finds the pid it just terminated — `TerminateProcess` no-ops on the already-dead pid, but the code then unconditionally logs `killed orphan VMM pid=… func=firecracker.Delete`. Fires on **every** force-rm of a running FC VM (surfaced during the FC v1.16 race e2e — 11/11 deletes warned).

## Fix

Gate the terminate+warn on a live `utils.IsProcessAlive(pid)` check. A pid from the pre-`stopOne` snapshot that has since exited is skipped silently; only a genuinely still-alive VMM (a real leaked orphan) is terminated and logged. Backend-agnostic (shared path; CH's fork-vmm delete hits the same code).

## Verified on bare metal (before/after, isolated stores, cleaned up)

| binary | force-rm running FC VM | leftover |
|---|---|---|
| fleet v0.4.5 (unfixed) | `WRN killed orphan VMM pid=79909 … func=firecracker.Delete` | 0 |
| this branch | **no warning** (clean force-rm) | 0 |

Delete still removes the VM in both cases — only the spurious warning is gone. `make lint` 0×2, 25 pkgs green.