### PR TITLE
images/oci: retry a failed layer download/conversion

### DIFF
--- a/images/oci/process.go
+++ b/images/oci/process.go
@@ -51,6 +51,12 @@ func processLayer(ctx context.Context, j layerJob) error {
 
 	logger.Debugf(ctx, "Layer %d: sha256:%s -> erofs (single-pass)", j.idx, digestHex[:12])
 
+	// Hoisted out of the retried region: a too-old mkfs.erofs is permanent,
+	// retrying it would burn attempts, backoff sleeps, and aborted blob GETs.
+	if err = checkErofsVersion(ctx); err != nil {
+		return err
+	}
+
 	layerDir := filepath.Join(j.workDir, fmt.Sprintf("layer-%d", j.idx))
 	erofsPath := filepath.Join(layerDir, digestHex+".erofs")
 	layerUUID := utils.UUIDv5(digestHex)
@@ -112,11 +118,9 @@ func applyCachedLayerPaths(conf *Config, result *pullLayerResult, digestHex stri
 	}
 }
 
-// retryLayer runs one layer attempt up to attempts times, sleeping backoff
-// between failures. A transient stream break is indistinguishable from bad
-// input by the time mkfs or the boot scan reports it, so every error is
-// retried — the attempt count bounds the waste and re-downloads are
-// digest-addressed. Context cancellation stops the retries immediately.
+// retryLayer runs fn up to attempts times, sleeping backoff between failures;
+// every error retries — a mid-stream break is indistinguishable from bad input
+// by the time mkfs or the boot scan reports it.
 func retryLayer(ctx context.Context, attempts int, backoff time.Duration, fn func() error) error {
 	var err error
 	for attempt := 1; ; attempt++ {
@@ -126,12 +130,10 @@ func retryLayer(ctx context.Context, attempts int, backoff time.Duration, fn fun
 		if attempt == attempts || ctx.Err() != nil {
 			return err
 		}
-		timer := time.NewTimer(backoff)
 		select {
 		case <-ctx.Done():
-			timer.Stop()
 			return err
-		case <-timer.C:
+		case <-time.After(backoff):
 		}
 	}
 }

--- a/images/oci/process.go
+++ b/images/oci/process.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/projecteru2/core/log"
@@ -13,6 +14,11 @@ import (
 	"github.com/cocoonstack/cocoon/progress"
 	ociProgress "github.com/cocoonstack/cocoon/progress/oci"
 	"github.com/cocoonstack/cocoon/utils"
+)
+
+const (
+	pullLayerAttempts = 3
+	pullLayerBackoff  = 2 * time.Second
 )
 
 // layerJob carries the per-layer processing context (one struct per worker).
@@ -46,20 +52,18 @@ func processLayer(ctx context.Context, j layerJob) error {
 	logger.Debugf(ctx, "Layer %d: sha256:%s -> erofs (single-pass)", j.idx, digestHex[:12])
 
 	layerDir := filepath.Join(j.workDir, fmt.Sprintf("layer-%d", j.idx))
-	if err = os.MkdirAll(layerDir, 0o750); err != nil {
-		return fmt.Errorf("create layer work dir: %w", err)
-	}
-
-	rc, err := j.layer.Uncompressed()
-	if err != nil {
-		return fmt.Errorf("open uncompressed layer: %w", err)
-	}
-	defer rc.Close() //nolint:errcheck
-
 	erofsPath := filepath.Join(layerDir, digestHex+".erofs")
 	layerUUID := utils.UUIDv5(digestHex)
 
-	kernelPath, initrdPath, err := runErofsConversion(ctx, rc, layerDir, digestHex, layerUUID, erofsPath)
+	var kernelPath, initrdPath string
+	err = retryLayer(ctx, pullLayerAttempts, pullLayerBackoff, func() error {
+		var convErr error
+		kernelPath, initrdPath, convErr = convertLayer(ctx, j, layerDir, digestHex, layerUUID, erofsPath)
+		if convErr != nil {
+			logger.Warnf(ctx, "layer %d (sha256:%s): %v", j.idx, digestHex[:12], convErr)
+		}
+		return convErr
+	})
 	if err != nil {
 		return err
 	}
@@ -69,6 +73,24 @@ func processLayer(ctx context.Context, j layerJob) error {
 	j.result.erofsPath = erofsPath
 	j.tracker.OnEvent(ociProgress.Event{Phase: ociProgress.PhaseLayer, Index: j.idx, Total: j.total, Digest: digestHex[:12]})
 	return nil
+}
+
+// convertLayer downloads and converts one layer into a fresh layerDir; the
+// remote stream cannot resume, so each attempt redoes the whole layer and
+// must not see a previous attempt's partial erofs or scanned boot files.
+func convertLayer(ctx context.Context, j layerJob, layerDir, digestHex, layerUUID, erofsPath string) (kernelPath, initrdPath string, err error) {
+	if err = os.RemoveAll(layerDir); err != nil {
+		return "", "", fmt.Errorf("reset layer work dir: %w", err)
+	}
+	if err = os.MkdirAll(layerDir, 0o750); err != nil {
+		return "", "", fmt.Errorf("create layer work dir: %w", err)
+	}
+	rc, err := j.layer.Uncompressed()
+	if err != nil {
+		return "", "", fmt.Errorf("open uncompressed layer: %w", err)
+	}
+	defer rc.Close() //nolint:errcheck
+	return runErofsConversion(ctx, rc, layerDir, digestHex, layerUUID, erofsPath)
 }
 
 func handleCachedLayer(ctx context.Context, j layerJob, digestHex string) {
@@ -87,5 +109,29 @@ func applyCachedLayerPaths(conf *Config, result *pullLayerResult, digestHex stri
 	}
 	if utils.ValidFile(conf.InitrdPath(digestHex)) {
 		result.initrdPath = conf.InitrdPath(digestHex)
+	}
+}
+
+// retryLayer runs one layer attempt up to attempts times, sleeping backoff
+// between failures. A transient stream break is indistinguishable from bad
+// input by the time mkfs or the boot scan reports it, so every error is
+// retried — the attempt count bounds the waste and re-downloads are
+// digest-addressed. Context cancellation stops the retries immediately.
+func retryLayer(ctx context.Context, attempts int, backoff time.Duration, fn func() error) error {
+	var err error
+	for attempt := 1; ; attempt++ {
+		if err = fn(); err == nil {
+			return nil
+		}
+		if attempt == attempts || ctx.Err() != nil {
+			return err
+		}
+		timer := time.NewTimer(backoff)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return err
+		case <-timer.C:
+		}
 	}
 }

--- a/images/oci/process_test.go
+++ b/images/oci/process_test.go
@@ -1,0 +1,72 @@
+package oci
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRetryLayer(t *testing.T) {
+	sentinel := errors.New("stream broke")
+
+	t.Run("succeeds after transient failures", func(t *testing.T) {
+		calls := 0
+		err := retryLayer(t.Context(), 3, time.Millisecond, func() error {
+			calls++
+			if calls < 3 {
+				return sentinel
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("retryLayer() = %v, want nil", err)
+		}
+		if calls != 3 {
+			t.Fatalf("calls = %d, want 3", calls)
+		}
+	})
+
+	t.Run("exhausts attempts and returns the last error", func(t *testing.T) {
+		calls := 0
+		err := retryLayer(t.Context(), 3, time.Millisecond, func() error {
+			calls++
+			return sentinel
+		})
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("retryLayer() = %v, want %v", err, sentinel)
+		}
+		if calls != 3 {
+			t.Fatalf("calls = %d, want 3", calls)
+		}
+	})
+
+	t.Run("first success needs one call", func(t *testing.T) {
+		calls := 0
+		if err := retryLayer(t.Context(), 3, time.Millisecond, func() error {
+			calls++
+			return nil
+		}); err != nil {
+			t.Fatalf("retryLayer() = %v, want nil", err)
+		}
+		if calls != 1 {
+			t.Fatalf("calls = %d, want 1", calls)
+		}
+	})
+
+	t.Run("canceled context stops the retries", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		calls := 0
+		err := retryLayer(ctx, 5, time.Hour, func() error {
+			calls++
+			cancel()
+			return sentinel
+		})
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("retryLayer() = %v, want %v", err, sentinel)
+		}
+		if calls != 1 {
+			t.Fatalf("calls = %d, want 1 (no retry after cancel)", calls)
+		}
+	})
+}


