### PR TITLE
utils: close the exec race in TerminateProcess tests

### DIFF
--- a/utils/process_test.go
+++ b/utils/process_test.go
@@ -149,18 +149,6 @@ func TestVerifyProcessCmdline_WrongBinary(t *testing.T) {
 	_ = result // Just verify no panic.
 }
 
-// waitForExec blocks until /proc/<pid>/cmdline shows the target argv:
-// cmd.Start returns before the child execs, and TerminateProcess declines a
-// pid whose cmdline does not match (the stub-VMM race from cocoon#87).
-func waitForExec(t *testing.T, pid int, binaryName, expectArg string) {
-	t.Helper()
-	if err := WaitFor(t.Context(), 5*time.Second, time.Millisecond, func() (bool, error) {
-		return VerifyProcessCmdline(pid, binaryName, expectArg), nil
-	}); err != nil {
-		t.Fatalf("child never execed into %s: %v", binaryName, err)
-	}
-}
-
 func TestTerminateProcess_SleepProcess(t *testing.T) {
 	cmd := exec.Command("sleep", "60")
 	if err := cmd.Start(); err != nil {
@@ -309,4 +297,15 @@ func TestTerminateProcess_ContextCancelled(t *testing.T) {
 
 	// Cancelled ctx: may return WaitFor's ctx error but must still attempt the kill.
 	_ = TerminateProcess(ctx, pid, "sleep", "60", 100*time.Millisecond)
+}
+
+// waitForExec parks until the child's execve lands: cmd.Start returns
+// pre-exec, and TerminateProcess declines a mismatched cmdline (#87 race).
+func waitForExec(t *testing.T, pid int, binaryName, expectArg string) {
+	t.Helper()
+	if err := WaitFor(t.Context(), 5*time.Second, time.Millisecond, func() (bool, error) {
+		return VerifyProcessCmdline(pid, binaryName, expectArg), nil
+	}); err != nil {
+		t.Fatalf("child never execed into %s: %v", binaryName, err)
+	}
 }

--- a/utils/process_test.go
+++ b/utils/process_test.go
@@ -149,12 +149,25 @@ func TestVerifyProcessCmdline_WrongBinary(t *testing.T) {
 	_ = result // Just verify no panic.
 }
 
+// waitForExec blocks until /proc/<pid>/cmdline shows the target argv:
+// cmd.Start returns before the child execs, and TerminateProcess declines a
+// pid whose cmdline does not match (the stub-VMM race from cocoon#87).
+func waitForExec(t *testing.T, pid int, binaryName, expectArg string) {
+	t.Helper()
+	if err := WaitFor(t.Context(), 5*time.Second, time.Millisecond, func() (bool, error) {
+		return VerifyProcessCmdline(pid, binaryName, expectArg), nil
+	}); err != nil {
+		t.Fatalf("child never execed into %s: %v", binaryName, err)
+	}
+}
+
 func TestTerminateProcess_SleepProcess(t *testing.T) {
 	cmd := exec.Command("sleep", "60")
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start sleep: %v", err)
 	}
 	pid := cmd.Process.Pid
+	waitForExec(t, pid, "sleep", "60")
 
 	// Reap the child in background so it doesn't become a zombie after SIGTERM.
 	// Without this, kill(pid, 0) keeps returning nil for zombies and WaitFor times out.
@@ -217,6 +230,7 @@ func TestTerminateProcess_SIGTERMIgnored_FallsBackToKill(t *testing.T) {
 		t.Fatalf("start: %v", err)
 	}
 	pid := cmd.Process.Pid
+	waitForExec(t, pid, "bash", "sleep")
 
 	waitDone := make(chan struct{})
 	go func() {

--- a/utils/process_test.go
+++ b/utils/process_test.go
@@ -298,6 +298,7 @@ func TestTerminateProcess_ContextCancelled(t *testing.T) {
 		t.Fatal(err)
 	}
 	pid := cmd.Process.Pid
+	waitForExec(t, pid, "sleep", "60")
 	defer func() {
 		_ = cmd.Process.Kill()
 		_ = cmd.Wait()


### PR DESCRIPTION
Fixes the master CI timeout in [run 28918515841](https://github.com/cocoonstack/cocoon/actions/runs/28918515841): `TestTerminateProcess_SIGTERMIgnored_FallsBackToKill` hung 58s+.

## Root cause

`cmd.Start` returns before the child execs. On a slow runner `TerminateProcess` reads the pre-exec `/proc/<pid>/cmdline` (still the test binary), `VerifyProcessCmdline` declines the pid, so nothing is killed — the goroutine dump shows the reaper stuck in `cmd.Wait` on a bash still sleeping its full 60s, and the package breaches the 120s alarm. Same race as the stub-VMM test fixed in #87 round 3; `TestTerminateProcess_SleepProcess` had the identical exposure.

## Fix

`waitForExec` test helper — poll `VerifyProcessCmdline` (bounded 5s) after Start before exercising `TerminateProcess`; applied to both tests. Structural: the pre-exec window can no longer be observed.

## Verification

- `go test ./utils/ -run TestTerminateProcess -count=3` green on darwin
- `docker run golang:1.26 go test ./utils/ -run 'TestTerminateProcess|TestFindVMM' -count=5` green on Linux (the /proc path)
- `golangci-lint run ./utils/` clean on GOOS=linux and darwin