### PR TITLE
volumes primitives: vm disk attach/detach/list + vm clone --data-disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ Cocoon can hot-plug three classes of external resources onto a running VM:
 - **VFIO PCI passthrough** — a host PCI device bound to `vfio-pci` (GPU, NIC, NVMe). Attach hands the device to the guest with IOMMU isolation.
 - **Data disks** — an existing raw disk file, surfaced as `/dev/disk/by-id/virtio-<name>`. Cocoon never creates or deletes the backing file: it can outlive any VM and be re-attached elsewhere (a persistent volume).
 
-All attaches are **runtime-only**: the device lives only for the current VM process and is gone after stop/restart. Cocoon does not own the backend lifecycle (the user runs `virtiofsd`, binds the PCI device, provisions the disk file, etc.). Attached devices are not part of the VM record and are not preserved by snapshot / clone / restore. Cloud Hypervisor rejects snapshotting a VM with vhost-user or VFIO devices attached; a hot-attached **disk** is the exception — it is embedded in any later snapshot, so its backing file must stay readable at the same path for that snapshot to restore.
+All attaches are **runtime-only**: the device lives only for the current VM process and is gone after stop/restart. Cocoon does not own the backend lifecycle (the user runs `virtiofsd`, binds the PCI device, provisions the disk file, etc.). Attached devices are not part of the VM record and are not preserved by snapshot / clone / restore. Cloud Hypervisor rejects snapshotting a VM with vhost-user or VFIO devices attached; cocoon likewise refuses to snapshot or hibernate a VM with a hot-attached disk ("disk not present in VM record") — detach first. Attach/detach are also refused while the VM is paused (a snapshot/hibernate capture in flight).
 
 ### Vhost-user-fs
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Lightweight MicroVM engine with dual hypervisor backends: [Cloud Hypervisor](htt
 - **TC redirect I/O path** — veth ↔ TAP wired via ingress qdisc + mirred redirect (no bridge in the data path)
 - **DNS configuration** — custom DNS servers injected into VMs via kernel cmdline (OCI) or cloud-init network-config (cloudimg)
 - **Cloud-init metadata** — automatic NoCloud cidata FAT12 disk for cloudimg VMs (hostname, configurable user/password via `--user`/`--password`, multi-NIC Netplan v2 network-config); cidata is automatically skipped on subsequent boots
-- **User data disks** — `--data-disk` attaches additional virtio-blk disks per VM, with optional ext4 mkfs at create time, cloud-init `mounts:` auto-mount on cloudimg+CH (via `/dev/disk/by-id/virtio-<name>`), per-disk DirectIO override, and 1:1 inheritance through snapshot/clone/restore
+- **User data disks** — `--data-disk` attaches additional virtio-blk disks per VM, with optional ext4 mkfs at create time, cloud-init `mounts:` auto-mount on cloudimg+CH (via `/dev/disk/by-id/virtio-<name>`), per-disk DirectIO override, and 1:1 inheritance through snapshot/clone/restore; `vm clone --data-disk` adds fresh disks to a clone and `vm disk attach/detach` hot-plugs existing raw files on a running VM (both CH only)
 - **Hugepages** — automatic detection of host hugepage configuration; VM memory backed by hugepages when available
 - **Memory balloon** — 25% of memory returned via virtio-balloon (deflate-on-OOM, free-page reporting) when memory >= 256 MiB
 - **Graceful shutdown** — ACPI power-button for UEFI VMs with configurable timeout, fallback to SIGTERM → SIGKILL
@@ -152,6 +152,10 @@ cocoon
 │   ├── device
 │   │   ├── attach [flags] VM     Attach a VFIO PCI device (CH only)
 │   │   └── detach [flags] VM     Detach a VFIO PCI device by --id
+│   ├── disk
+│   │   ├── attach [flags] VM     Hot-attach an existing raw disk file (CH only)
+│   │   ├── detach [flags] VM     Detach a hot-attached disk by --name (keeps the file)
+│   │   └── list VM               List hot-attached disks
 │   ├── net [flags] VM             Resize NIC count on a running VM (CH only)
 │   └── debug [flags] IMAGE        Generate hypervisor launch command (dry run)
 ├── snapshot
@@ -224,6 +228,7 @@ Applies to `cocoon vm clone`:
 | `--on-demand` | `false`             | Use UFFD on-demand memory loading for faster clone (CH only; snapshot file must remain on disk) |
 | `--pull`  | `false`              | Auto-pull base image if not found locally (for cross-node clone)      |
 | `--from-dir` | empty                | Clone from a snapshot directory (must contain `snapshot.json`); mutually exclusive with positional `SNAPSHOT` |
+| `--data-disk` | empty (repeatable)  | Create a fresh data disk for the clone and hot-add it after restore: `size=20G[,name=...][,fstype=ext4|none]` (CH only; names must not collide with disks inherited from the snapshot) |
 
 CPU, memory, and storage all inherit from the snapshot — both hypervisors
 restore the guest from the snapshot's binary device state, so those values
@@ -482,18 +487,19 @@ cocoon vm run --data-disk size=20G,name=raw,fstype=none <oci-image>
 
 ### Snapshot/Clone/Restore
 
-Phase 1 inherits data disks 1:1: snapshot reflinks each `data-<name>.raw` into the snapshot tar, clone re-creates them under the new VM's runDir (and regenerates cidata so cloud-init re-mounts on the new identity), and restore rolls all data disks back to the snapshot timepoint along with the rootfs and memory state. Adding or removing data disks at clone time is not supported in Phase 1 — provision the disks at create time and treat the snapshot as immutable.
+Phase 1 inherits data disks 1:1: snapshot reflinks each `data-<name>.raw` into the snapshot tar, clone re-creates them under the new VM's runDir (and regenerates cidata so cloud-init re-mounts on the new identity), and restore rolls all data disks back to the snapshot timepoint along with the rootfs and memory state. Cloud Hypervisor clones can additionally CREATE fresh data disks at clone time via `--data-disk` (hot-added after restore — the snapshot's device tree itself cannot grow); removing inherited disks at clone time is not supported, and Firecracker clones reject `--data-disk`.
 
 Restore preflight verifies sidecar integrity, file presence (vmstate, memory, COW, every `data-*.raw`), and per-index Role/Path/RO match between sidecar and CH config.json **before** killing the running VM, so a malformed or imported snapshot fails fast and leaves the live VM untouched.
 
 ## Runtime Device Attach (Cloud Hypervisor only)
 
-Cocoon can hot-plug two classes of external resources onto a running VM:
+Cocoon can hot-plug three classes of external resources onto a running VM:
 
 - **Vhost-user-fs** — a file share served by an external `virtiofsd` (or compatible backend) over a Unix socket. Attach surfaces a virtio-fs device in the guest, accessible via `mount -t virtiofs <tag> /mnt/...`.
 - **VFIO PCI passthrough** — a host PCI device bound to `vfio-pci` (GPU, NIC, NVMe). Attach hands the device to the guest with IOMMU isolation.