### PR DESCRIPTION
## What

`processLayer` retries a failed layer download+conversion up to 3 attempts (2s apart), each in a fresh per-layer work dir so a partial erofs or half-scanned boot files from a broken attempt can never leak into the result. Context cancellation stops the retries immediately (the pull's worker pool cancels siblings on hard failure, and those must not burn retries).

Review follow-up (second commit): the #95 version gate is checked once in `processLayer` ahead of the retried region — a too-old mkfs.erofs is permanent, so retrying it would burn attempts, sleeps, and aborted blob GETs per layer (all-cached pulls still succeed on an old-mkfs host; the gate inside `startErofsConversion` keeps covering the import path). Also `time.After` replaces the timer dance and the `retryLayer` godoc is tightened.

## Why

A transient registry/network blip mid-stream currently fails the entire multi-layer pull — hit in practice on a 6-layer pull where one layer's stream broke. The HTTP-level retries in go-containerregistry only cover request setup; a stream that dies mid-body surfaces as an mkfs or boot-scan error and is indistinguishable from bad input at that point. Bounded retries with digest-addressed re-downloads are the proportionate fix: a genuinely bad layer wastes two extra attempts, a blip no longer kills the pull.

## Verification

- Unit: `TestRetryLayer` — succeeds-after-transient-failures, exhausts-attempts-returns-last-error, first-success-single-call, canceled-context-stops-retries.
- Hardware (Ubuntu 24.04 test node, isolated `--root-dir`): `image pull ghcr.io/cocoonstack/sandbox/boot:6.18.37` with the patched binary completes (happy path; the retry loop itself is unit-covered).
- `golangci-lint run ./images/oci/` clean on GOOS=linux and darwin.
