### PR TITLE
fix: clamp pull_conns + surface silent reseed skips + test retry rule

### DIFF
--- a/cmd/vm/reseed.go
+++ b/cmd/vm/reseed.go
@@ -92,7 +92,8 @@ func signalReseed(ctx context.Context, vm *types.VM, regenMachineID bool) bool {
 		return false
 	}
 	if vm.VsockSocket == "" {
-		logger.Debug(ctx, "skip reseed signal: vsock not configured")
+		// Not Debug: a legacy VM silently keeps the snapshot's CRNG state.
+		logger.Warnf(ctx, "skip reseed for %s: no vsock; this clone keeps the snapshot's CRNG state — recreate the VM to enable the agent", vm.ID)
 		return false
 	}
 	if err := reseedVM(ctx, vm, regenMachineID); err != nil {

--- a/cmd/vm/reseed_test.go
+++ b/cmd/vm/reseed_test.go
@@ -1,9 +1,18 @@
 package vm
 
 import (
+	"bufio"
 	"context"
 	"errors"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
 	"testing"
+
+	"github.com/cocoonstack/cocoon-agent/agent"
 
 	"github.com/cocoonstack/cocoon/types"
 )
@@ -37,5 +46,53 @@ func TestReseedVM_CtxCanceled(t *testing.T) {
 	vm := &types.VM{ID: "vm1", VsockSocket: "/tmp/does-not-matter.sock"}
 	if err := reseedVM(ctx, vm, false); !errors.Is(err, context.Canceled) {
 		t.Fatalf("got err=%v, want context.Canceled", err)
+	}
+}
+
+// TestReseedVM_AgentRejectionNotRetried pins the dial-vs-rejection distinction:
+// once the agent answers, its reply is final and must not be billed the retry budget.
+func TestReseedVM_AgentRejectionNotRetried(t *testing.T) {
+	// A short dir: unix socket paths are capped at ~104 bytes, which t.TempDir() blows past.
+	dir, err := os.MkdirTemp("/tmp", "rsd")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+	sock := filepath.Join(dir, "s.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	var accepts atomic.Int32
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			accepts.Add(1)
+			br := bufio.NewReader(conn)
+			_, _ = br.ReadString('\n')            // CONNECT <port>
+			_, _ = io.WriteString(conn, "OK 1\n") // hybrid-vsock handshake ack
+			_, _ = br.ReadString('\n')            // reseed opening frame
+			// A live agent rejects (e.g. version skew); reseedVM must surface it, not retry.
+			_ = agent.NewEncoder(conn).Encode(agent.Message{Type: agent.MsgError, Message: "version skew"})
+			_ = conn.Close()
+		}
+	}()
+
+	vm := &types.VM{ID: "vm1", VsockSocket: sock}
+	err = reseedVM(t.Context(), vm, false)
+	if err == nil || !strings.Contains(err.Error(), "version skew") {
+		t.Fatalf("err = %v, want it to carry the agent's rejection", err)
+	}
+	_ = ln.Close()
+	<-done
+	if n := accepts.Load(); n != 1 {
+		t.Errorf("agent accepted %d times; a live rejection must not be retried (want 1)", n)
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,8 @@ const (
 
 	// defaultPullConns is the default concurrent Range connections per cloud-image download.
 	defaultPullConns = 8
+	// maxPullConns caps it so a misconfigured pull_conns can't exhaust file descriptors.
+	maxPullConns = 64
 )
 
 // HypervisorType identifies the selected hypervisor backend.
@@ -69,9 +71,9 @@ func (c *Config) EffectivePoolSize() int {
 	return utils.PoolSizeOrDefault(c.PoolSize)
 }
 
-// EffectivePullConns returns PullConns if set, otherwise defaultPullConns.
+// EffectivePullConns returns PullConns (defaultPullConns when unset) clamped to maxPullConns.
 func (c *Config) EffectivePullConns() int {
-	return utils.OrDefault(c.PullConns, defaultPullConns)
+	return min(utils.OrDefault(c.PullConns, defaultPullConns), maxPullConns)
 }
 
 // Validate checks that all config fields are within acceptable ranges.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cocoonstack/cocoon
 go 1.26.4
 
 require (
-	github.com/cocoonstack/cocoon-agent v0.1.7
+	github.com/cocoonstack/cocoon-agent v0.1.8
 	github.com/containernetworking/cni v1.3.0
 	github.com/containernetworking/plugins v1.9.0
 	github.com/creack/pty v1.1.24

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b h1:r6VH0faHjZe
 github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b/go.mod h1:Vz9DsVWQQhf3vs21MhPMZpMGSht7O/2vFW2xusFUVOs=
 github.com/cockroachdb/redact v1.1.5 h1:u1PMllDkdFfPWaNGMyLD1+so+aq3uUItthCFqzwPJ30=
 github.com/cockroachdb/redact v1.1.5/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
-github.com/cocoonstack/cocoon-agent v0.1.7 h1:lPoN/IBEJUdWph030qkyRUc9MY64DhuJ5XrYNjdoUKk=
-github.com/cocoonstack/cocoon-agent v0.1.7/go.mod h1:gKIfL2r6VvHHo2z6OpLb8qxwupFX6ApIGNwfP0ltrs8=
+github.com/cocoonstack/cocoon-agent v0.1.8 h1:moVCYob2B53j3vT7V6u2Z8UX5E+uj6CNcSZpxS8yfVw=
+github.com/cocoonstack/cocoon-agent v0.1.8/go.mod h1:gKIfL2r6VvHHo2z6OpLb8qxwupFX6ApIGNwfP0ltrs8=
 github.com/containerd/stargz-snapshotter/estargz v0.18.2 h1:yXkZFYIzz3eoLwlTUZKz2iQ4MrckBxJjkmD16ynUTrw=
 github.com/containerd/stargz-snapshotter/estargz v0.18.2/go.mod h1:XyVU5tcJ3PRpkA9XS2T5us6Eg35yM0214Y+wvrZTBrY=
 github.com/containernetworking/cni v1.3.0 h1:v6EpN8RznAZj9765HhXQrtXgX+ECGebEYEmnuFjskwo=

--- a/images/cloudimg/pull.go
+++ b/images/cloudimg/pull.go
@@ -313,6 +313,9 @@ func hashDigest(dst *os.File) (string, error) {
 
 // splitRanges divides [0,size) into up to n contiguous, inclusive-ended byte ranges.
 func splitRanges(size int64, n int) []byteRange {
+	if n < 1 {
+		n = 1
+	}
 	chunk := (size + int64(n) - 1) / int64(n)
 	ranges := make([]byteRange, 0, n)
 	for start := int64(0); start < size; start += chunk {

--- a/os-image/android/14.0/Dockerfile
+++ b/os-image/android/14.0/Dockerfile
@@ -18,8 +18,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Bumping COCOON_AGENT_VERSION must also update COCOON_AGENT_SHA256 — the
 # sha256sum -c step below fails the build when they drift.
-ARG COCOON_AGENT_VERSION=0.1.7
-ARG COCOON_AGENT_SHA256=210f34043d1def6f06f7b4a3722feb1bc6e46368d6419d264b7bb03bfc22cda0
+ARG COCOON_AGENT_VERSION=0.1.8
+ARG COCOON_AGENT_SHA256=88247fe230e4064fce4515e14aa0d70d0b8d070f876bf3295240392698dfaee0
 
 RUN --mount=type=secret,id=cocoon_overlay \
     --mount=type=secret,id=cocoon_network \

--- a/os-image/android/15.0/Dockerfile
+++ b/os-image/android/15.0/Dockerfile
@@ -18,8 +18,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Bumping COCOON_AGENT_VERSION must also update COCOON_AGENT_SHA256 — the
 # sha256sum -c step below fails the build when they drift.
-ARG COCOON_AGENT_VERSION=0.1.7
-ARG COCOON_AGENT_SHA256=210f34043d1def6f06f7b4a3722feb1bc6e46368d6419d264b7bb03bfc22cda0
+ARG COCOON_AGENT_VERSION=0.1.8
+ARG COCOON_AGENT_SHA256=88247fe230e4064fce4515e14aa0d70d0b8d070f876bf3295240392698dfaee0
 
 RUN --mount=type=secret,id=cocoon_overlay \
     --mount=type=secret,id=cocoon_network \

--- a/os-image/ubuntu/install-agent.sh
+++ b/os-image/ubuntu/install-agent.sh
@@ -7,11 +7,11 @@
 # `systemctl enable` is a no-op when the symlinks are already in place.
 set -eu
 
-AGENT_VERSION="${COCOON_AGENT_VERSION:-0.1.7}"
+AGENT_VERSION="${COCOON_AGENT_VERSION:-0.1.8}"
 ARCH="${TARGETARCH:-$(dpkg --print-architecture)}"
 case "$ARCH" in
-    amd64) AGENT_ARCH="x86_64"; AGENT_SHA256="210f34043d1def6f06f7b4a3722feb1bc6e46368d6419d264b7bb03bfc22cda0" ;;
-    arm64) AGENT_ARCH="arm64";  AGENT_SHA256="4728ca3d3221ed27cfa08b6e8c497fbfee45b8c0f509778a7bf7291a18206111" ;;
+    amd64) AGENT_ARCH="x86_64"; AGENT_SHA256="88247fe230e4064fce4515e14aa0d70d0b8d070f876bf3295240392698dfaee0" ;;
+    arm64) AGENT_ARCH="arm64";  AGENT_SHA256="26eb63095eb8d7934d7c7f583002abf70ec363e29d9768c8dfb23a022152429a" ;;
     *) echo "install-agent: unsupported arch '$ARCH'" >&2; exit 1 ;;
 esac
 


### PR DESCRIPTION
Adversarial-review findings on tonight's parallel-download + CRNG-reseed features.

## Fixes
- **pull_conns upper bound** — `EffectivePullConns` was only lower-bounded (OrDefault ≤0→8); a misconfigured `pull_conns: 100000` fanned out ~100k range connections/goroutines and exhausted file descriptors. Clamp to **maxPullConns (64)**. `splitRanges` also guards `n<1` so it can't divide by zero.
- **Silent reseed skip → Warn** — the no-vsock skip on the auto clone/restore path logged at **Debug**, so a legacy (pre-vsock) VM silently kept the snapshot's CRNG state while the command reported success. Warn now, with a remediation hint. (Windows skip stays Debug — permanent, already hinted.)
- **Test the dial-vs-rejection rule** — `TestReseedVM_AgentRejectionNotRetried` stands up a mock agent that completes the hybrid-vsock handshake then returns an error, and asserts reseedVM surfaces it after **exactly one** accept — pinning the rule commit 2010949 introduced (a live agent's reply is final, not retried), which had no test.

## Verification
GOWORK=off build/test/`-race` green (cmd/vm, config, cloudimg); lint 0 issues both GOOS; `golangci-lint fmt --diff` clean (the local make fmt-check drift is the documented gofumpt@latest toolchain skew, not these files).