+- **Data disks** — an existing raw disk file, surfaced as `/dev/disk/by-id/virtio-<name>`. Cocoon never creates or deletes the backing file: it can outlive any VM and be re-attached elsewhere (a persistent volume).
 
-Both attaches are **runtime-only**: the device lives only for the current VM process and is gone after stop/restart. Cocoon does not own the backend lifecycle (the user runs `virtiofsd`, binds the PCI device, etc.). Attached devices are not part of the VM record and are not preserved by snapshot / clone / restore. Cloud Hypervisor itself rejects snapshotting a VM that has vhost-user or VFIO devices attached, so plan accordingly.
+All attaches are **runtime-only**: the device lives only for the current VM process and is gone after stop/restart. Cocoon does not own the backend lifecycle (the user runs `virtiofsd`, binds the PCI device, provisions the disk file, etc.). Attached devices are not part of the VM record and are not preserved by snapshot / clone / restore. Cloud Hypervisor rejects snapshotting a VM with vhost-user or VFIO devices attached; a hot-attached **disk** is the exception — it is embedded in any later snapshot, so its backing file must stay readable at the same path for that snapshot to restore.
 
 ### Vhost-user-fs
 
@@ -525,6 +531,33 @@ Flags:
 | `--num-queues` | `1` | Request queues |
 | `--queue-size` | `1024` | Queue depth |
 
+### Data disk hot-attach
+
+```bash
+# Provision a raw disk file anywhere on the host (cocoon never touches its lifecycle).
+dd if=/dev/zero of=/srv/volumes/vol1.raw bs=1M count=1024 && mkfs.ext4 /srv/volumes/vol1.raw
+
+# Attach: name is the guest serial (/dev/disk/by-id/virtio-vol1) and the detach key.
+cocoon vm disk attach my-vm --path /srv/volumes/vol1.raw --name vol1
+
+# Inside the guest:
+mount /dev/disk/by-id/virtio-vol1 /mnt/vol1
+
+# Detach later (backing file kept; re-attach to any VM to see the same data):
+cocoon vm disk detach my-vm --name vol1
+```
+
+Flags:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--path` | required | Absolute path to an existing raw disk file |
+| `--name` | required | Guest serial and detach key (`^[a-z][a-z0-9_-]{0,19}$`) |
+| `--readonly` | `false` | Attach read-only |
+
+Re-attaching the same name immediately after a detach can race the guest's
+device teardown — give the guest a moment before the re-attach.
+
 ### VFIO PCI passthrough
 
 Prerequisite: host has `intel_iommu=on` (or `amd_iommu=on`) on the kernel command line and the target PCI device is bound to `vfio-pci`.
@@ -542,7 +575,7 @@ cocoon vm device attach my-vm --pci 01:00.0 --id mygpu
 cocoon vm device detach my-vm --id mygpu
 ```
 
-`cocoon vm inspect VM` includes an `attached_devices` field for running VMs that surfaces every attached vhost-user-fs share and VFIO device, read live from CH `vm.info`. The field is omitted for stopped VMs.
+`cocoon vm inspect VM` includes an `attached_devices` field for running VMs that surfaces every attached vhost-user-fs share, VFIO device, and hot-attached disk, read live from CH `vm.info`. The field is omitted for stopped VMs.
 
 ## NIC Hot-Resize (Cloud Hypervisor only)
 
@@ -718,7 +751,7 @@ A snapshot contains the full VM state:
 
 ### Clone Constraints
 
-CPU, memory, and storage are fixed at snapshot time on both backends: the guest is reconstructed from the snapshot's binary device state, so growing them at clone time would not be honored. NIC count inherits by default; Cloud Hypervisor clones can override it via `--nics N` (cocoon hot-swaps the snapshot's NICs for a fresh set right after restore). Firecracker clones must keep the snapshot's NIC topology — `--nics` is rejected because FC's `network_overrides` only retargets existing interfaces, it cannot add or drop them. Create a fresh VM with `cocoon vm run` if a different CPU/memory/storage shape is needed.
+CPU, memory, and storage are fixed at snapshot time on both backends: the guest is reconstructed from the snapshot's binary device state, so growing them at clone time would not be honored. NIC count inherits by default; Cloud Hypervisor clones can override it via `--nics N` (cocoon hot-swaps the snapshot's NICs for a fresh set right after restore). Firecracker clones must keep the snapshot's NIC topology — `--nics` is rejected because FC's `network_overrides` only retargets existing interfaces, it cannot add or drop them. Fresh data disks can be added to a Cloud Hypervisor clone via `--data-disk` (hot-added after restore); Firecracker rejects it — no hotplug. Create a fresh VM with `cocoon vm run` if a different CPU/memory/storage shape is needed.
 
 ### Post-Clone Guest Setup
 

--- a/cmd/core/vmconfig.go
+++ b/cmd/core/vmconfig.go
@@ -86,6 +86,11 @@ func CloneVMConfigFromFlags(cmd *cobra.Command, snapCfg types.SnapshotConfig) (*
 	}
 
 	onDemand, _ := cmd.Flags().GetBool("on-demand")
+	dataDiskRaw, _ := cmd.Flags().GetStringArray("data-disk")
+	dataDisks, err := parseDataDiskFlags(dataDiskRaw)
+	if err != nil {
+		return nil, err
+	}
 
 	return &types.VMConfig{
 		Name: vmName,
@@ -103,7 +108,8 @@ func CloneVMConfigFromFlags(cmd *cobra.Command, snapCfg types.SnapshotConfig) (*
 			Windows:       snapCfg.Windows,
 			SharedMemory:  snapCfg.SharedMemory,
 		},
-		OnDemand: onDemand,
+		DataDisks: dataDisks,
+		OnDemand:  onDemand,
 	}, nil
 }
 

