### PR TITLE
fix(vm): spare a stopped origin when the restore kill step fails

### DIFF
--- a/hypervisor/restore.go
+++ b/hypervisor/restore.go
@@ -18,14 +18,16 @@ import (
 func (b *Backend) KillForRestore(ctx context.Context, vmID string, rec *VMRecord, terminate func(pid int) error, runtimeFiles []string) error {
 	killErr := b.WithRunningVM(ctx, rec, terminate)
 	if killErr != nil && !errors.Is(killErr, ErrNotRunning) {
-		b.MarkError(ctx, vmID)
+		// A stopped origin has no live VMM, so a transient liveness-scan error
+		// here must not brick the wake — nothing was mutated, retry converges.
+		b.FailRestore(ctx, vmID, rec.State)
 		return fmt.Errorf("stop running VM: %w", killErr)
 	}
 	CleanupRuntimeFiles(ctx, rec.RunDir, runtimeFiles)
 	return nil
 }
 
-// FailRestore marks the VM error after a post-kill restore failure; a stopped
+// FailRestore marks the VM error after a restore-path failure; a stopped
 // origin is spared so hibernate wake stays retryable. Run-dir-mutating steps
 // (staged merge, direct populate) quarantine unconditionally at their own
 // site; origin is the pre-kill state — the DB may read stopped after the kill.

--- a/hypervisor/restore_test.go
+++ b/hypervisor/restore_test.go
@@ -201,3 +201,42 @@ func TestResolveForRestoreStates(t *testing.T) {
 		})
 	}
 }
+
+func TestKillForRestoreFailureKeepsOriginContract(t *testing.T) {
+	tests := []struct {
+		name   string
+		origin types.VMState
+		want   types.VMState
+	}{
+		{"stopped origin stays restorable (hibernate wake)", types.VMStateStopped, types.VMStateStopped},
+		{"running origin quarantines", types.VMStateRunning, types.VMStateError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, id := newHibernateTestVM(t)
+			if err := b.DB.Update(t.Context(), func(idx *VMIndex) error {
+				idx.VMs[id].State = tt.origin
+				return nil
+			}); err != nil {
+				t.Fatalf("seed state: %v", err)
+			}
+			rec, err := b.LoadRecord(t.Context(), id)
+			if err != nil {
+				t.Fatalf("load record: %v", err)
+			}
+
+			killErr := b.KillForRestore(t.Context(), id, &rec, func(int) error { return errors.New("kill refused") }, nil)
+			if killErr == nil || !strings.Contains(killErr.Error(), "stop running VM") {
+				t.Fatalf("KillForRestore: %v, want stop running VM error", killErr)
+			}
+
+			got, err := b.LoadRecord(t.Context(), id)
+			if err != nil {
+				t.Fatalf("reload record: %v", err)
+			}
+			if got.State != tt.want {
+				t.Errorf("state %s, want %s", got.State, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #91.

## What

`KillForRestore` marked the VM `error` on any non-`ErrNotRunning` failure — including `WithRunningVM`'s **fail-closed /proc-scan error**, which is a false liveness-unknown for a hibernated VM (its VMM is provably gone: hibernate's own terminate failure already marks `error`, so `stopped` implies no VMM). A transient procfs hiccup at wake therefore bricked the VM permanently: `ResolveForRestore` refuses `error` state, and nothing on disk had been mutated. Route the failure through `FailRestore` (#89's origin-aware helper) instead:

- **stopped origin** (hibernate wake): spared — stays `stopped`, wake retries converge
- **running origin** (in-place revert): unchanged — a failed kill of a live VMM still quarantines

Plus a one-word `FailRestore` doc fix ("post-kill" → "restore-path": it now also guards the kill step itself; the origin-provenance note is unchanged and still holds — the kill step *is* pre-kill).

## Deliberately accepted corner

A `stopped` record with a genuinely live VMM (half-failed `vm start`) whose kill fails is now also spared: restore aborts before any mutation either way (no double-VMM risk), and sparing lets the next wake retry the kill instead of welding shut a record that was already lying. A sentinel-error split in `WithRunningVM` (scan-error vs real kill failure) was evaluated and rejected as overdesign — it would touch a primitive shared by stop/delete/start to sharpen behavior only in this should-never-happen corner.

## Verification

- `TestKillForRestoreFailureKeepsOriginContract` (reuses the stub-VMM harness; injects a failing terminate — the /proc-scan branch itself isn't unit-reachable, but both branches converge on the one changed marking site): stopped→stays stopped, running→error
- **Negative-tested**: with the fix stashed the stopped case FAILs; restored it PASSes
- `make lint` 0 issues ×2 GOOS, full suite 25 pkgs green