### PR TITLE
vm rm --force: skip the graceful window like stop --force

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ cocoon
 │   ├── console [flags] VM         Attach interactive console
 │   ├── exec [flags] VM -- CMD     Run a command in a running VM via cocoon-agent (vsock)
 │   ├── logs [-f] [--tail N] VM    Print the per-VM hypervisor log file
-│   ├── rm [flags] VM [VM...]      Delete VM(s) (--force to stop first)
+│   ├── rm [flags] VM [VM...]      Delete VM(s) (--force kills running VMs immediately)
 │   ├── restore [flags] VM SNAP   Restore a VM (running or stopped) to a snapshot
 │   ├── hibernate [flags] VM       Atomically snapshot a running VM and stop it
 │   ├── status [VM...]             Watch VM status in real time
@@ -668,6 +668,7 @@ OCI images must include a `resolve_disk()` init script that supports device path
 - **Direct-boot VMs (CH, OCI)**: `vm.shutdown` API → SIGTERM → 5s → SIGKILL (no ACPI support)
 - **Firecracker VMs**: `SendCtrlAltDel` → SIGTERM → 5s → SIGKILL
 - **Force stop** (`--force`): skip ACPI, immediate SIGTERM → SIGKILL
+- **Force delete** (`vm rm --force`): same immediate path as force stop, then delete — no graceful window
 - PID ownership is verified before sending signals to prevent killing unrelated processes
 
 ### Stop Flags

--- a/cmd/vm/commands.go
+++ b/cmd/vm/commands.go
@@ -138,7 +138,7 @@ func Command(h Actions) *cobra.Command {
 		Args:  cobra.MinimumNArgs(1),
 		RunE:  h.RM,
 	}
