### PR TITLE
images/oci: enforce mkfs.erofs >= 1.8 before EROFS conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Lightweight MicroVM engine with dual hypervisor backends: [Cloud Hypervisor](htt
 - [Cloud Hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor) v51.0+ (for Windows VMs, use our [CH fork](https://github.com/cocoonstack/cloud-hypervisor/tree/dev) and [firmware fork](https://github.com/cocoonstack/rust-hypervisor-firmware/tree/dev) for full compatibility — see [KNOWN_ISSUES.md](KNOWN_ISSUES.md))
 - [Firecracker](https://github.com/firecracker-microvm/firecracker) v1.16+ (optional, for `--fc` backend; `vm clone` requires >= v1.16 for the vsock override)
 - `qemu-img` (from qemu-utils, for cloud images)
+- `mkfs.erofs` from erofs-utils **>= 1.8** (for OCI images; 1.7.x tar mode
+  silently corrupts layers — cocoon refuses to convert with older versions)
 - UEFI firmware (`CLOUDHV.fd`, for cloud images, not needed with `--fc`)
 - CNI plugins (`bridge`, `host-local`, `loopback`)
 - Go 1.25+ (build only)

--- a/doctor/check.sh
+++ b/doctor/check.sh
@@ -140,6 +140,16 @@ bin_to_pkg() {
     esac
 }
 
+# Mirror the runtime floor in images/oci/erofs.go: erofs-utils < 1.8 tar mode
+# silently corrupts layers, so doctor must not PASS a host cocoon will refuse.
+erofs_version_ok() {
+    local xy major minor
+    xy=$(echo "$1" | grep -oE '[0-9]+\.[0-9]+' | head -1)
+    [ -n "$xy" ] || return 1
+    major=${xy%%.*}; minor=${xy#*.}
+    [ "$major" -gt 1 ] || { [ "$major" -eq 1 ] && [ "$minor" -ge 8 ]; }
+}
+
 check_binary() {
     local name="$1"
     if command -v "$name" &>/dev/null; then
@@ -153,6 +163,10 @@ check_binary() {
             mkfs.ext4)        ver=$("$name" -V 2>&1 | head -1) || true ;;
             mkfs.erofs)       ver=$("$name" --version 2>&1 | head -1) || true ;;
         esac
+        if [ "$name" = "mkfs.erofs" ] && ! erofs_version_ok "$ver"; then
+            fail "$name (${ver:-unknown}) is older than 1.8 — tar mode silently corrupts layers; apt ships 1.7.x, install erofs-utils >= 1.8 from source"
+            return
+        fi
         pass "${name}${ver:+ ($ver)}"
     else
         fail "$name not found in PATH"
@@ -161,6 +175,10 @@ check_binary() {
             pkg=$(bin_to_pkg "$name")
             if [ -n "$pkg" ] && command -v apt-get &>/dev/null; then
                 apt-get install -y "$pkg" &>/dev/null && fixed "apt-get install $pkg" || warn "failed to install $pkg"
+                if [ "$name" = "mkfs.erofs" ] && command -v mkfs.erofs &>/dev/null \
+                    && ! erofs_version_ok "$(mkfs.erofs --version 2>&1 | head -1)"; then
+                    warn "installed mkfs.erofs is still older than 1.8 — install erofs-utils from source"
+                fi
             fi
         fi
     fi

--- a/images/oci/erofs.go
+++ b/images/oci/erofs.go
@@ -6,15 +6,35 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
 )
 
 const (
 	erofsBlockSize   = 4096
 	erofsCompression = "lz4hc"
+
+	// erofs-utils 1.7.x tar mode writes corrupt compressed clusters for some
+	// inputs and still exits 0; the corruption surfaces only as EUCLEAN at
+	// read time (#94). 1.8 is the first safe series.
+	erofsMinMajor = 1
+	erofsMinMinor = 8
+)
+
+var (
+	erofsVersionRe = regexp.MustCompile(`(\d+)\.(\d+)`)
+
+	erofsCheckMu sync.Mutex
+	erofsCheckOK bool
 )
 
 // startErofsConversion pipes a tar stream into mkfs.erofs; caller writes+closes stdin, then cmd.Wait().
 func startErofsConversion(ctx context.Context, uuid, outputPath string) (cmd *exec.Cmd, stdin io.WriteCloser, output *bytes.Buffer, err error) {
+	if err = checkErofsVersion(ctx); err != nil {
+		return nil, nil, nil, err
+	}
 	// shell out because no Go EROFS writer library; mkfs.erofs is authoritative.
 	cmd = exec.CommandContext(ctx, "mkfs.erofs", //nolint:gosec
 		"--tar=f",
@@ -65,4 +85,40 @@ func runErofsConversion(ctx context.Context, src io.Reader, scanDir, namePrefix,
 		return "", "", fmt.Errorf("scan boot files: %w", scanErr)
 	}
 	return kernelPath, initrdPath, nil
+}
+
+// checkErofsVersion refuses conversion when mkfs.erofs predates the floor.
+// Only success is cached: a transient probe failure or an in-place
+// erofs-utils upgrade is re-probed on the next conversion.
+func checkErofsVersion(ctx context.Context) error {
+	erofsCheckMu.Lock()
+	defer erofsCheckMu.Unlock()
+	if erofsCheckOK {
+		return nil
+	}
+	out, err := exec.CommandContext(ctx, "mkfs.erofs", "--version").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("probe mkfs.erofs version: %w (output: %s)", err, bytes.TrimSpace(out))
+	}
+	if err := erofsVersionAtLeast(string(out)); err != nil {
+		return err
+	}
+	erofsCheckOK = true
+	return nil
+}
+
+// erofsVersionAtLeast parses the leading "X.Y" from `mkfs.erofs --version`
+// output ("mkfs.erofs (erofs-utils) 1.8.10") and compares it to the floor.
+func erofsVersionAtLeast(output string) error {
+	m := erofsVersionRe.FindStringSubmatch(output)
+	if m == nil {
+		return fmt.Errorf("cannot parse mkfs.erofs version from %q", strings.TrimSpace(output))
+	}
+	major, _ := strconv.Atoi(m[1])
+	minor, _ := strconv.Atoi(m[2])
+	if major > erofsMinMajor || (major == erofsMinMajor && minor >= erofsMinMinor) {
+		return nil
+	}
+	return fmt.Errorf("mkfs.erofs %s.%s is older than %d.%d: its tar mode silently corrupts layers (EUCLEAN at read time) — upgrade erofs-utils",
+		m[1], m[2], erofsMinMajor, erofsMinMinor)
 }

--- a/images/oci/erofs_test.go
+++ b/images/oci/erofs_test.go
@@ -1,0 +1,27 @@
+package oci
+
+import "testing"
+
+func TestErofsVersionAtLeast(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  string
+		wantErr bool
+	}{
+		{"current", "mkfs.erofs (erofs-utils) 1.8.10\navailable compressors: lz4, lz4hc", false},
+		{"floor exact", "mkfs.erofs (erofs-utils) 1.8", false},
+		{"double digit minor", "mkfs.erofs (erofs-utils) 1.10.0", false},
+		{"next major", "mkfs.erofs (erofs-utils) 2.0", false},
+		{"ubuntu 24.04 stock", "mkfs.erofs (erofs-utils) 1.7.1", true},
+		{"ancient", "mkfs.erofs (erofs-utils) 1.5", true},
+		{"unparseable", "command not found", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := erofsVersionAtLeast(tt.output)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("erofsVersionAtLeast(%q) = %v, wantErr %v", tt.output, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #94.

## What

`startErofsConversion` now probes `mkfs.erofs --version` and refuses to convert below 1.8:

```
Error: pull …: process layers: start erofs conversion: mkfs.erofs 1.7 is older than 1.8: its tar mode silently corrupts layers (EUCLEAN at read time) — upgrade erofs-utils
```

Only success is cached (one probe per process); a transient probe failure or an in-place erofs-utils upgrade is re-probed on the next conversion, so recovery needs no daemon restart. README gains the erofs-utils >= 1.8 requirement.

`doctor/check.sh` mirrors the floor so preflight cannot contradict the runtime gate: mkfs.erofs below 1.8 now FAILs (previously PASS — Ubuntu 24.04 stock 1.7.1 included) with source-install guidance, and `--fix` warns when the apt-installed erofs-utils is still pre-1.8.

## Why

erofs-utils 1.7.x tar mode (Ubuntu 24.04 ships 1.7.1) writes corrupt compressed clusters for some inputs and still exits 0; the corruption surfaces only at read time as EUCLEAN / `invalid logical cluster` guest errors — see #94 for the full failure analysis.

## Verification

- Unit: `go test ./images/oci/ -run TestErofsVersion` — 7-case table over real `--version` outputs (1.8.10, 1.8, 1.10.0, 2.0 pass; 1.7.1, 1.5, unparseable refuse).
- Hardware (Ubuntu 24.04 test node, isolated `--root-dir`): PATH-shimmed fake `mkfs.erofs` reporting 1.7.1 → `image pull` refused with the message above, nothing converted; real 1.8.10 → `image pull ghcr.io/cocoonstack/sandbox/boot:6.18.37` completes (2 layers converted).
- `golangci-lint run ./images/oci/` clean on GOOS=linux and darwin.
- doctor: table test over the same 7 version strings against the extracted `erofs_version_ok`, plus PATH-shimmed full-script runs — 1.7.1 → FAIL, 1.8.10 → PASS, missing binary → unchanged not-found path.
