### PR TITLE
fix(cmd): vm exec attaches stdin only with -i

### DIFF
--- a/cmd/vm/commands.go
+++ b/cmd/vm/commands.go
@@ -112,6 +112,7 @@ func Command(h Actions) *cobra.Command {
 		RunE:  h.Exec,
 	}
 	execCmd.Flags().StringArrayP("env", "e", nil, "extra env var KEY=VALUE (repeatable)")
+	execCmd.Flags().BoolP("interactive", "i", false, "attach the caller's stdin to the command (otherwise stdin closes immediately)")
 
 	reseedCmd := &cobra.Command{
 		Use:   "reseed VM",

--- a/cmd/vm/exec.go
+++ b/cmd/vm/exec.go
@@ -58,7 +58,14 @@ func (h Handler) Exec(cmd *cobra.Command, args []string) error {
 	}
 	defer conn.Close() //nolint:errcheck
 
-	code, err := client.Run(ctx, conn, argv, env, os.Stdin, os.Stdout, os.Stderr)
+	// Stdin is opt-in (docker semantics): a nil reader makes client.Run close
+	// the child's stdin immediately, so scripted callers feeding a shell over
+	// stdin don't have the rest of their script swallowed by the pump.
+	var stdin io.Reader
+	if interactive, _ := cmd.Flags().GetBool("interactive"); interactive {
+		stdin = os.Stdin
+	}
+	code, err := client.Run(ctx, conn, argv, env, stdin, os.Stdout, os.Stderr)
 	if err != nil {
 		return fmt.Errorf("exec: %w", err)
 	}


### PR DESCRIPTION
Fixes #84.

`vm exec` passed `os.Stdin` to `client.Run` unconditionally; the stdin pump's read-ahead consumed whatever the caller's stdin held — in scripted/heredoc use, the rest of the script — even when the guest command never read stdin, and the bytes were dropped after `MsgExit`.

Docker semantics now:

- default: nil reader → `client.Run` sends `MsgStdinClose` immediately
- `-i/--interactive`: attach `os.Stdin` (previous behavior)

**Breaking**: existing pipelines (`echo x | cocoon vm exec vm -- cat`) must add `-i`. The client library is unchanged — the reader choice was always the caller's; the CLI just never offered it.

Verified: `make lint test` green (GOOS linux+darwin matrix).