-	rmCmd.Flags().Bool("force", false, "force delete running VMs")
+	rmCmd.Flags().Bool("force", false, "force delete running VMs (immediate SIGTERM/SIGKILL, no graceful window)")
 	cliutil.AddOutputFlag(rmCmd)
 
 	restoreCmd := &cobra.Command{

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -42,6 +42,22 @@ type inspectOutput struct {
 	AttachedDevices *attachedDevices `json:"attached_devices,omitempty"`
 }
 
+// applyStopFlags maps --force / --timeout onto the stop window shared by the
+// stop and rm handlers: force means "now", docker-style (StopTimeoutSeconds
+// = -1, immediate SIGTERM/SIGKILL) — FC guests without i8042 never see
+// CtrlAltDel and would otherwise burn the full graceful window (#82). rm has
+// no --timeout flag; the missing-flag read is a no-op zero.
+func applyStopFlags(conf *config.Config, cmd *cobra.Command) {
+	force, _ := cmd.Flags().GetBool("force")
+	timeout, _ := cmd.Flags().GetInt("timeout")
+	switch {
+	case force:
+		conf.StopTimeoutSeconds = -1
+	case timeout > 0:
+		conf.StopTimeoutSeconds = timeout
+	}
+}
+
 func (h Handler) Start(cmd *cobra.Command, args []string) error {
 	ctx, conf, err := h.Init(cmd)
 	if err != nil {
@@ -72,14 +88,7 @@ func (h Handler) Stop(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	force, _ := cmd.Flags().GetBool("force")
-	timeout, _ := cmd.Flags().GetInt("timeout")
-
-	if force {
-		conf.StopTimeoutSeconds = -1
-	} else if timeout > 0 {
-		conf.StopTimeoutSeconds = timeout
-	}
+	applyStopFlags(conf, cmd)
 
 	hypers, err := cmdcore.InitAllHypervisors(ctx, conf)
 	if err != nil {
@@ -200,12 +209,7 @@ func (h Handler) RM(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	force, _ := cmd.Flags().GetBool("force")
-	// force means "now", docker-rm-like: skip the graceful window the same
-	// way stop --force does — FC guests without i8042 never see CtrlAltDel
-	// and would burn the full 30s per VM otherwise (#82).
-	if force {
-		conf.StopTimeoutSeconds = -1
-	}
+	applyStopFlags(conf, cmd)
 
 	hypers, err := cmdcore.InitAllHypervisors(ctx, conf)
 	if err != nil {

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -200,6 +200,12 @@ func (h Handler) RM(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	force, _ := cmd.Flags().GetBool("force")
+	// force means "now", docker-rm-like: skip the graceful window the same
+	// way stop --force does — FC guests without i8042 never see CtrlAltDel
+	// and would burn the full 30s per VM otherwise (#82).
+	if force {
+		conf.StopTimeoutSeconds = -1
+	}
 
 	hypers, err := cmdcore.InitAllHypervisors(ctx, conf)
 	if err != nil {

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -42,22 +42,6 @@ type inspectOutput struct {
 	AttachedDevices *attachedDevices `json:"attached_devices,omitempty"`
 }
 
-// applyStopFlags maps --force / --timeout onto the stop window shared by the
-// stop and rm handlers: force means "now", docker-style (StopTimeoutSeconds
-// = -1, immediate SIGTERM/SIGKILL) — FC guests without i8042 never see
-// CtrlAltDel and would otherwise burn the full graceful window (#82). rm has
-// no --timeout flag; the missing-flag read is a no-op zero.
-func applyStopFlags(conf *config.Config, cmd *cobra.Command) {
-	force, _ := cmd.Flags().GetBool("force")
-	timeout, _ := cmd.Flags().GetInt("timeout")
-	switch {
-	case force:
-		conf.StopTimeoutSeconds = -1
-	case timeout > 0:
-		conf.StopTimeoutSeconds = timeout
-	}
-}
-
 func (h Handler) Start(cmd *cobra.Command, args []string) error {
 	ctx, conf, err := h.Init(cmd)
 	if err != nil {
@@ -300,6 +284,20 @@ func (h Handler) recoverNetwork(ctx context.Context, conf *config.Config, hyper 
 		if _, recoverErr := netProvider.Add(ctx, vm.ID, &vm.Config, network.AddRecover(vm.NetworkConfigs)...); recoverErr != nil {
 			logger.Warnf(ctx, "recover network for VM %s: %v (start will fail)", vm.ID, recoverErr)
 		}
+	}
+}
+
+// applyStopFlags maps --force (-1 = immediate kill, docker-style; #82: FC
+// guests without i8042 never answer CtrlAltDel) and --timeout onto the stop
+// window for stop and rm; rm has no --timeout flag, that read no-ops.
+func applyStopFlags(conf *config.Config, cmd *cobra.Command) {
+	force, _ := cmd.Flags().GetBool("force")
+	timeout, _ := cmd.Flags().GetInt("timeout")
+	switch {
+	case force:
+		conf.StopTimeoutSeconds = -1
+	case timeout > 0:
+		conf.StopTimeoutSeconds = timeout
 	}
 }
 

--- a/cmd/vm/lifecycle_test.go
+++ b/cmd/vm/lifecycle_test.go
@@ -4,6 +4,10 @@ import (
 	"io"
 	"os"
 	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cocoonstack/cocoon/config"
 )
 
 func TestSeekToLastNLines(t *testing.T) {
@@ -38,6 +42,36 @@ func TestSeekToLastNLines(t *testing.T) {
 			}
 			if string(got) != tt.want {
 				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyStopFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		force   bool
+		timeout int
+		hasFlag bool
+		want    int
+	}{
+		{"force wins", true, 0, true, -1},
+		{"force beats timeout", true, 10, true, -1},
+		{"timeout applies", false, 10, true, 10},
+		{"defaults untouched", false, 0, true, 30},
+		{"rm has no timeout flag", true, 0, false, -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			cmd.Flags().Bool("force", tt.force, "")
+			if tt.hasFlag {
+				cmd.Flags().Int("timeout", tt.timeout, "")
+			}
+			conf := &config.Config{StopTimeoutSeconds: 30}
+			applyStopFlags(conf, cmd)
+			if conf.StopTimeoutSeconds != tt.want {
+				t.Errorf("StopTimeoutSeconds = %d, want %d", conf.StopTimeoutSeconds, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #82.

## What

`RM` now maps `--force` to `StopTimeoutSeconds = -1` before initializing the backends — identical to the `Stop` handler's mapping — so the stop-before-delete escalates immediately instead of burning the graceful window. Flag help updated to say so. Non-force behavior unchanged (running VM still refuses without `--force`).

## Why

`--force` meant two different things on `stop` and `rm`: on rm it only authorized deleting a running VM while still running the default 30s graceful stop. Firecracker's only graceful mechanism is CtrlAltDel via the emulated i8042, which minimal/sandbox guest kernels never observe — every `rm --force` of a running FC VM burned the full 30s. Ecosystem convention (docker rm -f, virsh destroy) is that force means now.

## Verification

Ubuntu 24.04 test node, FC `--nics 0` VM from a sandbox rt image:

- baseline official v0.4.8: `time vm rm --force` → **30.050s** (waits out the window)
- patched: → **0.046s**, VM deleted, run dir cleaned
- negative: `vm rm` (no --force) on a running VM still refuses with "running (force required)"
- `golangci-lint run ./cmd/vm/` clean on GOOS=linux and darwin