### PR TITLE
fix(fc): re-anchor clone drives at their own paths after snapshot load

### DIFF
--- a/hypervisor/firecracker/api.go
+++ b/hypervisor/firecracker/api.go
@@ -126,6 +126,18 @@ func putMachineConfig(ctx context.Context, hc *http.Client, cfg fcMachineConfig)
 	return putJSON(ctx, hc, "/machine-config", cfg, "machine-config")
 }
 
+// patchDrivePath repoints a block device's backing file on a booted VM.
+func patchDrivePath(ctx context.Context, hc *http.Client, driveID, pathOnHost string) error {
+	body, err := json.Marshal(struct {
+		DriveID    string `json:"drive_id"`
+		PathOnHost string `json:"path_on_host"`
+	}{DriveID: driveID, PathOnHost: pathOnHost})
+	if err != nil {
+		return fmt.Errorf("marshal drive patch: %w", err)
+	}
+	return fcAPIOnce(ctx, hc, http.MethodPatch, "/drives/"+driveID, body)
+}
+
 func putBootSource(ctx context.Context, hc *http.Client, boot fcBootSource) error {
 	return putJSON(ctx, hc, "/boot-source", boot, "boot-source")
 }

--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -136,10 +136,7 @@ func (fc *Firecracker) restoreAndResumeClone(
 	// Re-anchor redirected drives at the clone's own paths: the loaded
 	// vmstate still names the source's, and any future snapshot of this VM
 	// would embed those dangling paths — breaking its restore (hibernate).
-	for i, src := range srcConfigs {
-		if i >= len(dstConfigs) || src.Path == dstConfigs[i].Path {
-			continue
-		}
+	for _, i := range redirectedDriveIndices(srcConfigs, dstConfigs) {
 		if err = patchDrivePath(ctx, hc, fmt.Sprintf(driveIDFmt, i), dstConfigs[i].Path); err != nil {
 			return fmt.Errorf("re-anchor drive %d: %w", i, err)
 		}
@@ -167,12 +164,23 @@ func rebuildCloneStorage(meta *hypervisor.SnapshotMeta, cowPath string) ([]*type
 	return configs, nil
 }
 
+// redirectedDriveIndices lists the drives whose source and clone paths
+// differ: exactly the set createDriveRedirects symlinks and the re-anchor
+// loop patches — the two must never diverge, so both derive from here.
+func redirectedDriveIndices(srcConfigs, dstConfigs []*types.StorageConfig) []int {
+	var indices []int
+	for i, src := range srcConfigs {
+		if i < len(dstConfigs) && src.Path != dstConfigs[i].Path {
+			indices = append(indices, i)
+		}
+	}
+	return indices
+}
+
 func createDriveRedirects(srcConfigs, dstConfigs []*types.StorageConfig) ([]driveRedirect, error) {
 	var redirects []driveRedirect
-	for i, src := range srcConfigs {
-		if i >= len(dstConfigs) || src.Path == dstConfigs[i].Path {
-			continue
-		}
+	for _, i := range redirectedDriveIndices(srcConfigs, dstConfigs) {
+		src := srcConfigs[i]
 		r := driveRedirect{symlinkPath: src.Path}
 
 		if _, err := os.Stat(src.Path); err == nil {

--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -90,7 +90,7 @@ func (fc *Firecracker) cloneAfterExtract(ctx context.Context, vmID string, vmCfg
 			return fmt.Errorf("launch FC: %w", launchErr)
 		}
 
-		return fc.restoreAndResumeClone(ctx, pid, sockPath, runDir, networkConfigs)
+		return fc.restoreAndResumeClone(ctx, pid, sockPath, runDir, networkConfigs, meta.StorageConfigs, storageConfigs)
 	}); cloneErr != nil {
 		fc.MarkError(ctx, vmID)
 		return nil, cloneErr
@@ -116,6 +116,7 @@ func (fc *Firecracker) restoreAndResumeClone(
 	pid int,
 	sockPath, runDir string,
 	networkConfigs []*types.NetworkConfig,
+	srcConfigs, dstConfigs []*types.StorageConfig,
 ) (err error) {
 	defer func() {
 		if err != nil {
@@ -131,6 +132,17 @@ func (fc *Firecracker) restoreAndResumeClone(
 	hc := utils.NewSocketHTTPClient(sockPath)
 	if err = resumeVM(ctx, hc); err != nil {
 		return fmt.Errorf("resume: %w", err)
+	}
+	// Re-anchor redirected drives at the clone's own paths: the loaded
+	// vmstate still names the source's, and any future snapshot of this VM
+	// would embed those dangling paths — breaking its restore (hibernate).
+	for i, src := range srcConfigs {
+		if i >= len(dstConfigs) || src.Path == dstConfigs[i].Path {
+			continue
+		}
+		if err = patchDrivePath(ctx, hc, fmt.Sprintf(driveIDFmt, i), dstConfigs[i].Path); err != nil {
+			return fmt.Errorf("re-anchor drive %d: %w", i, err)
+		}
 	}
 	return nil
 }

--- a/hypervisor/firecracker/clone_test.go
+++ b/hypervisor/firecracker/clone_test.go
@@ -1,0 +1,85 @@
+package firecracker
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/cocoonstack/cocoon/types"
+)
+
+func TestRedirectedDriveIndices(t *testing.T) {
+	sc := func(paths ...string) []*types.StorageConfig {
+		configs := make([]*types.StorageConfig, len(paths))
+		for i, p := range paths {
+			configs[i] = &types.StorageConfig{Path: p}
+		}
+		return configs
+	}
+	tests := []struct {
+		name     string
+		src, dst []*types.StorageConfig
+		want     []int
+	}{
+		{"all equal", sc("/a", "/b"), sc("/a", "/b"), nil},
+		{"one differs", sc("/a", "/b", "/c"), sc("/a", "/B", "/c"), []int{1}},
+		{"all differ", sc("/a", "/b"), sc("/A", "/B"), []int{0, 1}},
+		{"dst shorter", sc("/a", "/b"), sc("/A"), []int{0}},
+		{"empty", nil, nil, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := redirectedDriveIndices(tt.src, tt.dst); !slices.Equal(got, tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// The redirect set and the re-anchor set must be the same drives: both loops
+// derive from redirectedDriveIndices, and this pins createDriveRedirects to
+// it — a symlink appears exactly where the shared function says.
+func TestCreateDriveRedirectsMatchesIndices(t *testing.T) {
+	dir := t.TempDir()
+	mk := func(name, content string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+			t.Fatalf("setup %s: %v", name, err)
+		}
+		return p
+	}
+	src := []*types.StorageConfig{
+		{Path: filepath.Join(dir, "gone", "layer.img")}, // shared layer, same both sides
+		{Path: filepath.Join(dir, "gone", "cow.raw")},   // source path no longer exists
+		{Path: mk("data.img", "data")},                  // source still present: backed up
+	}
+	dst := []*types.StorageConfig{
+		{Path: src[0].Path},
+		{Path: mk("clone-cow.raw", "cow")},
+		{Path: mk("clone-data.img", "data2")},
+	}
+
+	redirects, err := createDriveRedirects(src, dst)
+	if err != nil {
+		t.Fatalf("createDriveRedirects: %v", err)
+	}
+	defer cleanupDriveRedirects(redirects)
+
+	want := redirectedDriveIndices(src, dst)
+	if len(redirects) != len(want) {
+		t.Fatalf("%d redirects for indices %v", len(redirects), want)
+	}
+	for n, i := range want {
+		if redirects[n].symlinkPath != src[i].Path {
+			t.Errorf("redirect %d at %q, want %q", n, redirects[n].symlinkPath, src[i].Path)
+		}
+		target, readErr := os.Readlink(src[i].Path)
+		if readErr != nil {
+			t.Fatalf("drive %d not symlinked: %v", i, readErr)
+		}
+		if target != dst[i].Path {
+			t.Errorf("drive %d links to %q, want %q", i, target, dst[i].Path)
+		}
+	}
+}


### PR DESCRIPTION
Snapshots taken of an FC clone could not be restored: `snapshot/load` reopens the drive paths embedded in the vmstate, clone satisfies them with temporary symlink redirects, and the loaded VMM's device config keeps naming the **source's** paths. A later `vm hibernate`/`snapshot save` of the clone embeds those dangling paths, and its restore dies with `Error manipulating the backing file: No such file or directory` on the source COW (the golden builder's run dir, long gone).

Fix: after resume, `PATCH /drives/{id}` repoints each redirected drive at the clone's canonical path — same inode through the redirect, so the guest observes nothing; every future snapshot of the clone now embeds paths that exist at restore time.

Found by the sandbox control-plane e2e (its warm pool is golden clones; the new hibernate → transparent-wake smoke step failed exactly here), reproduced and verified on hardware: with this fix the full suite passes, including clone → hibernate (467ms end-to-end through the SDK relay, session state intact after wake). `make lint test` green.