### PR TITLE
refactor(utils): export SplitRanges/CopyRangeBody range-download helpers

### DIFF
--- a/images/cloudimg/pull.go
+++ b/images/cloudimg/pull.go
@@ -74,11 +74,6 @@ func (cw countingWriter) Write(p []byte) (int, error) {
 	return n, err
 }
 
-// byteRange is an inclusive [start, end] byte span for an HTTP Range request.
-type byteRange struct {
-	start, end int64
-}
-
 // rangeProbe carries the resolved URL and total size of a Range-capable source.
 type rangeProbe struct {
 	finalURL string
@@ -249,8 +244,8 @@ func downloadRangesParallel(ctx context.Context, client *http.Client, url string
 	tracker.OnEvent(cloudimgProgress.Event{Phase: cloudimgProgress.PhaseDownload, BytesTotal: size})
 	pc := &progressCounter{total: size, tracker: tracker}
 
-	ranges := splitRanges(size, pullConns)
-	if _, err := utils.Map(ctx, ranges, func(ctx context.Context, _ int, r byteRange) (struct{}, error) {
+	ranges := utils.SplitRanges(size, pullConns)
+	if _, err := utils.Map(ctx, ranges, func(ctx context.Context, _ int, r [2]int64) (struct{}, error) {
 		return struct{}{}, downloadRange(ctx, client, url, dst, r, pc)
 	}, pullConns); err != nil {
 		return fmt.Errorf("download %s: %w", url, err)
@@ -264,38 +259,22 @@ func downloadRangesParallel(ctx context.Context, client *http.Client, url string
 	return nil
 }
 
-func downloadRange(ctx context.Context, client *http.Client, url string, dst *os.File, r byteRange, pc *progressCounter) error {
+func downloadRange(ctx context.Context, client *http.Client, url string, dst *os.File, r [2]int64, pc *progressCounter) error {
+	start, end := r[0], r[1]
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return fmt.Errorf("create range request: %w", err)
 	}
-	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", r.start, r.end))
+	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", start, end))
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("http get range %d-%d: %w", r.start, r.end, err)
+		return fmt.Errorf("http get range %d-%d: %w", start, end, err)
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
-	if resp.StatusCode != http.StatusPartialContent {
-		return fmt.Errorf("http get range %d-%d: status %s", r.start, r.end, resp.Status)
-	}
-	// A mismatched span would land bytes at the wrong offsets; a short body would
-	// leave a zero hole that hashDigest then blesses with a "valid" digest.
-	if cr := resp.Header.Get("Content-Range"); !strings.HasPrefix(cr, fmt.Sprintf("bytes %d-%d/", r.start, r.end)) {
-		return fmt.Errorf("http get range %d-%d: mismatched content-range %q", r.start, r.end, cr)
-	}
-
-	want := r.end - r.start + 1
-	w := countingWriter{w: io.NewOffsetWriter(dst, r.start), pc: pc}
-	n, err := io.Copy(w, io.LimitReader(resp.Body, want))
-	if err != nil {
-		return fmt.Errorf("write range %d-%d: %w", r.start, r.end, err)
-	}
-	if n != want {
-		return fmt.Errorf("http get range %d-%d: short body %d of %d bytes", r.start, r.end, n, want)
-	}
-	return nil
+	w := countingWriter{w: io.NewOffsetWriter(dst, start), pc: pc}
+	return utils.CopyRangeBody(resp, w, start, end)
 }
 
 // hashDigest re-reads dst from disk: scattered parallel writes can't feed a streaming
@@ -309,23 +288,6 @@ func hashDigest(dst *os.File) (string, error) {
 		return "", fmt.Errorf("hash temp file: %w", err)
 	}
 	return hex.EncodeToString(h.Sum(nil)), nil
-}
-
-// splitRanges divides [0,size) into up to n contiguous, inclusive-ended byte ranges.
-func splitRanges(size int64, n int) []byteRange {
-	if n < 1 {
-		n = 1
-	}
-	chunk := (size + int64(n) - 1) / int64(n)
-	ranges := make([]byteRange, 0, n)
-	for start := int64(0); start < size; start += chunk {
-		end := start + chunk - 1
-		if end >= size {
-			end = size - 1
-		}
-		ranges = append(ranges, byteRange{start: start, end: end})
-	}
-	return ranges
 }
 
 // parseContentRangeSize extracts the total size from a "Content-Range: bytes 0-0/12345" header value.

--- a/utils/httprange.go
+++ b/utils/httprange.go
@@ -1,0 +1,48 @@
+package utils
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// SplitRanges divides [0,size) into up to n contiguous, inclusive-ended byte ranges.
+func SplitRanges(size int64, n int) [][2]int64 {
+	if n < 1 {
+		n = 1
+	}
+	chunk := (size + int64(n) - 1) / int64(n)
+	ranges := make([][2]int64, 0, n)
+	for start := int64(0); start < size; start += chunk {
+		end := start + chunk - 1
+		if end >= size {
+			end = size - 1
+		}
+		ranges = append(ranges, [2]int64{start, end})
+	}
+	return ranges
+}
+
+// CopyRangeBody validates resp as the answer to a bytes=start-end Range request
+// (206 status, matching Content-Range span, full-length body) and copies exactly
+// the requested bytes into w. A mismatched span would land bytes at the wrong
+// offsets; a short body would leave a zero hole — both would otherwise surface
+// only when a later digest pass re-hashes the assembled file.
+func CopyRangeBody(resp *http.Response, w io.Writer, start, end int64) error {
+	if resp.StatusCode != http.StatusPartialContent {
+		return fmt.Errorf("range %d-%d: unexpected status %s", start, end, resp.Status)
+	}
+	if cr := resp.Header.Get("Content-Range"); !strings.HasPrefix(cr, fmt.Sprintf("bytes %d-%d/", start, end)) {
+		return fmt.Errorf("range %d-%d: mismatched content-range %q", start, end, cr)
+	}
+	want := end - start + 1
+	n, err := io.Copy(w, io.LimitReader(resp.Body, want))
+	if err != nil {
+		return fmt.Errorf("range %d-%d: %w", start, end, err)
+	}
+	if n != want {
+		return fmt.Errorf("range %d-%d: short body %d of %d bytes", start, end, n, want)
+	}
+	return nil
+}

--- a/utils/httprange_test.go
+++ b/utils/httprange_test.go
@@ -1,0 +1,82 @@
+package utils
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestSplitRanges(t *testing.T) {
+	sizes := []int64{1, 7, 8, 9, 100, 257 << 10, (257 << 10) + 7}
+	for _, size := range sizes {
+		for _, n := range []int{0, 1, 3, 8, 100} {
+			ranges := SplitRanges(size, n)
+			if len(ranges) == 0 {
+				t.Fatalf("size=%d n=%d: no ranges", size, n)
+			}
+			if ranges[0][0] != 0 {
+				t.Errorf("size=%d n=%d: first start %d, want 0", size, n, ranges[0][0])
+			}
+			if last := ranges[len(ranges)-1][1]; last != size-1 {
+				t.Errorf("size=%d n=%d: last end %d, want %d", size, n, last, size-1)
+			}
+			// contiguous + non-overlapping: each start is the previous end + 1
+			for i := 1; i < len(ranges); i++ {
+				if ranges[i][0] != ranges[i-1][1]+1 {
+					t.Errorf("size=%d n=%d: gap/overlap at %d: %v after %v", size, n, i, ranges[i], ranges[i-1])
+				}
+			}
+			if n >= 1 && len(ranges) > n {
+				t.Errorf("size=%d n=%d: %d chunks exceeds n", size, n, len(ranges))
+			}
+		}
+	}
+	if got := SplitRanges(0, 4); len(got) != 0 {
+		t.Errorf("size=0: got %v, want no ranges", got)
+	}
+}
+
+func TestCopyRangeBody(t *testing.T) {
+	const start, end = 10, 19
+	body := "0123456789"
+	tests := []struct {
+		name         string
+		status       int
+		contentRange string
+		body         string
+		wantErr      string
+	}{
+		{"ok", http.StatusPartialContent, "bytes 10-19/100", body, ""},
+		{"extra bytes beyond span are not copied", http.StatusPartialContent, "bytes 10-19/100", body + "EXTRA", ""},
+		{"non-206 status", http.StatusOK, "", body, "unexpected status"},
+		{"mismatched span", http.StatusPartialContent, "bytes 0-9/100", body, "mismatched content-range"},
+		{"short body", http.StatusPartialContent, "bytes 10-19/100", "0123", "short body"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &http.Response{
+				StatusCode: tt.status,
+				Status:     fmt.Sprintf("%d %s", tt.status, http.StatusText(tt.status)),
+				Header:     http.Header{"Content-Range": {tt.contentRange}},
+				Body:       io.NopCloser(strings.NewReader(tt.body)),
+			}
+			var buf bytes.Buffer
+			err := CopyRangeBody(resp, &buf, start, end)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("got %v, want nil", err)
+				}
+				if buf.String() != body {
+					t.Errorf("copied %q, want %q", buf.String(), body)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("got %v, want error containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Extracts the HTTP Range download helpers into `utils` as exported functions:

- `SplitRanges(size int64, n int) [][2]int64` — contiguous, inclusive-ended split of `[0,size)` into up to `n` ranges (`n<1` clamps to 1).
- `CopyRangeBody(resp *http.Response, w io.Writer, start, end int64) error` — the three response guards (206 status, matching `Content-Range` span, full-length body via `LimitReader` + short-body check) plus the copy itself.

`images/cloudimg` switches to the shared helpers, dropping the package-local `byteRange`/`splitRanges` and the inline guard block. Behavior is unchanged; `TestCopyRangeBody` pins each guard and `TestSplitRanges` pins the split contract.

Motivation: cocoon-macos `cmd/image/oci.go` carries a byte-identical copy of both; after the next cocoon release it can import these and drop the duplicate.