--- a/cmd/vm/commands.go
+++ b/cmd/vm/commands.go
@@ -26,6 +26,9 @@ type Actions interface {
 	Status(cmd *cobra.Command, args []string) error
 	FsAttach(cmd *cobra.Command, args []string) error
 	FsDetach(cmd *cobra.Command, args []string) error
+	DiskAttach(cmd *cobra.Command, args []string) error
+	DiskDetach(cmd *cobra.Command, args []string) error
+	DiskList(cmd *cobra.Command, args []string) error
 	DeviceAttach(cmd *cobra.Command, args []string) error
 	DeviceDetach(cmd *cobra.Command, args []string) error
 	NetResize(cmd *cobra.Command, args []string) error
@@ -210,6 +213,7 @@ func Command(h Actions) *cobra.Command {
 		statusCmd,
 		buildFsCommand(h),
 		buildDeviceCommand(h),
+		buildDiskCommand(h),
 		buildNetCommand(h),
 	)
 	return vmCmd
@@ -226,6 +230,47 @@ func buildNetCommand(h Actions) *cobra.Command {
 	_ = cmd.MarkFlagRequired("nics")
 	cliutil.AddOutputFlag(cmd)
 	return cmd
+}
+
+func buildDiskCommand(h Actions) *cobra.Command {
+	parent := &cobra.Command{
+		Use:   "disk",
+		Short: "Attach/detach an extra raw data disk to a running VM (CH only)",
+	}
+
+	attach := &cobra.Command{
+		Use:   "attach VM",
+		Short: "Hot-attach an existing raw disk file to a running VM",
+		Args:  cobra.ExactArgs(1),
+		RunE:  h.DiskAttach,
+	}
+	attach.Flags().String("path", "", "absolute path to an existing raw disk file (required; never deleted by cocoon)")
+	attach.Flags().String("name", "", "disk name: guest /dev/disk/by-id/virtio-<name> and the detach key (required)")
+	attach.Flags().Bool("readonly", false, "attach read-only")
+	_ = attach.MarkFlagRequired("path")
+	_ = attach.MarkFlagRequired("name")
+	cliutil.AddOutputFlag(attach)
+
+	detach := &cobra.Command{
+		Use:   "detach VM",
+		Short: "Detach a hot-attached disk from a running VM (keeps the backing file)",
+		Args:  cobra.ExactArgs(1),
+		RunE:  h.DiskDetach,
+	}
+	detach.Flags().String("name", "", "disk name used at attach (required)")
+	_ = detach.MarkFlagRequired("name")
+	cliutil.AddOutputFlag(detach)
+
+	list := &cobra.Command{
+		Use:   "list VM",
+		Short: "List hot-attached disks on a running VM",
+		Args:  cobra.ExactArgs(1),
+		RunE:  h.DiskList,
+	}
+	cliutil.AddOutputFlag(list)
+
+	parent.AddCommand(attach, detach, list)
+	return parent
 }
 
 func buildFsCommand(h Actions) *cobra.Command {
@@ -322,5 +367,6 @@ func addCloneFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("no-direct-io", false, "disable O_DIRECT on writable disks (inherit from snapshot if not set)")
 	cmd.Flags().Bool("on-demand", false, "use UFFD on-demand memory loading for faster clone (CH only; snapshot file must remain on disk)")
 	cmd.Flags().Bool("pull", false, "auto-pull base image if not found locally (for cross-node clone)")
+	cmd.Flags().StringArray("data-disk", nil, "create and hot-add an extra data disk to the clone: size=20G[,name=...][,fstype=ext4|none]; repeatable (CH only)")
 	cmd.Flags().String("from-dir", "", "clone from a snapshot directory (must contain snapshot.json) instead of the local snapshot DB; mutually exclusive with positional SNAPSHOT")
 }

--- a/cmd/vm/disk.go
+++ b/cmd/vm/disk.go
@@ -1,0 +1,66 @@
+package vm
+
+import (
+	"github.com/projecteru2/core/log"
+	"github.com/spf13/cobra"
+
+	"github.com/cocoonstack/cocoon/cmd/cliutil"
+	"github.com/cocoonstack/cocoon/extend/disk"
+)
+
+func (h Handler) DiskAttach(cmd *cobra.Command, args []string) error {
+	ctx, _, _, a, err := resolveAttacher[disk.Attacher](h, cmd, args, "disk attach", disk.ErrUnsupportedBackend)
+	if err != nil {
+		return err
+	}
+	path, _ := cmd.Flags().GetString("path")
+	name, _ := cmd.Flags().GetString("name")
+	readonly, _ := cmd.Flags().GetBool("readonly")
+	id, err := a.DiskAttach(ctx, args[0], disk.Spec{Path: path, Name: name, ReadOnly: readonly})
+	if err != nil {
+		return classifyAttachErr(err)
+	}
+	if done, jsonErr := cliutil.MaybeOutputJSON(cmd, map[string]string{"vm": args[0], "name": name, "id": id}); done {
+		return jsonErr
+	}
+	log.WithFunc("cmd.vm.disk.attach").Infof(ctx, "attached disk name=%s id=%s vm=%s", name, id, args[0])
+	return nil
+}
+
+func (h Handler) DiskDetach(cmd *cobra.Command, args []string) error {
+	ctx, _, _, a, err := resolveAttacher[disk.Attacher](h, cmd, args, "disk detach", disk.ErrUnsupportedBackend)
+	if err != nil {
+		return err
+	}
+	name, _ := cmd.Flags().GetString("name")
+	if err := a.DiskDetach(ctx, args[0], name); err != nil {
+		return classifyAttachErr(err)
+	}
+	if done, jsonErr := cliutil.MaybeOutputJSON(cmd, map[string]string{"vm": args[0], "name": name}); done {
+		return jsonErr
+	}
+	log.WithFunc("cmd.vm.disk.detach").Infof(ctx, "detached disk name=%s vm=%s", name, args[0])
+	return nil
+}
+
+func (h Handler) DiskList(cmd *cobra.Command, args []string) error {
+	ctx, _, _, l, err := resolveAttacher[disk.Lister](h, cmd, args, "disk list", disk.ErrUnsupportedBackend)
+	if err != nil {
+		return err
+	}
+	disks, err := l.DiskList(ctx, args[0])
+	if err != nil {
+		return classifyAttachErr(err)
+	}
+	if done, jsonErr := cliutil.MaybeOutputJSON(cmd, disks); done {
+		return jsonErr
+	}
+	logger := log.WithFunc("cmd.vm.disk.list")
+	for _, d := range disks {
+		logger.Infof(ctx, "%s  %s  readonly=%v", d.Name, d.Path, d.ReadOnly)
+	}
+	if len(disks) == 0 {
+		logger.Info(ctx, "no hot-attached disks")
+	}
+	return nil
+}

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -16,6 +16,7 @@ import (
 	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
 	"github.com/cocoonstack/cocoon/config"
 	"github.com/cocoonstack/cocoon/console"
+	"github.com/cocoonstack/cocoon/extend/disk"
 	"github.com/cocoonstack/cocoon/extend/fs"
 	"github.com/cocoonstack/cocoon/extend/vfio"
 	"github.com/cocoonstack/cocoon/hypervisor"
@@ -35,6 +36,7 @@ const (
 type attachedDevices struct {
 	Fs      []fs.Attached   `json:"fs,omitempty"`
 	Devices []vfio.Attached `json:"devices,omitempty"`
+	Disks   []disk.Attached `json:"disks,omitempty"`
 }
 
 type inspectOutput struct {
@@ -384,7 +386,14 @@ func collectAttachedDevices(ctx context.Context, hyper hypervisor.Hypervisor, re
 			out.Devices = devs
 		}
 	}
-	if len(out.Fs) == 0 && len(out.Devices) == 0 {
+	if l, ok := hyper.(disk.Lister); ok {
+		if devs, err := l.DiskList(ctx, ref); err != nil {
+			logger.Warnf(ctx, "list hot-attached disks for %s: %v", ref, err)
+		} else {
+			out.Disks = devs
+		}
+	}
+	if len(out.Fs) == 0 && len(out.Devices) == 0 && len(out.Disks) == 0 {
 		return nil
 	}
 	return out

--- a/cmd/vm/run.go
+++ b/cmd/vm/run.go
@@ -334,8 +334,7 @@ func (h Handler) prepareClone(ctx context.Context, cmd *cobra.Command, conf *con
 		}
 		nics, _ = cmd.Flags().GetInt("nics")
 	}
-	// Fast-fail beside the --nics precedent, before network setup and tar
-	// extraction; fc's clone-extract guard stays as the library backstop.
+	// Pre-extract fast-fail; fc's clone-extract guard stays as the library backstop.
 	if len(vmCfg.DataDisks) > 0 && conf.UseFirecracker {
 		return nil, "", nil, types.NetSetup{}, fmt.Errorf("--data-disk on clone is Cloud Hypervisor only (Firecracker has no disk hotplug): %w", disk.ErrUnsupportedBackend)
 	}

--- a/cmd/vm/run.go
+++ b/cmd/vm/run.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cocoonstack/cocoon/cmd/cliutil"
 	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
 	"github.com/cocoonstack/cocoon/config"
+	"github.com/cocoonstack/cocoon/extend/disk"
 	"github.com/cocoonstack/cocoon/hypervisor"
 	"github.com/cocoonstack/cocoon/network"
 	"github.com/cocoonstack/cocoon/snapshot"
@@ -332,6 +333,11 @@ func (h Handler) prepareClone(ctx context.Context, cmd *cobra.Command, conf *con
 			return nil, "", nil, types.NetSetup{}, fmt.Errorf("--nics override on clone is Cloud Hypervisor only (FC network_overrides retargets existing NICs, not resize)")
 		}
 		nics, _ = cmd.Flags().GetInt("nics")
+	}
+	// Fast-fail beside the --nics precedent, before network setup and tar
+	// extraction; fc's clone-extract guard stays as the library backstop.
+	if len(vmCfg.DataDisks) > 0 && conf.UseFirecracker {
+		return nil, "", nil, types.NetSetup{}, fmt.Errorf("--data-disk on clone is Cloud Hypervisor only (Firecracker has no disk hotplug): %w", disk.ErrUnsupportedBackend)
 	}
 	netProvider, netSetup, err := initNetwork(ctx, conf, vmID, nics, vmCfg, tapQueues(vmCfg.CPU, conf.UseFirecracker), bridgeDev)
 	if err != nil {

--- a/extend/disk/disk.go
+++ b/extend/disk/disk.go
@@ -1,7 +1,6 @@
-// Package disk is the runtime attach interface for extra virtio-blk data
-// disks backed by existing raw files. Attach is runtime-only: the disk is
-// not part of the VM record, snapshot/hibernate of the VM is refused while
-// one is attached (detach first), and detach never deletes the backing file.
+// Package disk is the runtime attach interface for extra virtio-blk disks
+// backed by existing raw files. Attach is runtime-only — snapshot/hibernate
+// is refused while one is attached; detach never deletes the backing file.
 package disk
 
 import (
@@ -26,8 +25,7 @@ type Spec struct {
 	ReadOnly bool
 }
 
-// Normalize enforces required fields; the name doubles as the guest serial
-// (/dev/disk/by-id/virtio-<name>) and the detach key.
+// Normalize enforces required fields; Name doubles as the guest serial (/dev/disk/by-id/virtio-<name>) and the detach key.
 func (s *Spec) Normalize() error {
 	if s.Path == "" {
 		return fmt.Errorf("path is required")
@@ -63,8 +61,7 @@ type Lister interface {
 	DiskList(ctx context.Context, vmRef string) ([]Attached, error)
 }
 
-// DeriveID returns the deterministic CH device id for a disk name (used by
-// attach + detach so concurrent attaches collide on CH's id check).
+// DeriveID returns the deterministic CH device id for a disk name (used by attach + detach so concurrent attaches collide on CH's id check).
 func DeriveID(name string) string {
 	return diskIDPrefix + name
 }

--- a/extend/disk/disk.go
+++ b/extend/disk/disk.go
@@ -1,0 +1,77 @@
+// Package disk is the runtime attach interface for extra virtio-blk data
+// disks backed by existing raw files. Attach is runtime-only — a hot-added
+// disk joins any snapshot taken afterwards, so its backing file must stay
+// readable at the same path for later restores; detach never deletes the
+// backing file.
+package disk
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/cocoonstack/cocoon/types"
+)
+
+// ErrUnsupportedBackend signals the backend cannot hot-plug virtio-blk disks (e.g. Firecracker).
+var ErrUnsupportedBackend = errors.New("backend does not support disk attach")
+
+// Spec is one attach request: an existing raw disk file.
+type Spec struct {
+	Path     string
+	Name     string
+	ReadOnly bool
+}
+
+// Normalize enforces required fields; the name doubles as the guest serial
+// (/dev/disk/by-id/virtio-<name>) and the detach key.
+func (s *Spec) Normalize() error {
+	if s.Path == "" {
+		return fmt.Errorf("path is required")
+	}
+	if !filepath.IsAbs(s.Path) {
+		return fmt.Errorf("path must be absolute, got %q", s.Path)
+	}
+	if s.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	if !types.ValidDataDiskName(s.Name) {
+		return fmt.Errorf("name %q invalid: must match ^[a-z][a-z0-9_-]{0,19}$", s.Name)
+	}
+	return nil
+}
+
+// Attached is the inspect-time view of one hot-added disk read from the running VM's CH config.
+type Attached struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Path     string `json:"path"`
+	ReadOnly bool   `json:"readonly,omitempty"`
+}
+
+// Attacher hot-plugs and removes virtio-blk data disks on a running VM.
+type Attacher interface {
+	DiskAttach(ctx context.Context, vmRef string, spec Spec) (deviceID string, err error)
+	DiskDetach(ctx context.Context, vmRef, name string) error
+}
+
+// Lister enumerates hot-added disks from running VM state.
+type Lister interface {
+	DiskList(ctx context.Context, vmRef string) ([]Attached, error)
+}
+
+// DeriveID returns the deterministic CH device id for a disk name (used by
+// attach + detach so concurrent attaches collide on CH's id check).
+func DeriveID(name string) string {
+	return "cocoon-disk-" + name
+}
+
+// NameFromID reverses DeriveID; empty when id is not a hot-added disk.
+func NameFromID(id string) string {
+	const prefix = "cocoon-disk-"
+	if len(id) > len(prefix) && id[:len(prefix)] == prefix {
+		return id[len(prefix):]
+	}
+	return ""
+}

--- a/extend/disk/disk.go
+++ b/extend/disk/disk.go
@@ -1,8 +1,7 @@
 // Package disk is the runtime attach interface for extra virtio-blk data
-// disks backed by existing raw files. Attach is runtime-only — a hot-added
-// disk joins any snapshot taken afterwards, so its backing file must stay
-// readable at the same path for later restores; detach never deletes the
-// backing file.
+// disks backed by existing raw files. Attach is runtime-only: the disk is
+// not part of the VM record, snapshot/hibernate of the VM is refused while
+// one is attached (detach first), and detach never deletes the backing file.
 package disk
 
 import (
@@ -67,10 +66,11 @@ func DeriveID(name string) string {
 	return "cocoon-disk-" + name
 }
 
-// NameFromID reverses DeriveID; empty when id is not a hot-added disk.
+// NameFromID reverses DeriveID; empty when id is not a hot-added disk
+// (foreign same-prefix ids with an illegal name suffix are not ours).
 func NameFromID(id string) string {
 	const prefix = "cocoon-disk-"
-	if len(id) > len(prefix) && id[:len(prefix)] == prefix {
+	if len(id) > len(prefix) && id[:len(prefix)] == prefix && types.ValidDataDiskName(id[len(prefix):]) {
 		return id[len(prefix):]
 	}
 	return ""

--- a/extend/disk/disk.go
+++ b/extend/disk/disk.go
@@ -9,9 +9,12 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/cocoonstack/cocoon/types"
 )
+
+const diskIDPrefix = "cocoon-disk-"
 
 // ErrUnsupportedBackend signals the backend cannot hot-plug virtio-blk disks (e.g. Firecracker).
 var ErrUnsupportedBackend = errors.New("backend does not support disk attach")
@@ -63,15 +66,15 @@ type Lister interface {
 // DeriveID returns the deterministic CH device id for a disk name (used by
 // attach + detach so concurrent attaches collide on CH's id check).
 func DeriveID(name string) string {
-	return "cocoon-disk-" + name
+	return diskIDPrefix + name
 }
 
 // NameFromID reverses DeriveID; empty when id is not a hot-added disk
 // (foreign same-prefix ids with an illegal name suffix are not ours).
 func NameFromID(id string) string {
-	const prefix = "cocoon-disk-"
-	if len(id) > len(prefix) && id[:len(prefix)] == prefix && types.ValidDataDiskName(id[len(prefix):]) {
-		return id[len(prefix):]
+	name, ok := strings.CutPrefix(id, diskIDPrefix)
+	if ok && types.ValidDataDiskName(name) {
+		return name
 	}
 	return ""
 }

--- a/extend/disk/disk_test.go
+++ b/extend/disk/disk_test.go
@@ -37,3 +37,11 @@ func TestDeriveIDRoundTrip(t *testing.T) {
 		t.Fatalf("NameFromID(foreign id) = %q, want empty", got)
 	}
 }
+
+func TestNameFromIDRejectsForeignSuffix(t *testing.T) {
+	for _, id := range []string{"cocoon-disk-VOL1", "cocoon-disk-", "cocoon-disk-9bad", "cocoon-disk-abcdefghijklmnopqrstu"} {
+		if got := NameFromID(id); got != "" {
+			t.Errorf("NameFromID(%q) = %q, want empty", id, got)
+		}
+	}
+}

--- a/extend/disk/disk_test.go
+++ b/extend/disk/disk_test.go
@@ -1,0 +1,39 @@
+package disk
+
+import "testing"
+
+func TestSpecNormalize(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    Spec
+		wantErr bool
+	}{
+		{"valid", Spec{Path: "/data/vol1.raw", Name: "vol1"}, false},
+		{"missing path", Spec{Name: "vol1"}, true},
+		{"relative path", Spec{Path: "vol1.raw", Name: "vol1"}, true},
+		{"missing name", Spec{Path: "/data/vol1.raw"}, true},
+		{"bad name", Spec{Path: "/data/vol1.raw", Name: "VOL1"}, true},
+		{"name too long", Spec{Path: "/d/v.raw", Name: "abcdefghijklmnopqrstu"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.spec.Normalize()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Normalize() = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDeriveIDRoundTrip(t *testing.T) {
+	id := DeriveID("vol1")
+	if id != "cocoon-disk-vol1" {
+		t.Fatalf("DeriveID = %q", id)
+	}
+	if got := NameFromID(id); got != "vol1" {
+		t.Fatalf("NameFromID(%q) = %q, want vol1", id, got)
+	}
+	if got := NameFromID("cocoon-fs-x"); got != "" {
+		t.Fatalf("NameFromID(foreign id) = %q, want empty", got)
+	}
+}

--- a/hypervisor/cloudhypervisor/api.go
+++ b/hypervisor/cloudhypervisor/api.go
@@ -119,6 +119,7 @@ type chVMInfoConfig struct {
 	Serial  chRuntimeFile `json:"serial"`
 	Console chRuntimeFile `json:"console"`
 	Memory  chMemory      `json:"memory"`
+	Disks   []chDisk      `json:"disks,omitempty"`
 	Fs      []chFs        `json:"fs,omitempty"`
 	Devices []chDevice    `json:"devices,omitempty"`
 	Nets    []chNet       `json:"net,omitempty"`

--- a/hypervisor/cloudhypervisor/api.go
+++ b/hypervisor/cloudhypervisor/api.go
@@ -111,6 +111,7 @@ type chPciDeviceInfo struct {
 }
 
 type chVMInfoResponse struct {
+	State      string                     `json:"state,omitempty"`
 	Config     chVMInfoConfig             `json:"config"`
 	DeviceTree map[string]json.RawMessage `json:"device_tree,omitempty"`
 }

--- a/hypervisor/cloudhypervisor/clone.go
+++ b/hypervisor/cloudhypervisor/clone.go
@@ -22,6 +22,7 @@ type cloneResumeOpts struct {
 	directBoot          bool
 	hadCidataInSnapshot bool
 	storageConfigs      []*types.StorageConfig
+	dataDisks           []*types.StorageConfig
 	networkConfigs      []*types.NetworkConfig
 	snapshotCfg         *chVMConfig
 }
@@ -71,11 +72,17 @@ func (ch *CloudHypervisor) cloneAfterExtract(ctx context.Context, vmID string, v
 	if err != nil {
 		return nil, err
 	}
+	// The patch list is taken before the new --data-disk configs are appended:
+	// they are not in the snapshot's device tree and are hot-added post-restore.
+	patchStorageConfigs := restorePatchStorageConfigs(storageConfigs, directBoot, vmCfg.Windows, hadCidataInSnapshot)
+	newDataDisks, err := ch.prepareCloneDataDisks(ctx, vmID, vmCfg, storageConfigs)
+	if err != nil {
+		return nil, err
+	}
+	storageConfigs = append(storageConfigs, newDataDisks...)
 	if vErr := types.ValidateStorageConfigs(storageConfigs); vErr != nil {
 		return nil, fmt.Errorf("validate post-cidata storage: %w", vErr)
 	}
-
-	patchStorageConfigs := restorePatchStorageConfigs(storageConfigs, directBoot, vmCfg.Windows, hadCidataInSnapshot)
 
 	consoleSock := hypervisor.ConsoleSockPath(runDir)
 	if err = patchCHConfig(chConfigPath, &patchOptions{
@@ -120,6 +127,7 @@ func (ch *CloudHypervisor) cloneAfterExtract(ctx context.Context, vmID string, v
 		directBoot:          directBoot,
 		hadCidataInSnapshot: hadCidataInSnapshot,
 		storageConfigs:      storageConfigs,
+		dataDisks:           newDataDisks,
 		networkConfigs:      networkConfigs,
 		snapshotCfg:         chCfg,
 	}); err != nil {
@@ -172,10 +180,33 @@ func (ch *CloudHypervisor) restoreAndResumeClone(
 			return fmt.Errorf("vm.add-disk (cidata): %w", err)
 		}
 	}
+	for _, sc := range opts.dataDisks {
+		if err = addDiskVM(ctx, hc, storageConfigToDisk(sc, opts.vmCfg.CPU, opts.vmCfg.DiskQueueSize, opts.vmCfg.NoDirectIO)); err != nil {
+			return fmt.Errorf("vm.add-disk (data %s): %w", sc.Serial, err)
+		}
+	}
 	if err = resumeVM(ctx, hc); err != nil {
 		return fmt.Errorf("vm.resume: %w", err)
 	}
 	return nil
+}
+
+// prepareCloneDataDisks creates the --data-disk files requested for a clone.
+// The snapshot's device tree cannot grow at restore, so these are hot-added
+// after resume; a name colliding with an inherited disk's serial would
+// overwrite its backing file in the clone run dir.
+func (ch *CloudHypervisor) prepareCloneDataDisks(ctx context.Context, vmID string, vmCfg *types.VMConfig, existing []*types.StorageConfig) ([]*types.StorageConfig, error) {
+	if len(vmCfg.DataDisks) == 0 {
+		return nil, nil
+	}
+	for _, spec := range vmCfg.DataDisks {
+		for _, sc := range existing {
+			if sc.Serial == spec.Name {
+				return nil, fmt.Errorf("--data-disk name %q collides with a disk inherited from the snapshot", spec.Name)
+			}
+		}
+	}
+	return hypervisor.PrepareDataDisks(ctx, ch.conf.VMRunDir(vmID), vmCfg.DataDisks)
 }
 
 func (ch *CloudHypervisor) ensureCloneCidata(vmID string, vmCfg *types.VMConfig, networkConfigs []*types.NetworkConfig, storageConfigs []*types.StorageConfig, directBoot bool) ([]*types.StorageConfig, error) {

--- a/hypervisor/cloudhypervisor/clone.go
+++ b/hypervisor/cloudhypervisor/clone.go
@@ -191,10 +191,9 @@ func (ch *CloudHypervisor) restoreAndResumeClone(
 	return nil
 }
 
-// prepareCloneDataDisks creates the --data-disk files requested for a clone.
-// The snapshot's device tree cannot grow at restore, so these are hot-added
-// after restore, before resume; a name colliding with an inherited disk's
-// serial would overwrite its backing file in the clone run dir.
+// prepareCloneDataDisks creates the --data-disk files requested for a clone;
+// a name colliding with an inherited disk's serial would overwrite its
+// backing file in the clone run dir, hence the pre-create scan.
 func (ch *CloudHypervisor) prepareCloneDataDisks(ctx context.Context, vmID string, vmCfg *types.VMConfig, existing []*types.StorageConfig) ([]*types.StorageConfig, error) {
 	if len(vmCfg.DataDisks) == 0 {
 		return nil, nil

--- a/hypervisor/cloudhypervisor/clone.go
+++ b/hypervisor/cloudhypervisor/clone.go
@@ -193,8 +193,8 @@ func (ch *CloudHypervisor) restoreAndResumeClone(
 
 // prepareCloneDataDisks creates the --data-disk files requested for a clone.
 // The snapshot's device tree cannot grow at restore, so these are hot-added
-// after resume; a name colliding with an inherited disk's serial would
-// overwrite its backing file in the clone run dir.
+// after restore, before resume; a name colliding with an inherited disk's
+// serial would overwrite its backing file in the clone run dir.
 func (ch *CloudHypervisor) prepareCloneDataDisks(ctx context.Context, vmID string, vmCfg *types.VMConfig, existing []*types.StorageConfig) ([]*types.StorageConfig, error) {
 	if len(vmCfg.DataDisks) == 0 {
 		return nil, nil

--- a/hypervisor/cloudhypervisor/extend.go
+++ b/hypervisor/cloudhypervisor/extend.go
@@ -215,10 +215,8 @@ func (ch *CloudHypervisor) attachWith(
 	if err != nil {
 		return "", err
 	}
-	// A paused VMM means a snapshot/hibernate/fork capture window is open;
-	// mutating the device set mid-capture would desync config and memory.
-	if info.State == chStatePaused {
-		return "", fmt.Errorf("vm is paused (snapshot or hibernate in flight); retry after it completes")
+	if err = ensureNotPaused(info); err != nil {
+		return "", err
 	}
 	if checkErr := preCheck(info); checkErr != nil {
 		return "", checkErr
@@ -251,10 +249,10 @@ func (ch *CloudHypervisor) detachWith(
 	findID func(*chVMInfoResponse) (string, error),
 ) error {
 	hc, info, err := ch.inspectRunning(ctx, vmRef)
-	if err == nil && info.State == chStatePaused {
-		err = fmt.Errorf("vm is paused (snapshot or hibernate in flight); retry after it completes")
-	}
 	if err != nil {
+		return err
+	}
+	if err = ensureNotPaused(info); err != nil {
 		return err
 	}
 	deviceID, err := findID(info)
@@ -263,6 +261,15 @@ func (ch *CloudHypervisor) detachWith(
 	}
 	if err := removeDeviceVM(ctx, hc, deviceID); err != nil {
 		return fmt.Errorf("vm.remove-device %s: %w", deviceID, err)
+	}
+	return nil
+}
+
+// ensureNotPaused refuses device-set mutations while a capture window is open
+// (snapshot/hibernate/fork): mutating mid-capture would desync config and memory.
+func ensureNotPaused(info *chVMInfoResponse) error {
+	if info.State == chStatePaused {
+		return fmt.Errorf("vm is paused (snapshot or hibernate in flight); retry after it completes")
 	}
 	return nil
 }

--- a/hypervisor/cloudhypervisor/extend.go
+++ b/hypervisor/cloudhypervisor/extend.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/cocoonstack/cocoon/extend/disk"
 	"github.com/cocoonstack/cocoon/extend/fs"
 	"github.com/cocoonstack/cocoon/extend/netresize"
 	"github.com/cocoonstack/cocoon/extend/vfio"
@@ -18,12 +19,73 @@ import (
 )
 
 var (
+	_ disk.Attacher     = (*CloudHypervisor)(nil)
+	_ disk.Lister       = (*CloudHypervisor)(nil)
 	_ fs.Attacher       = (*CloudHypervisor)(nil)
 	_ fs.Lister         = (*CloudHypervisor)(nil)
 	_ vfio.Attacher     = (*CloudHypervisor)(nil)
 	_ vfio.Lister       = (*CloudHypervisor)(nil)
 	_ netresize.Resizer = (*CloudHypervisor)(nil)
 )
+
+func (ch *CloudHypervisor) DiskAttach(ctx context.Context, vmRef string, spec disk.Spec) (string, error) {
+	if err := spec.Normalize(); err != nil {
+		return "", err
+	}
+	if _, err := os.Stat(spec.Path); err != nil {
+		return "", fmt.Errorf("disk path: %w", err)
+	}
+	vm, err := ch.Inspect(ctx, vmRef)
+	if err != nil {
+		return "", err
+	}
+	// Route through storageConfigToDisk: the CH fork refuses disks without an
+	// explicit image_type, and DirectIO/queue semantics must match create-path
+	// data disks.
+	d := storageConfigToDisk(&types.StorageConfig{
+		Role: types.StorageRoleData, Path: spec.Path, Serial: spec.Name, RO: spec.ReadOnly,
+	}, vm.Config.CPU, vm.Config.DiskQueueSize, vm.Config.NoDirectIO)
+	id := disk.DeriveID(spec.Name)
+	d.ID = id
+	return ch.attachWith(ctx, vmRef, "vm.add-disk", d, id, func(info *chVMInfoResponse) error {
+		for _, ex := range info.Config.Disks {
+			if ex.ID == id {
+				return fmt.Errorf("disk name %q already attached", spec.Name)
+			}
+			if ex.Path == spec.Path {
+				return fmt.Errorf("disk path %q already attached as %q", spec.Path, ex.ID)
+			}
+		}
+		return nil
+	})
+}
+
+func (ch *CloudHypervisor) DiskDetach(ctx context.Context, vmRef, name string) error {
+	if name == "" {
+		return fmt.Errorf("name is required")
+	}
+	id := disk.DeriveID(name)
+	return ch.detachWith(ctx, vmRef, func(info *chVMInfoResponse) (string, error) {
+		for _, ex := range info.Config.Disks {
+			if ex.ID == id {
+				return ex.ID, nil
+			}
+		}
+		return "", fmt.Errorf("disk %q not attached", name)
+	})
+}
+
+func (ch *CloudHypervisor) DiskList(ctx context.Context, vmRef string) ([]disk.Attached, error) {
+	return listWith(ctx, ch, vmRef, func(info *chVMInfoResponse) []disk.Attached {
+		var out []disk.Attached
+		for _, d := range info.Config.Disks {
+			if name := disk.NameFromID(d.ID); name != "" {
+				out = append(out, disk.Attached{ID: d.ID, Name: name, Path: d.Path, ReadOnly: d.ReadOnly})
+			}
+		}
+		return out
+	})
+}
 
 func (ch *CloudHypervisor) FsAttach(ctx context.Context, vmRef string, spec fs.Spec) (string, error) {
 	if err := spec.Normalize(); err != nil {

--- a/hypervisor/cloudhypervisor/extend.go
+++ b/hypervisor/cloudhypervisor/extend.go
@@ -18,6 +18,8 @@ import (
 	"github.com/cocoonstack/cocoon/utils"
 )
 
+const chStatePaused = "Paused"
+
 var (
 	_ disk.Attacher     = (*CloudHypervisor)(nil)
 	_ disk.Lister       = (*CloudHypervisor)(nil)
@@ -213,6 +215,11 @@ func (ch *CloudHypervisor) attachWith(
 	if err != nil {
 		return "", err
 	}
+	// A paused VMM means a snapshot/hibernate/fork capture window is open;
+	// mutating the device set mid-capture would desync config and memory.
+	if info.State == chStatePaused {
+		return "", fmt.Errorf("vm is paused (snapshot or hibernate in flight); retry after it completes")
+	}
 	if checkErr := preCheck(info); checkErr != nil {
 		return "", checkErr
 	}
@@ -244,6 +251,9 @@ func (ch *CloudHypervisor) detachWith(
 	findID func(*chVMInfoResponse) (string, error),
 ) error {
 	hc, info, err := ch.inspectRunning(ctx, vmRef)
+	if err == nil && info.State == chStatePaused {
+		err = fmt.Errorf("vm is paused (snapshot or hibernate in flight); retry after it completes")
+	}
 	if err != nil {
 		return err
 	}

--- a/hypervisor/cloudhypervisor/extend.go
+++ b/hypervisor/cloudhypervisor/extend.go
@@ -41,9 +41,8 @@ func (ch *CloudHypervisor) DiskAttach(ctx context.Context, vmRef string, spec di
 	if err != nil {
 		return "", err
 	}
-	// Route through storageConfigToDisk: the CH fork refuses disks without an
-	// explicit image_type, and DirectIO/queue semantics must match create-path
-	// data disks.
+	// The CH fork refuses disks without an explicit image_type; DirectIO/queue
+	// semantics must match create-path data disks.
 	d := storageConfigToDisk(&types.StorageConfig{
 		Role: types.StorageRoleData, Path: spec.Path, Serial: spec.Name, RO: spec.ReadOnly,
 	}, vm.Config.CPU, vm.Config.DiskQueueSize, vm.Config.NoDirectIO)
@@ -265,15 +264,6 @@ func (ch *CloudHypervisor) detachWith(
 	return nil
 }
 
-// ensureNotPaused refuses device-set mutations while a capture window is open
-// (snapshot/hibernate/fork): mutating mid-capture would desync config and memory.
-func ensureNotPaused(info *chVMInfoResponse) error {
-	if info.State == chStatePaused {
-		return fmt.Errorf("vm is paused (snapshot or hibernate in flight); retry after it completes")
-	}
-	return nil
-}
-
 // runningVMClient asserts the CH process is alive and returns an http.Client on its API socket.
 func (ch *CloudHypervisor) runningVMClient(ctx context.Context, vmRef string) (*http.Client, error) {
 	hc, _, _, err := ch.runningVMClientWithRecord(ctx, vmRef)
@@ -300,6 +290,15 @@ func (ch *CloudHypervisor) runningVMClientWithRecord(ctx context.Context, vmRef 
 }
 
 // listWith returns nil (not error) for stopped VMs so inspect can omit the field.
+// ensureNotPaused refuses device-set mutations while a capture window is open
+// (snapshot/hibernate/fork): mutating mid-capture would desync config and memory.
+func ensureNotPaused(info *chVMInfoResponse) error {
+	if info.State == chStatePaused {
+		return fmt.Errorf("vm is paused (snapshot or hibernate in flight); retry after it completes")
+	}
+	return nil
+}
+
 func listWith[A any](
 	ctx context.Context, ch *CloudHypervisor, vmRef string,
 	extract func(*chVMInfoResponse) []A,

--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -28,6 +28,9 @@ func (fc *Firecracker) Clone(ctx context.Context, vmID string, vmCfg *types.VMCo
 }
 
 func (fc *Firecracker) cloneAfterExtract(ctx context.Context, vmID string, vmCfg *types.VMConfig, net types.NetSetup, runDir, logDir string, now time.Time, sourceSnapshotID string) (*types.VM, error) {
+	if len(vmCfg.DataDisks) > 0 {
+		return nil, fmt.Errorf("--data-disk on clone is Cloud Hypervisor only (Firecracker has no disk hotplug)")
+	}
 	networkConfigs := net.NetworkConfigs
 	logger := log.WithFunc("firecracker.Clone")
 

--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/projecteru2/core/log"
 
+	"github.com/cocoonstack/cocoon/extend/disk"
 	"github.com/cocoonstack/cocoon/hypervisor"
 	"github.com/cocoonstack/cocoon/types"
 	"github.com/cocoonstack/cocoon/utils"
@@ -29,7 +30,7 @@ func (fc *Firecracker) Clone(ctx context.Context, vmID string, vmCfg *types.VMCo
 
 func (fc *Firecracker) cloneAfterExtract(ctx context.Context, vmID string, vmCfg *types.VMConfig, net types.NetSetup, runDir, logDir string, now time.Time, sourceSnapshotID string) (*types.VM, error) {
 	if len(vmCfg.DataDisks) > 0 {
-		return nil, fmt.Errorf("--data-disk on clone is Cloud Hypervisor only (Firecracker has no disk hotplug)")
+		return nil, fmt.Errorf("--data-disk on clone is Cloud Hypervisor only (Firecracker has no disk hotplug): %w", disk.ErrUnsupportedBackend)
 	}
 	networkConfigs := net.NetworkConfigs
 	logger := log.WithFunc("firecracker.Clone")

--- a/hypervisor/firecracker/clone_guard_test.go
+++ b/hypervisor/firecracker/clone_guard_test.go
@@ -1,0 +1,20 @@
+package firecracker
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cocoonstack/cocoon/extend/disk"
+	"github.com/cocoonstack/cocoon/types"
+)
+
+func TestCloneAfterExtractRejectsDataDisks(t *testing.T) {
+	fc := &Firecracker{}
+	_, err := fc.cloneAfterExtract(t.Context(), "id", &types.VMConfig{
+		DataDisks: []types.DataDiskSpec{{Name: "v", Size: 1 << 24}},
+	}, types.NetSetup{}, t.TempDir(), t.TempDir(), time.Now(), "")
+	if !errors.Is(err, disk.ErrUnsupportedBackend) {
+		t.Fatalf("err = %v, want disk.ErrUnsupportedBackend", err)
+	}
+}


### PR DESCRIPTION
Closes #98.

## What

The volumes building blocks for the sandbox workstream, all Cloud Hypervisor only (Firecracker has no hotplug — typed errors from the extend resolver and at FC's shared clone-extract point, covering both the stream and `--from-dir` paths):

- **`vm disk attach VM --path /file.raw --name x [--readonly]`** — hot-adds an EXISTING raw file to a running VM as `/dev/disk/by-id/virtio-<name>`. The file lives outside the VM dir and is never created or deleted by cocoon: it is the persistent-volume primitive.
- **`vm disk detach VM --name x`** — removes the device, keeps the backing file.
- **`vm disk list VM`** — hot-added disks from running CH state (`cocoon-disk-` id namespace).
- **`vm clone --data-disk size=…,name=…`** — creates fresh data disks for a clone and hot-adds them post-restore (the cidata pattern): a snapshot's device tree cannot grow at restore, so the new configs are excluded from the restore patch, appended to the persisted record, and added via `vm.add-disk` before resume. Names colliding with a disk serial inherited from the snapshot are rejected (they would overwrite its backing file in the clone run dir).

Implementation mirrors the extend/fs + extend/vfio siblings (attachWith/detachWith/listWith); disks route through `storageConfigToDisk` because the CH fork refuses disks without an explicit `image_type` and DirectIO/queue semantics must match create-path data disks (found on hardware: a hand-rolled payload attaches but the guest cannot read the superblock).

## Verification (Ubuntu 24.04 test node, CH + FC, sandbox rt image)

- attach → guest sees `virtio-vol1`, mounts, writes — `WRITE-OK`
- detach → device gone in guest, backing file intact on host
- re-attach the same file → **previously written marker read back** (persistence across attach cycles)
- `vm clone t98snap --data-disk size=64M,name=vol2` → clone mounts `virtio-vol2`, writes — `clone-disk-ok`
- FC negatives: `clone --data-disk` → "Cloud Hypervisor only" typed error; `vm disk attach` on an FC VM → "backend does not support disk attach"
- unit: extend/disk Normalize/DeriveID table tests; `golangci-lint` clean on GOOS=linux+darwin across all touched packages

Known behavior: re-attaching the same name immediately after detach can race the guest's device teardown — give the guest a moment (the attach succeeds; the by-id link may lag). Runtime-only contract like extend/fs — and snapshot/hibernate of a VM with a hot-attached disk is refused (`snapshot config has disk ... not present in VM record`): detach first, snapshot, re-attach.

## Divergence from #98, on record

The issue sketched a record-persisted attach (netresize rollback pattern) with detach dropping the record entry; this PR deliberately ships attach as **runtime-only**. The taxonomy is ownership-based: record-owned disks are files cocoon creates inside the runDir (create/clone `--data-disk` — reflinked into snapshots, die with the VM); an external volume must not be record-owned or snapshot/clone would fork it. Re-attaching across stop/start is the orchestrator's call (mechanism, not policy).
