### PR TITLE
review round + volumes: runtime-only disk attach, ops lock across all mutating verbs (incl. vm rm), symlink-proof volume checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ Cocoon can hot-plug three classes of external resources onto a running VM:
 - **VFIO PCI passthrough** — a host PCI device bound to `vfio-pci` (GPU, NIC, NVMe). Attach hands the device to the guest with IOMMU isolation.
 - **Data disks** — an existing raw disk file, surfaced as `/dev/disk/by-id/virtio-<name>`. Cocoon never creates or deletes the backing file: it can outlive any VM and be re-attached elsewhere (a persistent volume).
 
-All attaches are **runtime-only**: the device lives only for the current VM process and is gone after stop/restart. Cocoon does not own the backend lifecycle (the user runs `virtiofsd`, binds the PCI device, provisions the disk file, etc.). Attached devices are not part of the VM record and are not preserved by snapshot / clone / restore. Cloud Hypervisor rejects snapshotting a VM with vhost-user or VFIO devices attached; cocoon likewise refuses to snapshot or hibernate a VM with a hot-attached disk ("disk not present in VM record") — detach first. Attach/detach are also refused while the VM is paused (a snapshot/hibernate capture in flight).
+Fs and VFIO attaches are **runtime-only**: the device lives only for the current VM process and is gone after stop/restart, and Cloud Hypervisor rejects snapshotting while one is attached. **Disk attaches persist**: the volume is recorded on the VM, survives stop/start, and rides hibernate/wake transparently (the guest resumes with the volume still mounted). Snapshots carry only the volume *reference* — the backing file is never copied into a snapshot and must stay readable at its absolute path; restoring a snapshot older than the volume's current content leaves the volume as-is (its content is not rolled back). Cloning a snapshot that references an external volume is refused — a clone would share the writable file. Cocoon never owns backend lifecycles (the user runs `virtiofsd`, binds PCI devices, provisions volume files). All mutating verbs on one VM (attach/detach, net resize, snapshot, hibernate, restore, stop) serialize on a per-VM lock, so concurrent invocations cannot interleave with a capture window.
 
 ### Vhost-user-fs
 
@@ -546,6 +546,11 @@ mount /dev/disk/by-id/virtio-vol1 /mnt/vol1
 # Detach later (backing file kept; re-attach to any VM to see the same data):
 cocoon vm disk detach my-vm --name vol1
 ```
+
+The attach persists: `vm stop` + `vm start` brings the volume back, and
+`vm hibernate` + wake resumes the guest with the volume still mounted.
+Detach before `snapshot save` if the snapshot will be a clone source —
+clones of volume-referencing snapshots are refused.
 
 Flags:
 

--- a/README.md
+++ b/README.md
@@ -154,8 +154,7 @@ cocoon
 │   │   └── detach [flags] VM     Detach a VFIO PCI device by --id
 │   ├── disk
 │   │   ├── attach [flags] VM     Hot-attach an existing raw disk file (CH only)
-│   │   ├── detach [flags] VM     Detach a hot-attached disk by --name (keeps the file)
-│   │   └── list VM               List hot-attached disks
+│   │   └── detach [flags] VM     Detach a hot-attached disk by --name (keeps the file)
 │   ├── net [flags] VM             Resize NIC count on a running VM (CH only)
 │   └── debug [flags] IMAGE        Generate hypervisor launch command (dry run)
 ├── snapshot
@@ -499,7 +498,7 @@ Cocoon can hot-plug three classes of external resources onto a running VM:
 - **VFIO PCI passthrough** — a host PCI device bound to `vfio-pci` (GPU, NIC, NVMe). Attach hands the device to the guest with IOMMU isolation.
 - **Data disks** — an existing raw disk file, surfaced as `/dev/disk/by-id/virtio-<name>`. Cocoon never creates or deletes the backing file: it can outlive any VM and be re-attached elsewhere (a persistent volume).
 
-Fs and VFIO attaches are **runtime-only**: the device lives only for the current VM process and is gone after stop/restart, and Cloud Hypervisor rejects snapshotting while one is attached. **Disk attaches persist across stop/start** — the volume is recorded on the VM, so `vm stop` + `vm start` brings it back (with a deterministic device id, so `disk list`/`detach` keep working) — but they are **capture-excluded**: `snapshot save` and `vm hibernate` refuse to run while an external volume is attached. External volumes are runtime state cocoon does not own (the user provisions the file and manages its filesystem), so they never enter a snapshot; detach the volume (and umount it in-guest) before snapshotting or hibernating, and re-attach it after the wake/restore. This keeps snapshot, hibernate/wake, restore, and clone entirely free of external-volume reasoning. Cocoon never creates, copies, or deletes the backing file. All mutating verbs on one VM (attach/detach, net resize, snapshot, hibernate, restore, stop) serialize on a per-VM lock, so concurrent invocations cannot interleave with a capture window.
+All three attaches are **runtime-only**: the device lives only for the current VM process and is gone after stop/restart — re-attach after the next start. Cloud Hypervisor itself rejects snapshotting while a vhost-user or VFIO device is attached; cocoon likewise refuses `snapshot save` and `vm hibernate` while an external disk is attached — umount it in-guest, detach, capture, then re-attach after the wake/restore. External volumes are host state cocoon does not own: it never creates, copies, or deletes the backing file, and snapshot, restore, and clone carry no trace of them. All mutating verbs on one VM (attach/detach, net resize, snapshot, hibernate, restore, stop) serialize on a per-VM lock, so concurrent invocations cannot interleave with a capture window.
 
 ### Vhost-user-fs
 
@@ -547,12 +546,13 @@ mount /dev/disk/by-id/virtio-vol1 /mnt/vol1
 cocoon vm disk detach my-vm --name vol1
 ```
 
-The attach persists across `vm stop` + `vm start` (the volume comes back).
-`snapshot save` and `vm hibernate` refuse to run while a volume is attached —
-detach it (umount in-guest first), snapshot/hibernate, then re-attach after
-the wake or restore. The backing file may live anywhere outside cocoon's
-managed directories (e.g. under `/tmp`); attach refuses a path under the
-root/run dirs because `vm rm` would delete it with the run dir.
+The attach is runtime-only, like `vm fs` and `vm device`: the disk is gone
+after `vm stop`/restart — re-attach it after the next start. `snapshot save`
+and `vm hibernate` refuse while a volume is attached — umount in-guest,
+detach, capture, then re-attach after the wake or restore. The backing file
+may live anywhere outside cocoon's managed directories (e.g. under `/tmp`);
+attach refuses a path under the root/run dirs because `vm rm` would delete
+it with the run dir.
 
 Flags:
 

--- a/README.md
+++ b/README.md
@@ -554,6 +554,7 @@ Flags:
 | `--path` | required | Absolute path to an existing raw disk file |
 | `--name` | required | Guest serial and detach key (`^[a-z][a-z0-9_-]{0,19}$`) |
 | `--readonly` | `false` | Attach read-only |
+| `--directio` | `auto` | O_DIRECT for the disk: `on`/`off`/`auto` (use `off` for files on tmpfs) |
 
 Re-attaching the same name immediately after a detach can race the guest's
 device teardown — give the guest a moment before the re-attach.

--- a/README.md
+++ b/README.md
@@ -547,8 +547,8 @@ cocoon vm disk detach my-vm --name vol1
 ```
 
 The backing file may live anywhere outside cocoon's managed directories;
-attach refuses a path under the root/run/log dirs because `vm rm` would
-delete it along with them.
+attach resolves symlinks and refuses a path under the root/run/log dirs
+because `vm rm` would delete it along with them.
 
 Flags:
 

--- a/README.md
+++ b/README.md
@@ -559,9 +559,10 @@ Flags:
 | `--readonly` | `false` | Attach read-only |
 | `--directio` | `auto` | O_DIRECT for the disk: `on`/`off`/`auto` (use `off` for files on tmpfs) |
 
-Re-attaching the same name immediately after a detach can race the guest's
-ACPI eject ack (~100ms on a healthy guest) — retry after a moment, or poll
-`vm inspect` until the disk leaves `attached_devices`.
+Detach blocks until the guest acks the ACPI eject (up to 30s — Windows can
+take 10–20s), so when it returns the slot, the name, and the backing file
+are free for immediate reuse; a guest that never acks fails the detach with
+a typed error.
 
 The block device (`/dev/vdX`, serial visible in `lsblk -o NAME,SERIAL`) is
 usable immediately after attach. The `/dev/disk/by-id/virtio-<name>` symlink

--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ Cocoon can hot-plug three classes of external resources onto a running VM:
 - **VFIO PCI passthrough** — a host PCI device bound to `vfio-pci` (GPU, NIC, NVMe). Attach hands the device to the guest with IOMMU isolation.
 - **Data disks** — an existing raw disk file, surfaced as `/dev/disk/by-id/virtio-<name>`. Cocoon never creates or deletes the backing file: it can outlive any VM and be re-attached elsewhere (a persistent volume).
 
-Fs and VFIO attaches are **runtime-only**: the device lives only for the current VM process and is gone after stop/restart, and Cloud Hypervisor rejects snapshotting while one is attached. **Disk attaches persist**: the volume is recorded on the VM, survives stop/start, and rides hibernate/wake transparently (the guest resumes with the volume still mounted). Snapshots carry only the volume *reference* — the backing file is never copied into a snapshot and must stay readable at its absolute path; restoring a snapshot older than the volume's current content leaves the volume as-is (its content is not rolled back). Cloning a snapshot that references an external volume is refused — a clone would share the writable file. Cocoon never owns backend lifecycles (the user runs `virtiofsd`, binds PCI devices, provisions volume files). All mutating verbs on one VM (attach/detach, net resize, snapshot, hibernate, restore, stop) serialize on a per-VM lock, so concurrent invocations cannot interleave with a capture window.
+Fs and VFIO attaches are **runtime-only**: the device lives only for the current VM process and is gone after stop/restart, and Cloud Hypervisor rejects snapshotting while one is attached. **Disk attaches persist across stop/start** — the volume is recorded on the VM, so `vm stop` + `vm start` brings it back (with a deterministic device id, so `disk list`/`detach` keep working) — but they are **capture-excluded**: `snapshot save` and `vm hibernate` refuse to run while an external volume is attached. External volumes are runtime state cocoon does not own (the user provisions the file and manages its filesystem), so they never enter a snapshot; detach the volume (and umount it in-guest) before snapshotting or hibernating, and re-attach it after the wake/restore. This keeps snapshot, hibernate/wake, restore, and clone entirely free of external-volume reasoning. Cocoon never creates, copies, or deletes the backing file. All mutating verbs on one VM (attach/detach, net resize, snapshot, hibernate, restore, stop) serialize on a per-VM lock, so concurrent invocations cannot interleave with a capture window.
 
 ### Vhost-user-fs
 
@@ -547,10 +547,12 @@ mount /dev/disk/by-id/virtio-vol1 /mnt/vol1
 cocoon vm disk detach my-vm --name vol1
 ```
 
-The attach persists: `vm stop` + `vm start` brings the volume back, and
-`vm hibernate` + wake resumes the guest with the volume still mounted.
-Detach before `snapshot save` if the snapshot will be a clone source —
-clones of volume-referencing snapshots are refused.
+The attach persists across `vm stop` + `vm start` (the volume comes back).
+`snapshot save` and `vm hibernate` refuse to run while a volume is attached —
+detach it (umount in-guest first), snapshot/hibernate, then re-attach after
+the wake or restore. The backing file may live anywhere outside cocoon's
+managed directories (e.g. under `/tmp`); attach refuses a path under the
+root/run dirs because `vm rm` would delete it with the run dir.
 
 Flags:
 

--- a/README.md
+++ b/README.md
@@ -560,7 +560,14 @@ Flags:
 | `--directio` | `auto` | O_DIRECT for the disk: `on`/`off`/`auto` (use `off` for files on tmpfs) |
 
 Re-attaching the same name immediately after a detach can race the guest's
-device teardown — give the guest a moment before the re-attach.
+ACPI eject ack (~100ms on a healthy guest) — retry after a moment, or poll
+`vm inspect` until the disk leaves `attached_devices`.
+
+The block device (`/dev/vdX`, serial visible in `lsblk -o NAME,SERIAL`) is
+usable immediately after attach. The `/dev/disk/by-id/virtio-<name>` symlink
+is created by guest udev and can lag or be skipped on minimal images —
+`udevadm trigger --action=add --subsystem-match=block && udevadm settle`
+materializes it; scripts should resolve by serial instead.
 
 ### VFIO PCI passthrough
 

--- a/README.md
+++ b/README.md
@@ -546,13 +546,9 @@ mount /dev/disk/by-id/virtio-vol1 /mnt/vol1
 cocoon vm disk detach my-vm --name vol1
 ```
 
-The attach is runtime-only, like `vm fs` and `vm device`: the disk is gone
-after `vm stop`/restart — re-attach it after the next start. `snapshot save`
-and `vm hibernate` refuse while a volume is attached — umount in-guest,
-detach, capture, then re-attach after the wake or restore. The backing file
-may live anywhere outside cocoon's managed directories (e.g. under `/tmp`);
-attach refuses a path under the root/run dirs because `vm rm` would delete
-it with the run dir.
+The backing file may live anywhere outside cocoon's managed directories;
+attach refuses a path under the root/run/log dirs because `vm rm` would
+delete it along with them.
 
 Flags:
 

--- a/cmd/core/vmconfig.go
+++ b/cmd/core/vmconfig.go
@@ -139,6 +139,21 @@ func EnsureFirmwarePath(conf *config.Config, bootCfg *types.BootConfig) {
 	}
 }
 
+// ParseDirectIO maps a directio value (on/off/auto) to the tri-state StorageConfig.DirectIO; auto is nil.
+func ParseDirectIO(val string) (*bool, error) {
+	switch val {
+	case "on":
+		t := true
+		return &t, nil
+	case "off":
+		f := false
+		return &f, nil
+	case "auto":
+		return nil, nil
+	}
+	return nil, fmt.Errorf("directio must be on/off/auto, got %q", val)
+}
+
 func sanitizeVMName(image string) string {
 	ref, err := name.ParseReference(image)
 	if err != nil {
@@ -166,22 +181,6 @@ func sanitizeVMName(image string) string {
 }
 
 // parseDataDiskFlags parses --data-disk values, normalizes defaults, and returns the spec list ready for hypervisor.PrepareDataDisks.
-// ParseDirectIO maps a directio value to the tri-state StorageConfig.DirectIO;
-// auto is nil (inherit the VM-level NoDirectIO default).
-func ParseDirectIO(val string) (*bool, error) {
-	switch val {
-	case "on":
-		t := true
-		return &t, nil
-	case "off":
-		f := false
-		return &f, nil
-	case "auto":
-		return nil, nil
-	}
-	return nil, fmt.Errorf("directio must be on/off/auto, got %q", val)
-}
-
 func parseDataDiskFlags(raw []string) ([]types.DataDiskSpec, error) {
 	specs := make([]types.DataDiskSpec, 0, len(raw))
 	for _, s := range raw {

--- a/cmd/core/vmconfig.go
+++ b/cmd/core/vmconfig.go
@@ -166,6 +166,22 @@ func sanitizeVMName(image string) string {
 }
 
 // parseDataDiskFlags parses --data-disk values, normalizes defaults, and returns the spec list ready for hypervisor.PrepareDataDisks.
+// ParseDirectIO maps a directio value to the tri-state StorageConfig.DirectIO;
+// auto is nil (inherit the VM-level NoDirectIO default).
+func ParseDirectIO(val string) (*bool, error) {
+	switch val {
+	case "on":
+		t := true
+		return &t, nil
+	case "off":
+		f := false
+		return &f, nil
+	case "auto":
+		return nil, nil
+	}
+	return nil, fmt.Errorf("directio must be on/off/auto, got %q", val)
+}
+
 func parseDataDiskFlags(raw []string) ([]types.DataDiskSpec, error) {
 	specs := make([]types.DataDiskSpec, 0, len(raw))
 	for _, s := range raw {
@@ -218,18 +234,11 @@ func parseDataDiskSpec(s string) (types.DataDiskSpec, error) {
 			spec.MountPoint = val
 			spec.MountPointSet = true
 		case "directio":
-			switch val {
-			case "on":
-				t := true
-				spec.DirectIO = &t
-			case "off":
-				f := false
-				spec.DirectIO = &f
-			case "auto":
-				// keep nil to inherit VM-level NoDirectIO
-			default:
-				return spec, fmt.Errorf("--data-disk: directio must be on/off/auto, got %q", val)
+			dio, err := ParseDirectIO(val)
+			if err != nil {
+				return spec, fmt.Errorf("--data-disk: %w", err)
 			}
+			spec.DirectIO = dio
 		default:
 			return spec, fmt.Errorf("--data-disk: unknown key %q", key)
 		}

--- a/cmd/images/import.go
+++ b/cmd/images/import.go
@@ -17,9 +17,6 @@ import (
 	"github.com/cocoonstack/cocoon/config"
 	"github.com/cocoonstack/cocoon/images/cloudimg"
 	"github.com/cocoonstack/cocoon/images/oci"
-	"github.com/cocoonstack/cocoon/progress"
-	cloudimgProgress "github.com/cocoonstack/cocoon/progress/cloudimg"
-	ociProgress "github.com/cocoonstack/cocoon/progress/oci"
 	"github.com/cocoonstack/cocoon/utils"
 )
 
@@ -106,21 +103,11 @@ func (h Handler) importCloudimgFiles(ctx context.Context, conf *config.Config, n
 	if err != nil {
 		return fmt.Errorf("init cloudimg backend: %w", err)
 	}
-	tracker := progress.NewTracker(func(e cloudimgProgress.Event) {
-		switch e.Phase {
-		case cloudimgProgress.PhaseDownload:
-			if len(files) == 1 {
-				logger.Infof(ctx, "hashing %s", files[0])
-			} else {
-				logger.Infof(ctx, "hashing split qcow2 parts (%d files)", len(files))
-			}
-		case cloudimgProgress.PhaseConvert:
-			logger.Info(ctx, "converting to qcow2...")
-		case cloudimgProgress.PhaseCommit:
-			logger.Info(ctx, "committing...")
-		case cloudimgProgress.PhaseDone:
-			logger.Infof(ctx, "done: %s", name)
+	tracker := cloudimgImportTracker(ctx, logger, name, func() string {
+		if len(files) == 1 {
+			return "hashing " + files[0]
 		}
+		return fmt.Sprintf("hashing split qcow2 parts (%d files)", len(files))
 	})
 	if err := cloudimgStore.Import(ctx, name, tracker, files...); err != nil {
 		return fmt.Errorf("import %s: %w", name, err)
@@ -134,17 +121,8 @@ func (h Handler) importOCIFiles(ctx context.Context, conf *config.Config, name s
 	if err != nil {
 		return fmt.Errorf("init oci backend: %w", err)
 	}
-	tracker := progress.NewTracker(func(e ociProgress.Event) {
-		switch e.Phase {
-		case ociProgress.PhasePull:
-			logger.Infof(ctx, "importing %s (%d layer(s))", name, e.Total)
-		case ociProgress.PhaseLayer:
-			logger.Infof(ctx, "[%d/%d] %s done", e.Index+1, e.Total, e.Digest)
-		case ociProgress.PhaseCommit:
-			logger.Info(ctx, "committing...")
-		case ociProgress.PhaseDone:
-			logger.Infof(ctx, "done: %s", name)
-		}
+	tracker := ociTracker(ctx, logger, name, func(total int) string {
+		return fmt.Sprintf("importing %s (%d layer(s))", name, total)
 	})
 	if err := ociStore.Import(ctx, name, tracker, files...); err != nil {
 		return fmt.Errorf("import %s: %w", name, err)
@@ -158,17 +136,8 @@ func (h Handler) importCloudimgReader(ctx context.Context, conf *config.Config, 
 	if err != nil {
 		return fmt.Errorf("init cloudimg backend: %w", err)
 	}
-	tracker := progress.NewTracker(func(e cloudimgProgress.Event) {
-		switch e.Phase {
-		case cloudimgProgress.PhaseDownload:
-			logger.Infof(ctx, "reading stream for %s", name)
-		case cloudimgProgress.PhaseConvert:
-			logger.Info(ctx, "converting to qcow2...")
-		case cloudimgProgress.PhaseCommit:
-			logger.Info(ctx, "committing...")
-		case cloudimgProgress.PhaseDone:
-			logger.Infof(ctx, "done: %s", name)
-		}
+	tracker := cloudimgImportTracker(ctx, logger, name, func() string {
+		return "reading stream for " + name
 	})
 	if err := cloudimgStore.ImportFromReader(ctx, name, tracker, r); err != nil {
 		return fmt.Errorf("import %s: %w", name, err)
@@ -182,17 +151,8 @@ func (h Handler) importOCIReader(ctx context.Context, conf *config.Config, name 
 	if err != nil {
 		return fmt.Errorf("init oci backend: %w", err)
 	}
-	tracker := progress.NewTracker(func(e ociProgress.Event) {
-		switch e.Phase {
-		case ociProgress.PhasePull:
-			logger.Infof(ctx, "importing %s (1 layer from stream)", name)
-		case ociProgress.PhaseLayer:
-			logger.Infof(ctx, "[1/1] %s done", e.Digest)
-		case ociProgress.PhaseCommit:
-			logger.Info(ctx, "committing...")
-		case ociProgress.PhaseDone:
-			logger.Infof(ctx, "done: %s", name)
-		}
+	tracker := ociTracker(ctx, logger, name, func(int) string {
+		return fmt.Sprintf("importing %s (1 layer from stream)", name)
 	})
 	if err := ociStore.ImportFromReader(ctx, name, tracker, r); err != nil {
 		return fmt.Errorf("import %s: %w", name, err)

--- a/cmd/images/pull.go
+++ b/cmd/images/pull.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cocoonstack/cocoon/images/oci"
 	"github.com/cocoonstack/cocoon/progress"
 	cloudimgProgress "github.com/cocoonstack/cocoon/progress/cloudimg"
-	ociProgress "github.com/cocoonstack/cocoon/progress/oci"
 )
 
 func (h Handler) Pull(cmd *cobra.Command, args []string) error {
@@ -44,17 +43,8 @@ func (h Handler) Pull(cmd *cobra.Command, args []string) error {
 
 func (h Handler) pullOCI(ctx context.Context, store *oci.OCI, image string) error {
 	logger := log.WithFunc("cmd.images.pullOCI")
-	tracker := progress.NewTracker(func(e ociProgress.Event) {
-		switch e.Phase {
-		case ociProgress.PhasePull:
-			logger.Infof(ctx, "pulling OCI image %s (%d layers)", image, e.Total)
-		case ociProgress.PhaseLayer:
-			logger.Infof(ctx, "[%d/%d] %s done", e.Index+1, e.Total, e.Digest)
-		case ociProgress.PhaseCommit:
-			logger.Info(ctx, "committing...")
-		case ociProgress.PhaseDone:
-			logger.Infof(ctx, "done: %s", image)
-		}
+	tracker := ociTracker(ctx, logger, image, func(total int) string {
+		return fmt.Sprintf("pulling OCI image %s (%d layers)", image, total)
 	})
 	if err := store.Pull(ctx, image, false, tracker); err != nil {
 		return fmt.Errorf("pull %s: %w", image, err)

--- a/cmd/images/utils.go
+++ b/cmd/images/utils.go
@@ -1,0 +1,43 @@
+package images
+
+import (
+	"context"
+
+	"github.com/projecteru2/core/log"
+
+	"github.com/cocoonstack/cocoon/progress"
+	cloudimgProgress "github.com/cocoonstack/cocoon/progress/cloudimg"
+	ociProgress "github.com/cocoonstack/cocoon/progress/oci"
+)
+
+// ociTracker logs OCI pull/import phases; pullMsg renders the PhasePull line.
+func ociTracker(ctx context.Context, logger *log.Fields, name string, pullMsg func(total int) string) progress.Tracker {
+	return progress.NewTracker(func(e ociProgress.Event) {
+		switch e.Phase {
+		case ociProgress.PhasePull:
+			logger.Info(ctx, pullMsg(e.Total))
+		case ociProgress.PhaseLayer:
+			logger.Infof(ctx, "[%d/%d] %s done", e.Index+1, e.Total, e.Digest)
+		case ociProgress.PhaseCommit:
+			logger.Info(ctx, "committing...")
+		case ociProgress.PhaseDone:
+			logger.Infof(ctx, "done: %s", name)
+		}
+	})
+}
+
+// cloudimgImportTracker logs cloudimg import phases; downloadMsg renders the PhaseDownload line (imports have no byte progress — pullCloudimg keeps its own progress-bar tracker).
+func cloudimgImportTracker(ctx context.Context, logger *log.Fields, name string, downloadMsg func() string) progress.Tracker {
+	return progress.NewTracker(func(e cloudimgProgress.Event) {
+		switch e.Phase {
+		case cloudimgProgress.PhaseDownload:
+			logger.Info(ctx, downloadMsg())
+		case cloudimgProgress.PhaseConvert:
+			logger.Info(ctx, "converting to qcow2...")
+		case cloudimgProgress.PhaseCommit:
+			logger.Info(ctx, "committing...")
+		case cloudimgProgress.PhaseDone:
+			logger.Infof(ctx, "done: %s", name)
+		}
+	})
+}

--- a/cmd/vm/commands.go
+++ b/cmd/vm/commands.go
@@ -28,7 +28,6 @@ type Actions interface {
 	FsDetach(cmd *cobra.Command, args []string) error
 	DiskAttach(cmd *cobra.Command, args []string) error
 	DiskDetach(cmd *cobra.Command, args []string) error
-	DiskList(cmd *cobra.Command, args []string) error
 	DeviceAttach(cmd *cobra.Command, args []string) error
 	DeviceDetach(cmd *cobra.Command, args []string) error
 	NetResize(cmd *cobra.Command, args []string) error
@@ -262,15 +261,7 @@ func buildDiskCommand(h Actions) *cobra.Command {
 	_ = detach.MarkFlagRequired("name")
 	cliutil.AddOutputFlag(detach)
 
-	list := &cobra.Command{
-		Use:   "list VM",
-		Short: "List hot-attached disks on a running VM",
-		Args:  cobra.ExactArgs(1),
-		RunE:  h.DiskList,
-	}
-	cliutil.AddOutputFlag(list)
-
-	parent.AddCommand(attach, detach, list)
+	parent.AddCommand(attach, detach)
 	return parent
 }
 

--- a/cmd/vm/commands.go
+++ b/cmd/vm/commands.go
@@ -247,6 +247,7 @@ func buildDiskCommand(h Actions) *cobra.Command {
 	attach.Flags().String("path", "", "absolute path to an existing raw disk file (required; never deleted by cocoon)")
 	attach.Flags().String("name", "", "disk name: guest /dev/disk/by-id/virtio-<name> and the detach key (required)")
 	attach.Flags().Bool("readonly", false, "attach read-only")
+	attach.Flags().String("directio", "auto", "O_DIRECT for the disk: on|off|auto (off for files on tmpfs)")
 	_ = attach.MarkFlagRequired("path")
 	_ = attach.MarkFlagRequired("name")
 	cliutil.AddOutputFlag(attach)

--- a/cmd/vm/disk.go
+++ b/cmd/vm/disk.go
@@ -48,25 +48,3 @@ func (h Handler) DiskDetach(cmd *cobra.Command, args []string) error {
 	log.WithFunc("cmd.vm.disk.detach").Infof(ctx, "detached disk name=%s vm=%s", name, args[0])
 	return nil
 }
-
-func (h Handler) DiskList(cmd *cobra.Command, args []string) error {
-	ctx, _, _, l, err := resolveAttacher[disk.Lister](h, cmd, args, "disk list", disk.ErrUnsupportedBackend)
-	if err != nil {
-		return err
-	}
-	disks, err := l.DiskList(ctx, args[0])
-	if err != nil {
-		return classifyAttachErr(err)
-	}
-	if done, jsonErr := cliutil.MaybeOutputJSON(cmd, disks); done {
-		return jsonErr
-	}
-	logger := log.WithFunc("cmd.vm.disk.list")
-	for _, d := range disks {
-		logger.Infof(ctx, "%s  %s  readonly=%v", d.Name, d.Path, d.ReadOnly)
-	}
-	if len(disks) == 0 {
-		logger.Info(ctx, "no hot-attached disks")
-	}
-	return nil
-}

--- a/cmd/vm/disk.go
+++ b/cmd/vm/disk.go
@@ -1,12 +1,11 @@
 package vm
 
 import (
-	"fmt"
-
 	"github.com/projecteru2/core/log"
 	"github.com/spf13/cobra"
 
 	"github.com/cocoonstack/cocoon/cmd/cliutil"
+	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
 	"github.com/cocoonstack/cocoon/extend/disk"
 )
 
@@ -18,7 +17,8 @@ func (h Handler) DiskAttach(cmd *cobra.Command, args []string) error {
 	path, _ := cmd.Flags().GetString("path")
 	name, _ := cmd.Flags().GetString("name")
 	readonly, _ := cmd.Flags().GetBool("readonly")
-	directIO, err := parseDirectIOFlag(cmd)
+	dioVal, _ := cmd.Flags().GetString("directio")
+	directIO, err := cmdcore.ParseDirectIO(dioVal)
 	if err != nil {
 		return err
 	}
@@ -69,20 +69,4 @@ func (h Handler) DiskList(cmd *cobra.Command, args []string) error {
 		logger.Info(ctx, "no hot-attached disks")
 	}
 	return nil
-}
-
-// parseDirectIOFlag maps --directio on|off|auto to the tri-state spec field.
-func parseDirectIOFlag(cmd *cobra.Command) (*bool, error) {
-	v, _ := cmd.Flags().GetString("directio")
-	switch v {
-	case "", "auto":
-		return nil, nil
-	case "on":
-		t := true
-		return &t, nil
-	case "off":
-		f := false
-		return &f, nil
-	}
-	return nil, fmt.Errorf("--directio must be on, off, or auto, got %q", v)
 }

--- a/cmd/vm/disk.go
+++ b/cmd/vm/disk.go
@@ -71,8 +71,7 @@ func (h Handler) DiskList(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// parseDirectIOFlag maps --directio on|off|auto to the tri-state spec field
-// (auto = create-path default; tmpfs-backed files need an explicit off).
+// parseDirectIOFlag maps --directio on|off|auto to the tri-state spec field.
 func parseDirectIOFlag(cmd *cobra.Command) (*bool, error) {
 	v, _ := cmd.Flags().GetString("directio")
 	switch v {

--- a/cmd/vm/disk.go
+++ b/cmd/vm/disk.go
@@ -1,6 +1,8 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/projecteru2/core/log"
 	"github.com/spf13/cobra"
 
@@ -16,7 +18,11 @@ func (h Handler) DiskAttach(cmd *cobra.Command, args []string) error {
 	path, _ := cmd.Flags().GetString("path")
 	name, _ := cmd.Flags().GetString("name")
 	readonly, _ := cmd.Flags().GetBool("readonly")
-	id, err := a.DiskAttach(ctx, args[0], disk.Spec{Path: path, Name: name, ReadOnly: readonly})
+	directIO, err := parseDirectIOFlag(cmd)
+	if err != nil {
+		return err
+	}
+	id, err := a.DiskAttach(ctx, args[0], disk.Spec{Path: path, Name: name, ReadOnly: readonly, DirectIO: directIO})
 	if err != nil {
 		return classifyAttachErr(err)
 	}
@@ -63,4 +69,21 @@ func (h Handler) DiskList(cmd *cobra.Command, args []string) error {
 		logger.Info(ctx, "no hot-attached disks")
 	}
 	return nil
+}
+
+// parseDirectIOFlag maps --directio on|off|auto to the tri-state spec field
+// (auto = create-path default; tmpfs-backed files need an explicit off).
+func parseDirectIOFlag(cmd *cobra.Command) (*bool, error) {
+	v, _ := cmd.Flags().GetString("directio")
+	switch v {
+	case "", "auto":
+		return nil, nil
+	case "on":
+		t := true
+		return &t, nil
+	case "off":
+		f := false
+		return &f, nil
+	}
+	return nil, fmt.Errorf("--directio must be on, off, or auto, got %q", v)
 }

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -260,6 +260,11 @@ func (h Handler) recoverNetwork(ctx context.Context, conf *config.Config, hyper 
 		if vm == nil {
 			continue
 		}
+		// A corrupt record (null NIC entry) must not grow fresh plumbing here; start will refuse it with a typed error.
+		if err := types.ValidateNetworkConfigs(vm.NetworkConfigs); err != nil {
+			logger.Warnf(ctx, "skip network recovery for VM %s: %v", vm.ID, err)
+			continue
+		}
 		backend := vm.ResolvedNetBackend()
 		if backend == "" {
 			continue

--- a/cmd/vm/run.go
+++ b/cmd/vm/run.go
@@ -455,12 +455,12 @@ func snapshotSource(cmd *cobra.Command, args []string, baseArgs int) (string, st
 	return "", args[baseArgs], nil
 }
 
-// tapQueues: FC=1, CH=CPU count.
+// tapQueues sizes the TAP queue count: FC opens the TAP single-queue, CH per-vCPU.
 func tapQueues(cpu int, useFC bool) int {
 	if useFC {
-		return 1
+		return network.NetNumQueues(1)
 	}
-	return cpu
+	return network.NetNumQueues(cpu)
 }
 
 func initNetwork(ctx context.Context, conf *config.Config, vmID string, nics int, vmCfg *types.VMConfig, queues int, bridgeDev string) (network.Network, types.NetSetup, error) {
@@ -488,11 +488,11 @@ func initNetwork(ctx context.Context, conf *config.Config, vmID string, nics int
 	if nics <= 0 {
 		return netProvider, setup, nil
 	}
-	// FC needs 1 TAP queue, CH needs per-vCPU; network reads vmCfg.CPU.
-	origCPU := vmCfg.CPU
-	vmCfg.CPU = queues
-	configs, err := netProvider.Add(ctx, vmID, vmCfg, network.AddRange(0, nics)...)
-	vmCfg.CPU = origCPU
+	specs := network.AddRange(0, nics)
+	for i := range specs {
+		specs[i].Queues = queues
+	}
+	configs, err := netProvider.Add(ctx, vmID, vmCfg, specs...)
 	if err != nil {
 		rollbackNetwork(ctx, netProvider, vmID)
 		return nil, types.NetSetup{}, fmt.Errorf("configure network: %w", err)

--- a/extend/disk/disk.go
+++ b/extend/disk/disk.go
@@ -18,11 +18,14 @@ const diskIDPrefix = "cocoon-disk-"
 // ErrUnsupportedBackend signals the backend cannot hot-plug virtio-blk disks (e.g. Firecracker).
 var ErrUnsupportedBackend = errors.New("backend does not support disk attach")
 
-// Spec is one attach request: an existing raw disk file.
+// Spec is one attach request: an existing raw disk file. DirectIO nil means
+// the create-path default (O_DIRECT unless writable disks have it disabled);
+// tmpfs-backed files need an explicit off.
 type Spec struct {
 	Path     string
 	Name     string
 	ReadOnly bool
+	DirectIO *bool
 }
 
 // Normalize enforces required fields; Name doubles as the guest serial (/dev/disk/by-id/virtio-<name>) and the detach key.

--- a/extend/fs/fs.go
+++ b/extend/fs/fs.go
@@ -33,24 +33,6 @@ type Spec struct {
 	QueueSize int
 }
 
-// Attached is the inspect-time view of one fs device read from the running VM's CH config.
-type Attached struct {
-	ID     string `json:"id"`
-	Tag    string `json:"tag"`
-	Socket string `json:"socket"`
-}
-
-// Attacher hot-plugs and removes vhost-user-fs devices.
-type Attacher interface {
-	FsAttach(ctx context.Context, vmRef string, spec Spec) (deviceID string, err error)
-	FsDetach(ctx context.Context, vmRef, tag string) error
-}
-
-// Lister enumerates currently-attached fs devices from running VM state.
-type Lister interface {
-	FsList(ctx context.Context, vmRef string) ([]Attached, error)
-}
-
 // Normalize enforces required fields and applies queue-size defaults; mutates the receiver.
 func (s *Spec) Normalize() error {
 	if s.Socket == "" {
@@ -74,6 +56,24 @@ func (s *Spec) Normalize() error {
 	s.NumQueues = cmp.Or(s.NumQueues, DefaultNumQueues)
 	s.QueueSize = cmp.Or(s.QueueSize, DefaultQueueSize)
 	return nil
+}
+
+// Attached is the inspect-time view of one fs device read from the running VM's CH config.
+type Attached struct {
+	ID     string `json:"id"`
+	Tag    string `json:"tag"`
+	Socket string `json:"socket"`
+}
+
+// Attacher hot-plugs and removes vhost-user-fs devices.
+type Attacher interface {
+	FsAttach(ctx context.Context, vmRef string, spec Spec) (deviceID string, err error)
+	FsDetach(ctx context.Context, vmRef, tag string) error
+}
+
+// Lister enumerates currently-attached fs devices from running VM state.
+type Lister interface {
+	FsList(ctx context.Context, vmRef string) ([]Attached, error)
 }
 
 // DeriveID returns the deterministic CH device id for a tag (used by attach + detach so concurrent attaches collide on CH's id check).

--- a/extend/fs/fs.go
+++ b/extend/fs/fs.go
@@ -17,12 +17,12 @@ const (
 )
 
 var (
+	// ErrUnsupportedBackend signals the backend cannot hot-plug vhost-user-fs (e.g. Firecracker).
+	ErrUnsupportedBackend = errors.New("backend does not support fs attach")
+
 	// Tag charset is intentionally portable: usable as a CH device id suffix
 	// (cocoon-fs-<tag>) and safe for shell quoting and guest mount commands.
 	validTagRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]{0,35}$`)
-
-	// ErrUnsupportedBackend signals the backend cannot hot-plug vhost-user-fs (e.g. Firecracker).
-	ErrUnsupportedBackend = errors.New("backend does not support fs attach")
 )
 
 // Spec is one attach request.

--- a/extend/netresize/netresize.go
+++ b/extend/netresize/netresize.go
@@ -18,6 +18,14 @@ type Spec struct {
 	Target int
 }
 
+// Normalize validates the spec.
+func (s *Spec) Normalize() error {
+	if s.Target < 0 {
+		return fmt.Errorf("--nics must be non-negative, got %d", s.Target)
+	}
+	return nil
+}
+
 // NIC is one NIC summary surfaced through Result.Added / Result.Removed.
 type NIC struct {
 	Index int    `json:"index"`
@@ -43,12 +51,4 @@ type Plumbing interface {
 // Resizer resizes a running VM's NIC count.
 type Resizer interface {
 	NetResize(ctx context.Context, vmRef string, spec Spec, plumbing Plumbing) (Result, error)
-}
-
-// Normalize validates the spec.
-func (s *Spec) Normalize() error {
-	if s.Target < 0 {
-		return fmt.Errorf("--nics must be non-negative, got %d", s.Target)
-	}
-	return nil
 }

--- a/extend/vfio/vfio.go
+++ b/extend/vfio/vfio.go
@@ -15,6 +15,9 @@ import (
 const SysfsPCIPrefix = "/sys/bus/pci/devices/"
 
 var (
+	// ErrUnsupportedBackend signals the backend cannot hot-plug VFIO devices (e.g. Firecracker).
+	ErrUnsupportedBackend = errors.New("backend does not support device attach")
+
 	// Match BDF in either short (01:00.0) or full (0000:01:00.0) form so the
 	// CLI accepts what `lspci` prints by default.
 	bdfShortRe = regexp.MustCompile(`^[0-9a-f]{2}:[0-9a-f]{2}\.[0-7]$`)
@@ -23,9 +26,6 @@ var (
 	// User-facing id charset matches CH device-id constraints; the prefix
 	// "cocoon-" is reserved so cocoon-derived ids never collide.
 	validIDRe = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$`)
-
-	// ErrUnsupportedBackend signals the backend cannot hot-plug VFIO devices (e.g. Firecracker).
-	ErrUnsupportedBackend = errors.New("backend does not support device attach")
 )
 
 // Spec is one attach request. PCI may be a short BDF, full BDF, or a sysfs path; NormalizePath canonicalizes it.

--- a/extend/vfio/vfio.go
+++ b/extend/vfio/vfio.go
@@ -34,6 +34,17 @@ type Spec struct {
 	ID  string
 }
 
+// NormalizedPath validates the spec and returns the canonical sysfs path; existence is checked at attach time.
+func (s *Spec) NormalizedPath() (string, error) {
+	if s.PCI == "" {
+		return "", fmt.Errorf("pci is required")
+	}
+	if s.ID != "" && (strings.HasPrefix(s.ID, "cocoon-") || !validIDRe.MatchString(s.ID)) {
+		return "", fmt.Errorf("id %q invalid: must match [A-Za-z0-9][A-Za-z0-9_.-]{0,63} and not start with cocoon-", s.ID)
+	}
+	return NormalizePath(s.PCI)
+}
+
 // Attached is the inspect-time view of one VFIO device from running VM state.
 type Attached struct {
 	ID  string `json:"id"`
@@ -49,17 +60,6 @@ type Attacher interface {
 // Lister enumerates VFIO devices from running VM state.
 type Lister interface {
 	DeviceList(ctx context.Context, vmRef string) ([]Attached, error)
-}
-
-// NormalizedPath validates the spec and returns the canonical sysfs path; existence is checked at attach time.
-func (s *Spec) NormalizedPath() (string, error) {
-	if s.PCI == "" {
-		return "", fmt.Errorf("pci is required")
-	}
-	if s.ID != "" && (strings.HasPrefix(s.ID, "cocoon-") || !validIDRe.MatchString(s.ID)) {
-		return "", fmt.Errorf("id %q invalid: must match [A-Za-z0-9][A-Za-z0-9_.-]{0,63} and not start with cocoon-", s.ID)
-	}
-	return NormalizePath(s.PCI)
 }
 
 // NormalizePath maps {short BDF, full BDF, sysfs path} → canonical /sys/bus/pci/devices/<bdf>; rejects paths outside that root.

--- a/hypervisor/backend.go
+++ b/hypervisor/backend.go
@@ -28,6 +28,8 @@ const (
 
 	// CowSerial is the well-known virtio serial for the COW disk attached to OCI VMs.
 	CowSerial = "cocoon-cow"
+	// COWRawFileName is the raw COW disk's file name in the run dir (single owner so snapshot matchers and clone path rewrites can't drift).
+	COWRawFileName = "cow.raw"
 
 	// CreatingStateGCGrace bounds how long GC tolerates a "creating" VM.
 	CreatingStateGCGrace = 24 * time.Hour

--- a/hypervisor/baseconfig.go
+++ b/hypervisor/baseconfig.go
@@ -36,15 +36,18 @@ func (c *BaseConfig) VMRunDir(vmID string) string { return filepath.Join(c.RunDi
 
 func (c *BaseConfig) VMLogDir(vmID string) string { return filepath.Join(c.LogDir(), vmID) }
 
-// DataDiskPath returns the canonical raw path; filename embeds the disk name so cleanSnapshotFiles prefix-match works.
-func (c *BaseConfig) DataDiskPath(vmID, name string) string {
-	return filepath.Join(c.VMRunDir(vmID), DataDiskBaseName(name))
-}
-
 // EnsureDirs creates all static directories required by the backend.
 func (c *BaseConfig) EnsureDirs() error {
 	return utils.EnsureDirs(c.dbDir(), c.RunDir(), c.LogDir())
 }
+
+// StopTimeout returns the guest-shutdown grace window; pair with ForceStop, which owns the negative sentinel.
+func (c *BaseConfig) StopTimeout() time.Duration {
+	return time.Duration(c.StopTimeoutSeconds) * time.Second
+}
+
+// ForceStop reports whether --force set the negative StopTimeoutSeconds sentinel (skip graceful shutdown).
+func (c *BaseConfig) ForceStop() bool { return c.StopTimeoutSeconds < 0 }
 
 // SocketWaitTimeout returns configured timeout or default (5s).
 func (c *BaseConfig) SocketWaitTimeout() time.Duration {

--- a/hypervisor/clone.go
+++ b/hypervisor/clone.go
@@ -68,11 +68,7 @@ func (b *Backend) CloneFromStream(
 
 // FinalizeClone persists the record and emits the clone open-interval pair.
 func (b *Backend) FinalizeClone(ctx context.Context, vmID string, info *types.VM, bootCfg *types.BootConfig, blobIDs map[string]struct{}, sourceSnapshotID string) error {
-	if err := b.DB.Update(ctx, func(idx *VMIndex) error {
-		r, err := idx.GetRecord(vmID)
-		if err != nil {
-			return err
-		}
+	if err := b.UpdateRecord(ctx, vmID, func(r *VMRecord) error {
 		r.VM = *info
 		r.BootConfig = bootCfg
 		r.FirstBooted = true

--- a/hypervisor/cloudhypervisor/args.go
+++ b/hypervisor/cloudhypervisor/args.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cocoonstack/cocoon/extend/disk"
 	"github.com/cocoonstack/cocoon/hypervisor"
 	"github.com/cocoonstack/cocoon/types"
 	"github.com/cocoonstack/cocoon/utils"
@@ -196,12 +195,6 @@ func storageConfigToDisk(storageConfig *types.StorageConfig, cpuCount, diskQueue
 		NumQueues: cpuCount,
 		QueueSize: diskQueueSize,
 	}
-	// External volumes keep a deterministic device id so disk list/detach
-	// find them again after stop/start and hibernate/wake.
-	if storageConfig.External {
-		d.ID = disk.DeriveID(storageConfig.Serial)
-	}
-
 	if storageConfig.DirectIO != nil {
 		d.DirectIO = *storageConfig.DirectIO
 	} else {
@@ -232,7 +225,6 @@ func storageConfigToDisk(storageConfig *types.StorageConfig, cpuCount, diskQueue
 func diskToCLIArg(d chDisk) string {
 	var b kvBuilder
 	b.add("path=" + d.Path)
-	b.addIf(d.ID != "", "id="+d.ID)
 	b.addIf(d.ReadOnly, "readonly=on")
 	b.addIf(d.DirectIO, "direct=on")
 	b.addIf(d.Sparse, "sparse=on")

--- a/hypervisor/cloudhypervisor/args.go
+++ b/hypervisor/cloudhypervisor/args.go
@@ -56,7 +56,7 @@ func buildVMConfig(_ context.Context, rec *hypervisor.VMRecord, consoleSockPath 
 		Vsock:    &chVsock{CID: hypervisor.VsockGuestCID, Socket: hypervisor.VsockSockPath(rec.RunDir)},
 	}
 
-	if isDirectBoot(rec.BootConfig) {
+	if hypervisor.IsDirectBoot(rec.BootConfig) {
 		cfg.Serial = &chRuntimeFile{Mode: "Off"}
 		cfg.Console = &chRuntimeFile{Mode: "Pty"}
 	} else {
@@ -286,7 +286,7 @@ func queueAffinityToCLI(qa []chQueueAffinity) string {
 
 // activeDisks filters cidata out of post-first-boot cloudimg VMs.
 func activeDisks(rec *hypervisor.VMRecord) []*types.StorageConfig {
-	skipCidata := rec.FirstBooted && !isDirectBoot(rec.BootConfig)
+	skipCidata := rec.FirstBooted && !hypervisor.IsDirectBoot(rec.BootConfig)
 	out := make([]*types.StorageConfig, 0, len(rec.StorageConfigs))
 	for _, sc := range rec.StorageConfigs {
 		if skipCidata && sc.Role == types.StorageRoleCidata {

--- a/hypervisor/cloudhypervisor/args.go
+++ b/hypervisor/cloudhypervisor/args.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cocoonstack/cocoon/extend/disk"
 	"github.com/cocoonstack/cocoon/hypervisor"
 	"github.com/cocoonstack/cocoon/types"
 	"github.com/cocoonstack/cocoon/utils"
@@ -195,6 +196,11 @@ func storageConfigToDisk(storageConfig *types.StorageConfig, cpuCount, diskQueue
 		NumQueues: cpuCount,
 		QueueSize: diskQueueSize,
 	}
+	// External volumes keep a deterministic device id so disk list/detach
+	// find them again after stop/start and hibernate/wake.
+	if storageConfig.External {
+		d.ID = disk.DeriveID(storageConfig.Serial)
+	}
 
 	if storageConfig.DirectIO != nil {
 		d.DirectIO = *storageConfig.DirectIO
@@ -226,6 +232,7 @@ func storageConfigToDisk(storageConfig *types.StorageConfig, cpuCount, diskQueue
 func diskToCLIArg(d chDisk) string {
 	var b kvBuilder
 	b.add("path=" + d.Path)
+	b.addIf(d.ID != "", "id="+d.ID)
 	b.addIf(d.ReadOnly, "readonly=on")
 	b.addIf(d.DirectIO, "direct=on")
 	b.addIf(d.Sparse, "sparse=on")

--- a/hypervisor/cloudhypervisor/clone.go
+++ b/hypervisor/cloudhypervisor/clone.go
@@ -41,7 +41,7 @@ func (ch *CloudHypervisor) cloneAfterExtract(ctx context.Context, vmID string, v
 		return nil, fmt.Errorf("parse CH config: %w", err)
 	}
 
-	meta, err := hypervisor.LoadAndValidateMeta(runDir, ch.conf.RootDir, ch.conf.Config.RunDir, nil)
+	meta, err := hypervisor.LoadAndValidateMeta(runDir, ch.conf.RootDir, ch.conf.Config.RunDir)
 	if err != nil {
 		return nil, fmt.Errorf("load snapshot meta: %w", err)
 	}
@@ -286,7 +286,7 @@ func restorePatchStorageConfigs(storageConfigs []*types.StorageConfig, directBoo
 // updateDataDiskPaths rewrites Role==Data paths to clone runDir; sidecar carries source paths.
 func updateDataDiskPaths(configs []*types.StorageConfig, newRunDir string) {
 	for _, sc := range configs {
-		if sc.Role == types.StorageRoleData && !sc.External {
+		if sc.Role == types.StorageRoleData {
 			sc.Path = filepath.Join(newRunDir, hypervisor.DataDiskBaseName(sc.Serial))
 		}
 	}

--- a/hypervisor/cloudhypervisor/clone.go
+++ b/hypervisor/cloudhypervisor/clone.go
@@ -51,7 +51,7 @@ func (ch *CloudHypervisor) cloneAfterExtract(ctx context.Context, vmID string, v
 
 	storageConfigs := meta.StorageConfigs
 	bootCfg := rebuildBootConfig(chCfg)
-	directBoot := isDirectBoot(bootCfg)
+	directBoot := hypervisor.IsDirectBoot(bootCfg)
 
 	cowPath := ch.cowPath(vmID, directBoot)
 	if err = updateCOWPath(storageConfigs, cowPath); err != nil {

--- a/hypervisor/cloudhypervisor/clone.go
+++ b/hypervisor/cloudhypervisor/clone.go
@@ -41,7 +41,7 @@ func (ch *CloudHypervisor) cloneAfterExtract(ctx context.Context, vmID string, v
 		return nil, fmt.Errorf("parse CH config: %w", err)
 	}
 
-	meta, err := hypervisor.LoadAndValidateMeta(runDir, ch.conf.RootDir, ch.conf.Config.RunDir)
+	meta, err := hypervisor.LoadAndValidateMeta(runDir, ch.conf.RootDir, ch.conf.Config.RunDir, nil)
 	if err != nil {
 		return nil, fmt.Errorf("load snapshot meta: %w", err)
 	}
@@ -286,7 +286,7 @@ func restorePatchStorageConfigs(storageConfigs []*types.StorageConfig, directBoo
 // updateDataDiskPaths rewrites Role==Data paths to clone runDir; sidecar carries source paths.
 func updateDataDiskPaths(configs []*types.StorageConfig, newRunDir string) {
 	for _, sc := range configs {
-		if sc.Role == types.StorageRoleData {
+		if sc.Role == types.StorageRoleData && !sc.External {
 			sc.Path = filepath.Join(newRunDir, hypervisor.DataDiskBaseName(sc.Serial))
 		}
 	}

--- a/hypervisor/cloudhypervisor/cloudhypervisor.go
+++ b/hypervisor/cloudhypervisor/cloudhypervisor.go
@@ -38,5 +38,5 @@ func New(conf *config.Config, rec metering.Recorder) (*CloudHypervisor, error) {
 
 // Delete removes VMs. Running VMs require force=true (stops them first).
 func (ch *CloudHypervisor) Delete(ctx context.Context, refs []string, force bool) ([]string, error) {
-	return ch.DeleteAll(ctx, refs, force, ch.stopOne)
+	return ch.DeleteAll(ctx, refs, force, ch.stopOneLocked)
 }

--- a/hypervisor/cloudhypervisor/console.go
+++ b/hypervisor/cloudhypervisor/console.go
@@ -24,7 +24,7 @@ func (ch *CloudHypervisor) Console(ctx context.Context, ref string) (io.ReadWrit
 	if err := ch.WithRunningVM(ctx, &rec, func(_ int) error {
 		path := resolveConsole(ctx, id, hypervisor.SocketPath(rec.RunDir),
 			hypervisor.ConsoleSockPath(rec.RunDir),
-			isDirectBoot(rec.BootConfig))
+			hypervisor.IsDirectBoot(rec.BootConfig))
 		if path == "" {
 			return fmt.Errorf("no console path for VM %s", id)
 		}

--- a/hypervisor/cloudhypervisor/direct.go
+++ b/hypervisor/cloudhypervisor/direct.go
@@ -27,7 +27,7 @@ func (ch *CloudHypervisor) DirectRestore(ctx context.Context, vmRef string, vmCf
 			return hypervisor.PopulateFromSrc(rec.RunDir, srcDir, cleanSnapshotFiles, cloneSnapshotFiles)
 		},
 		AfterExtract: func(ctx context.Context, vmID string, vmCfg *types.VMConfig, rec *hypervisor.VMRecord) (*types.VM, error) {
-			directBoot := isDirectBoot(rec.BootConfig)
+			directBoot := hypervisor.IsDirectBoot(rec.BootConfig)
 			return ch.restoreAfterExtract(ctx, vmID, vmCfg, rec, directBoot)
 		},
 	})

--- a/hypervisor/cloudhypervisor/extend.go
+++ b/hypervisor/cloudhypervisor/extend.go
@@ -320,6 +320,12 @@ func (ch *CloudHypervisor) detachWith(
 	if err := removeDeviceVM(ctx, hc, deviceID); err != nil {
 		return fmt.Errorf("vm.remove-device %s: %w", deviceID, err)
 	}
+	// Block until the guest acks the ACPI eject (B0EJ): only then has CH freed
+	// the slot, the id, and the backing file — a caller reusing either right
+	// after detach must not race a still-live device (Windows can take 10-20s).
+	if err := waitDeviceEjected(ctx, hc, deviceID, ejectWaitTimeout); err != nil {
+		return fmt.Errorf("device %s removal initiated but the guest has not ejected it: %w", deviceID, err)
+	}
 	return nil
 }
 

--- a/hypervisor/cloudhypervisor/extend.go
+++ b/hypervisor/cloudhypervisor/extend.go
@@ -10,8 +10,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/projecteru2/core/log"
-
 	"github.com/cocoonstack/cocoon/extend/disk"
 	"github.com/cocoonstack/cocoon/extend/fs"
 	"github.com/cocoonstack/cocoon/extend/netresize"
@@ -45,7 +43,7 @@ func (ch *CloudHypervisor) DiskAttach(ctx context.Context, vmRef string, spec di
 	if hypervisor.IsUnderDir(spec.Path, ch.conf.RootDir) || hypervisor.IsUnderDir(spec.Path, ch.conf.Config.RunDir) {
 		return "", fmt.Errorf("external volume path %s is inside a cocoon-managed directory", spec.Path)
 	}
-	hc, info, vmID, rec, unlock, err := ch.lockedDeviceOpWithRecord(ctx, vmRef)
+	hc, info, rec, unlock, err := ch.lockedDeviceOpWithRecord(ctx, vmRef)
 	if err != nil {
 		return "", err
 	}
@@ -67,25 +65,14 @@ func (ch *CloudHypervisor) DiskAttach(ctx context.Context, vmRef string, spec di
 			return "", fmt.Errorf("disk path %q already attached as %q", spec.Path, ex.ID)
 		}
 	}
-	// FSType none: the external file's filesystem is user-managed, mkfs and
-	// cloud-init mounts never apply to it.
-	sc := &types.StorageConfig{
-		Role: types.StorageRoleData, Path: spec.Path, Serial: spec.Name, RO: spec.ReadOnly,
-		DirectIO: spec.DirectIO, External: true, FSType: types.FSTypeNone,
-	}
 	// The CH fork refuses disks without an explicit image_type; DirectIO/queue
 	// semantics must match create-path data disks.
-	d := storageConfigToDisk(sc, rec.Config.CPU, rec.Config.DiskQueueSize, rec.Config.NoDirectIO)
+	d := storageConfigToDisk(&types.StorageConfig{
+		Role: types.StorageRoleData, Path: spec.Path, Serial: spec.Name, RO: spec.ReadOnly, DirectIO: spec.DirectIO,
+	}, rec.Config.CPU, rec.Config.DiskQueueSize, rec.Config.NoDirectIO)
+	d.ID = id
 	if err = addDiskVM(ctx, hc, d); err != nil {
 		return "", fmt.Errorf("vm.add-disk: %w", err)
-	}
-	// Persist so the volume survives stop/start and rides hibernate/wake; on
-	// persist failure remove the live device (netresize rollback pattern).
-	if err = ch.appendStorageConfig(ctx, vmID, sc); err != nil {
-		if rmErr := removeDeviceVM(ctx, hc, d.ID); rmErr != nil {
-			log.WithFunc("cloudhypervisor.DiskAttach").Warnf(ctx, "rollback vm.remove-device %s after persist failure: %v", d.ID, rmErr)
-		}
-		return "", fmt.Errorf("persist disk %s: %w", spec.Name, err)
 	}
 	return d.ID, nil
 }
@@ -94,7 +81,7 @@ func (ch *CloudHypervisor) DiskDetach(ctx context.Context, vmRef, name string) e
 	if name == "" {
 		return fmt.Errorf("name is required")
 	}
-	hc, info, vmID, _, unlock, err := ch.lockedDeviceOpWithRecord(ctx, vmRef)
+	hc, info, unlock, err := ch.lockedDeviceOp(ctx, vmRef)
 	if err != nil {
 		return err
 	}
@@ -108,9 +95,6 @@ func (ch *CloudHypervisor) DiskDetach(ctx context.Context, vmRef, name string) e
 	}
 	if err := removeDeviceVM(ctx, hc, id); err != nil {
 		return fmt.Errorf("vm.remove-device %s: %w", id, err)
-	}
-	if err := ch.removeStorageConfig(ctx, vmID, name); err != nil {
-		return fmt.Errorf("device removed but record retained for %s: %w", name, err)
 	}
 	return nil
 }
@@ -250,43 +234,27 @@ func (ch *CloudHypervisor) inspectRunning(ctx context.Context, vmRef string) (*h
 // of one path with different names both passed the old unlocked precheck).
 // Callers unlock after their API call; the flock dies with the process, so no
 // stale locks.
-func (ch *CloudHypervisor) lockedDeviceOpWithRecord(ctx context.Context, vmRef string) (*http.Client, *chVMInfoResponse, string, hypervisor.VMRecord, func(), error) {
+func (ch *CloudHypervisor) lockedDeviceOpWithRecord(ctx context.Context, vmRef string) (*http.Client, *chVMInfoResponse, hypervisor.VMRecord, func(), error) {
 	hc, vmID, rec, err := ch.runningVMClientWithRecord(ctx, vmRef)
 	if err != nil {
-		return nil, nil, "", hypervisor.VMRecord{}, nil, err
+		return nil, nil, hypervisor.VMRecord{}, nil, err
 	}
 	unlock, err := ch.LockVMOps(ctx, vmID)
 	if err != nil {
-		return nil, nil, "", hypervisor.VMRecord{}, nil, err
+		return nil, nil, hypervisor.VMRecord{}, nil, err
 	}
 	info, err := getVMInfo(ctx, hc)
 	if err != nil {
 		unlock()
-		return nil, nil, "", hypervisor.VMRecord{}, nil, err
+		return nil, nil, hypervisor.VMRecord{}, nil, err
 	}
-	return hc, info, vmID, rec, unlock, nil
+	return hc, info, rec, unlock, nil
 }
 
-// lockedDeviceOp is lockedDeviceOpWithRecord for callers that need neither the id nor the record.
+// lockedDeviceOp is lockedDeviceOpWithRecord for callers that don't need the record.
 func (ch *CloudHypervisor) lockedDeviceOp(ctx context.Context, vmRef string) (*http.Client, *chVMInfoResponse, func(), error) {
-	hc, info, _, _, unlock, err := ch.lockedDeviceOpWithRecord(ctx, vmRef)
+	hc, info, _, unlock, err := ch.lockedDeviceOpWithRecord(ctx, vmRef)
 	return hc, info, unlock, err
-}
-
-func (ch *CloudHypervisor) appendStorageConfig(ctx context.Context, vmID string, sc *types.StorageConfig) error {
-	return ch.UpdateRecord(ctx, vmID, func(r *hypervisor.VMRecord) error {
-		r.StorageConfigs = append(r.StorageConfigs, sc)
-		return nil
-	})
-}
-
-func (ch *CloudHypervisor) removeStorageConfig(ctx context.Context, vmID, serial string) error {
-	return ch.UpdateRecord(ctx, vmID, func(r *hypervisor.VMRecord) error {
-		r.StorageConfigs = slices.DeleteFunc(r.StorageConfigs, func(sc *types.StorageConfig) bool {
-			return sc.Role == types.StorageRoleData && sc.External && sc.Serial == serial
-		})
-		return nil
-	})
 }
 
 func (ch *CloudHypervisor) attachWith(

--- a/hypervisor/cloudhypervisor/extend.go
+++ b/hypervisor/cloudhypervisor/extend.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/projecteru2/core/log"
@@ -70,7 +71,7 @@ func (ch *CloudHypervisor) DiskAttach(ctx context.Context, vmRef string, spec di
 	// cloud-init mounts never apply to it.
 	sc := &types.StorageConfig{
 		Role: types.StorageRoleData, Path: spec.Path, Serial: spec.Name, RO: spec.ReadOnly,
-		DirectIO: spec.DirectIO, External: true, FSType: "none",
+		DirectIO: spec.DirectIO, External: true, FSType: types.FSTypeNone,
 	}
 	// The CH fork refuses disks without an explicit image_type; DirectIO/queue
 	// semantics must match create-path data disks.
@@ -102,14 +103,7 @@ func (ch *CloudHypervisor) DiskDetach(ctx context.Context, vmRef, name string) e
 		return err
 	}
 	id := disk.DeriveID(name)
-	found := false
-	for _, ex := range info.Config.Disks {
-		if ex.ID == id {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !slices.ContainsFunc(info.Config.Disks, func(d chDisk) bool { return d.ID == id }) {
 		return fmt.Errorf("disk %q not attached", name)
 	}
 	if err := removeDeviceVM(ctx, hc, id); err != nil {
@@ -280,29 +274,17 @@ func (ch *CloudHypervisor) lockedDeviceOp(ctx context.Context, vmRef string) (*h
 }
 
 func (ch *CloudHypervisor) appendStorageConfig(ctx context.Context, vmID string, sc *types.StorageConfig) error {
-	return ch.DB.Update(ctx, func(idx *hypervisor.VMIndex) error {
-		r, err := idx.GetRecord(vmID)
-		if err != nil {
-			return err
-		}
+	return ch.UpdateRecord(ctx, vmID, func(r *hypervisor.VMRecord) error {
 		r.StorageConfigs = append(r.StorageConfigs, sc)
 		return nil
 	})
 }
 
 func (ch *CloudHypervisor) removeStorageConfig(ctx context.Context, vmID, serial string) error {
-	return ch.DB.Update(ctx, func(idx *hypervisor.VMIndex) error {
-		r, err := idx.GetRecord(vmID)
-		if err != nil {
-			return err
-		}
-		kept := r.StorageConfigs[:0]
-		for _, sc := range r.StorageConfigs {
-			if sc.Role != types.StorageRoleData || !sc.External || sc.Serial != serial {
-				kept = append(kept, sc)
-			}
-		}
-		r.StorageConfigs = kept
+	return ch.UpdateRecord(ctx, vmID, func(r *hypervisor.VMRecord) error {
+		r.StorageConfigs = slices.DeleteFunc(r.StorageConfigs, func(sc *types.StorageConfig) bool {
+			return sc.Role == types.StorageRoleData && sc.External && sc.Serial == serial
+		})
 		return nil
 	})
 }

--- a/hypervisor/cloudhypervisor/extend.go
+++ b/hypervisor/cloudhypervisor/extend.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 
@@ -35,29 +36,22 @@ func (ch *CloudHypervisor) DiskAttach(ctx context.Context, vmRef string, spec di
 	if err := spec.Normalize(); err != nil {
 		return "", err
 	}
-	if _, err := os.Stat(spec.Path); err != nil {
-		return "", fmt.Errorf("disk path: %w", err)
-	}
-	// A volume under a cocoon-managed root would be deleted by vm rm / GC,
-	// breaking the never-deletes contract.
-	if hypervisor.IsUnderDir(spec.Path, ch.conf.RootDir) || hypervisor.IsUnderDir(spec.Path, ch.conf.Config.RunDir) ||
-		hypervisor.IsUnderDir(spec.Path, ch.conf.Config.LogDir) {
-		return "", fmt.Errorf("external volume path %s is inside a cocoon-managed directory", spec.Path)
-	}
-	// Config CPU/queue fields are frozen while the VM runs (restore rewrites
-	// them but holds the same ops lock), so the pre-lock record is safe here.
-	_, _, rec, err := ch.runningVMClientWithRecord(ctx, vmRef)
+	path, err := ch.resolveExternalVolume(spec.Path)
 	if err != nil {
 		return "", err
 	}
 	id := disk.DeriveID(spec.Name)
 	// The CH fork refuses disks without an explicit image_type; DirectIO/queue
-	// semantics must match create-path data disks.
-	d := storageConfigToDisk(&types.StorageConfig{
-		Role: types.StorageRoleData, Path: spec.Path, Serial: spec.Name, RO: spec.ReadOnly, DirectIO: spec.DirectIO,
-	}, rec.Config.CPU, rec.Config.DiskQueueSize, rec.Config.NoDirectIO)
-	d.ID = id
-	return ch.attachWith(ctx, vmRef, "vm.add-disk", d, id, func(info *chVMInfoResponse) error {
+	// semantics must match create-path data disks, so the disk is built from
+	// the record reloaded under the ops lock (restore rewrites Config in there).
+	makeBody := func(rec *hypervisor.VMRecord) any {
+		d := storageConfigToDisk(&types.StorageConfig{
+			Role: types.StorageRoleData, Path: path, Serial: spec.Name, RO: spec.ReadOnly, DirectIO: spec.DirectIO,
+		}, rec.Config.CPU, rec.Config.DiskQueueSize, rec.Config.NoDirectIO)
+		d.ID = id
+		return d
+	}
+	return ch.attachWith(ctx, vmRef, "vm.add-disk", makeBody, id, func(info *chVMInfoResponse) error {
 		for _, ex := range info.Config.Disks {
 			if ex.ID == id {
 				return fmt.Errorf("disk name %q already attached", spec.Name)
@@ -67,12 +61,33 @@ func (ch *CloudHypervisor) DiskAttach(ctx context.Context, vmRef string, spec di
 			if ex.Serial == spec.Name {
 				return fmt.Errorf("disk serial %q already used by disk %q", spec.Name, ex.ID)
 			}
-			if ex.Path == spec.Path {
-				return fmt.Errorf("disk path %q already attached as %q", spec.Path, ex.ID)
+			if ex.Path == path {
+				return fmt.Errorf("disk path %q already attached as %q", path, ex.ID)
 			}
 		}
 		return nil
 	})
+}
+
+// resolveExternalVolume canonicalizes path (EvalSymlinks also asserts existence)
+// and refuses anything inside a cocoon-managed root: vm rm / GC delete those
+// trees, breaking the never-deletes contract, and a symlink must not smuggle a
+// managed path past the check. Returns the resolved path so the duplicate
+// precheck and CH both see one canonical name per volume.
+func (ch *CloudHypervisor) resolveExternalVolume(path string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", fmt.Errorf("disk path: %w", err)
+	}
+	for _, dir := range []string{ch.conf.RootDir, ch.conf.Config.RunDir, ch.conf.Config.LogDir} {
+		if r, evalErr := filepath.EvalSymlinks(dir); evalErr == nil {
+			dir = r
+		}
+		if hypervisor.IsUnderDir(resolved, dir) {
+			return "", fmt.Errorf("external volume path %s is inside a cocoon-managed directory", path)
+		}
+	}
+	return resolved, nil
 }
 
 func (ch *CloudHypervisor) DiskDetach(ctx context.Context, vmRef, name string) error {
@@ -105,13 +120,16 @@ func (ch *CloudHypervisor) FsAttach(ctx context.Context, vmRef string, spec fs.S
 		return "", err
 	}
 	id := fs.DeriveID(spec.Tag)
-	return ch.attachWith(ctx, vmRef, "vm.add-fs", chFs{
-		ID:        id,
-		Tag:       spec.Tag,
-		Socket:    spec.Socket,
-		NumQueues: spec.NumQueues,
-		QueueSize: spec.QueueSize,
-	}, id, func(info *chVMInfoResponse) error {
+	makeBody := func(*hypervisor.VMRecord) any {
+		return chFs{
+			ID:        id,
+			Tag:       spec.Tag,
+			Socket:    spec.Socket,
+			NumQueues: spec.NumQueues,
+			QueueSize: spec.QueueSize,
+		}
+	}
+	return ch.attachWith(ctx, vmRef, "vm.add-fs", makeBody, id, func(info *chVMInfoResponse) error {
 		if !info.Config.Memory.Shared {
 			return fmt.Errorf("fs attach requires the VM to be created with --shared-memory (current memory shared=off; cannot be flipped on a running VM)")
 		}
@@ -156,10 +174,10 @@ func (ch *CloudHypervisor) DeviceAttach(ctx context.Context, vmRef string, spec 
 	if err != nil {
 		return "", err
 	}
-	return ch.attachWith(ctx, vmRef, "vm.add-device", chDevice{
-		ID:   spec.ID,
-		Path: path,
-	}, spec.ID, func(info *chVMInfoResponse) error {
+	makeBody := func(*hypervisor.VMRecord) any {
+		return chDevice{ID: spec.ID, Path: path}
+	}
+	return ch.attachWith(ctx, vmRef, "vm.add-device", makeBody, spec.ID, func(info *chVMInfoResponse) error {
 		// stat is gated behind the running-VM check so stopped VMs surface the state error, not a host-path one.
 		st, statErr := os.Stat(path)
 		if statErr != nil {
@@ -218,33 +236,40 @@ func (ch *CloudHypervisor) inspectRunning(ctx context.Context, vmRef string) (*h
 }
 
 // lockedDeviceOp serializes device-set mutations per VM across processes and
-// hands back a vm.info snapshot taken UNDER the lock, so precheck-then-call
-// is atomic against concurrent attach/detach (two attaches of one path with
-// different names both passed the old unlocked precheck). Callers unlock
-// after their API call; the flock dies with the process, so no stale locks.
-func (ch *CloudHypervisor) lockedDeviceOp(ctx context.Context, vmRef string) (*http.Client, *chVMInfoResponse, func(), error) {
+// hands back the record and a vm.info snapshot taken UNDER the lock, so
+// precheck-then-call is atomic against concurrent attach/detach and the
+// record's Config can't be a pre-restore vintage (restore rewrites it while
+// holding this lock). The flock dies with the process, so no stale locks.
+func (ch *CloudHypervisor) lockedDeviceOp(ctx context.Context, vmRef string) (*http.Client, hypervisor.VMRecord, *chVMInfoResponse, func(), error) {
 	hc, vmID, _, err := ch.runningVMClientWithRecord(ctx, vmRef)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, hypervisor.VMRecord{}, nil, nil, err
 	}
 	unlock, err := ch.LockVMOps(ctx, vmID)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, hypervisor.VMRecord{}, nil, nil, err
+	}
+	fail := func(err error) (*http.Client, hypervisor.VMRecord, *chVMInfoResponse, func(), error) {
+		unlock()
+		return nil, hypervisor.VMRecord{}, nil, nil, err
+	}
+	rec, err := ch.LoadRecord(ctx, vmID)
+	if err != nil {
+		return fail(err)
 	}
 	info, err := getVMInfo(ctx, hc)
 	if err != nil {
-		unlock()
-		return nil, nil, nil, err
+		return fail(err)
 	}
-	return hc, info, unlock, nil
+	return hc, rec, info, unlock, nil
 }
 
 func (ch *CloudHypervisor) attachWith(
 	ctx context.Context, vmRef, endpoint string,
-	body any, fallbackID string,
+	makeBody func(rec *hypervisor.VMRecord) any, fallbackID string,
 	preCheck func(*chVMInfoResponse) error,
 ) (string, error) {
-	hc, info, unlock, err := ch.lockedDeviceOp(ctx, vmRef)
+	hc, rec, info, unlock, err := ch.lockedDeviceOp(ctx, vmRef)
 	if err != nil {
 		return "", err
 	}
@@ -255,7 +280,7 @@ func (ch *CloudHypervisor) attachWith(
 	if checkErr := preCheck(info); checkErr != nil {
 		return "", checkErr
 	}
-	bodyBytes, err := json.Marshal(body)
+	bodyBytes, err := json.Marshal(makeBody(&rec))
 	if err != nil {
 		return "", fmt.Errorf("marshal %s: %w", endpoint, err)
 	}
@@ -282,7 +307,7 @@ func (ch *CloudHypervisor) detachWith(
 	ctx context.Context, vmRef string,
 	findID func(*chVMInfoResponse) (string, error),
 ) error {
-	hc, info, unlock, err := ch.lockedDeviceOp(ctx, vmRef)
+	hc, _, info, unlock, err := ch.lockedDeviceOp(ctx, vmRef)
 	if err != nil {
 		return err
 	}

--- a/hypervisor/cloudhypervisor/extend.go
+++ b/hypervisor/cloudhypervisor/extend.go
@@ -250,8 +250,12 @@ func (ch *CloudHypervisor) inspectRunning(ctx context.Context, vmRef string) (*h
 	return hc, info, nil
 }
 
-// lockedDeviceOpWithRecord is lockedDeviceOp for callers that also need the
-// VM id and record (the disk verbs persist to it).
+// lockedDeviceOpWithRecord serializes device-set mutations per VM across
+// processes and hands back a vm.info snapshot taken UNDER the lock, so
+// precheck-then-call is atomic against concurrent attach/detach (two attaches
+// of one path with different names both passed the old unlocked precheck).
+// Callers unlock after their API call; the flock dies with the process, so no
+// stale locks.
 func (ch *CloudHypervisor) lockedDeviceOpWithRecord(ctx context.Context, vmRef string) (*http.Client, *chVMInfoResponse, string, hypervisor.VMRecord, func(), error) {
 	hc, vmID, rec, err := ch.runningVMClientWithRecord(ctx, vmRef)
 	if err != nil {
@@ -267,6 +271,12 @@ func (ch *CloudHypervisor) lockedDeviceOpWithRecord(ctx context.Context, vmRef s
 		return nil, nil, "", hypervisor.VMRecord{}, nil, err
 	}
 	return hc, info, vmID, rec, unlock, nil
+}
+
+// lockedDeviceOp is lockedDeviceOpWithRecord for callers that need neither the id nor the record.
+func (ch *CloudHypervisor) lockedDeviceOp(ctx context.Context, vmRef string) (*http.Client, *chVMInfoResponse, func(), error) {
+	hc, info, _, _, unlock, err := ch.lockedDeviceOpWithRecord(ctx, vmRef)
+	return hc, info, unlock, err
 }
 
 func (ch *CloudHypervisor) appendStorageConfig(ctx context.Context, vmID string, sc *types.StorageConfig) error {
@@ -295,28 +305,6 @@ func (ch *CloudHypervisor) removeStorageConfig(ctx context.Context, vmID, serial
 		r.StorageConfigs = kept
 		return nil
 	})
-}
-
-// lockedDeviceOp serializes device-set mutations per VM across processes and
-// hands back a vm.info snapshot taken UNDER the lock, so precheck-then-call
-// is atomic against concurrent attach/detach (two attaches of one path with
-// different names both passed the old unlocked precheck). Callers unlock
-// after their API call; the flock dies with the process, so no stale locks.
-func (ch *CloudHypervisor) lockedDeviceOp(ctx context.Context, vmRef string) (*http.Client, *chVMInfoResponse, func(), error) {
-	hc, vmID, _, err := ch.runningVMClientWithRecord(ctx, vmRef)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	unlock, err := ch.LockVMOps(ctx, vmID)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	info, err := getVMInfo(ctx, hc)
-	if err != nil {
-		unlock()
-		return nil, nil, nil, err
-	}
-	return hc, info, unlock, nil
 }
 
 func (ch *CloudHypervisor) attachWith(

--- a/hypervisor/cloudhypervisor/extend.go
+++ b/hypervisor/cloudhypervisor/extend.go
@@ -45,6 +45,7 @@ func (ch *CloudHypervisor) DiskAttach(ctx context.Context, vmRef string, spec di
 	// semantics must match create-path data disks.
 	d := storageConfigToDisk(&types.StorageConfig{
 		Role: types.StorageRoleData, Path: spec.Path, Serial: spec.Name, RO: spec.ReadOnly,
+		DirectIO: spec.DirectIO,
 	}, vm.Config.CPU, vm.Config.DiskQueueSize, vm.Config.NoDirectIO)
 	id := disk.DeriveID(spec.Name)
 	d.ID = id
@@ -52,6 +53,11 @@ func (ch *CloudHypervisor) DiskAttach(ctx context.Context, vmRef string, spec di
 		for _, ex := range info.Config.Disks {
 			if ex.ID == id {
 				return fmt.Errorf("disk name %q already attached", spec.Name)
+			}
+			// Record data disks carry CH auto ids — match serials too, else two
+			// devices race for one /dev/disk/by-id/virtio-<name>.
+			if ex.Serial == spec.Name {
+				return fmt.Errorf("disk serial %q already used by disk %q", spec.Name, ex.ID)
 			}
 			if ex.Path == spec.Path {
 				return fmt.Errorf("disk path %q already attached as %q", spec.Path, ex.ID)
@@ -289,7 +295,6 @@ func (ch *CloudHypervisor) runningVMClientWithRecord(ctx context.Context, vmRef 
 	return utils.NewSocketHTTPClient(sockPath), vmID, rec, nil
 }
 
-// listWith returns nil (not error) for stopped VMs so inspect can omit the field.
 // ensureNotPaused refuses device-set mutations while a capture window is open
 // (snapshot/hibernate/fork): mutating mid-capture would desync config and memory.
 func ensureNotPaused(info *chVMInfoResponse) error {
@@ -299,6 +304,7 @@ func ensureNotPaused(info *chVMInfoResponse) error {
 	return nil
 }
 
+// listWith returns nil (not error) for stopped VMs so inspect can omit the field.
 func listWith[A any](
 	ctx context.Context, ch *CloudHypervisor, vmRef string,
 	extract func(*chVMInfoResponse) []A,

--- a/hypervisor/cloudhypervisor/extend.go
+++ b/hypervisor/cloudhypervisor/extend.go
@@ -39,6 +39,11 @@ func (ch *CloudHypervisor) DiskAttach(ctx context.Context, vmRef string, spec di
 	if _, err := os.Stat(spec.Path); err != nil {
 		return "", fmt.Errorf("disk path: %w", err)
 	}
+	// A volume under a cocoon-managed root would be deleted by vm rm / GC,
+	// breaking the never-deletes contract.
+	if hypervisor.IsUnderDir(spec.Path, ch.conf.RootDir) || hypervisor.IsUnderDir(spec.Path, ch.conf.Config.RunDir) {
+		return "", fmt.Errorf("external volume path %s is inside a cocoon-managed directory", spec.Path)
+	}
 	hc, info, vmID, rec, unlock, err := ch.lockedDeviceOpWithRecord(ctx, vmRef)
 	if err != nil {
 		return "", err

--- a/hypervisor/cloudhypervisor/extend.go
+++ b/hypervisor/cloudhypervisor/extend.go
@@ -69,27 +69,6 @@ func (ch *CloudHypervisor) DiskAttach(ctx context.Context, vmRef string, spec di
 	})
 }
 
-// resolveExternalVolume canonicalizes path (EvalSymlinks also asserts existence)
-// and refuses anything inside a cocoon-managed root: vm rm / GC delete those
-// trees, breaking the never-deletes contract, and a symlink must not smuggle a
-// managed path past the check. Returns the resolved path so the duplicate
-// precheck and CH both see one canonical name per volume.
-func (ch *CloudHypervisor) resolveExternalVolume(path string) (string, error) {
-	resolved, err := filepath.EvalSymlinks(path)
-	if err != nil {
-		return "", fmt.Errorf("disk path: %w", err)
-	}
-	for _, dir := range []string{ch.conf.RootDir, ch.conf.Config.RunDir, ch.conf.Config.LogDir} {
-		if r, evalErr := filepath.EvalSymlinks(dir); evalErr == nil {
-			dir = r
-		}
-		if hypervisor.IsUnderDir(resolved, dir) {
-			return "", fmt.Errorf("external volume path %s is inside a cocoon-managed directory", path)
-		}
-	}
-	return resolved, nil
-}
-
 func (ch *CloudHypervisor) DiskDetach(ctx context.Context, vmRef, name string) error {
 	if name == "" {
 		return fmt.Errorf("name is required")
@@ -203,10 +182,8 @@ func (ch *CloudHypervisor) DeviceDetach(ctx context.Context, vmRef, id string) e
 		return fmt.Errorf("id is required")
 	}
 	return ch.detachWith(ctx, vmRef, func(info *chVMInfoResponse) (string, error) {
-		for _, ex := range info.Config.Devices {
-			if ex.ID == id {
-				return id, nil
-			}
+		if slices.ContainsFunc(info.Config.Devices, func(d chDevice) bool { return d.ID == id }) {
+			return id, nil
 		}
 		return "", fmt.Errorf("device id %q not attached", id)
 	})
@@ -220,6 +197,27 @@ func (ch *CloudHypervisor) DeviceList(ctx context.Context, vmRef string) ([]vfio
 		}
 		return out
 	})
+}
+
+// resolveExternalVolume canonicalizes path (EvalSymlinks also asserts existence)
+// and refuses anything inside a cocoon-managed root: vm rm / GC delete those
+// trees, breaking the never-deletes contract, and a symlink must not smuggle a
+// managed path past the check. Returns the resolved path so the duplicate
+// precheck and CH both see one canonical name per volume.
+func (ch *CloudHypervisor) resolveExternalVolume(path string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", fmt.Errorf("disk path: %w", err)
+	}
+	for _, dir := range []string{ch.conf.RootDir, ch.conf.Config.RunDir, ch.conf.Config.LogDir} {
+		if r, evalErr := filepath.EvalSymlinks(dir); evalErr == nil {
+			dir = r
+		}
+		if hypervisor.IsUnderDir(resolved, dir) {
+			return "", fmt.Errorf("external volume path %s is inside a cocoon-managed directory", path)
+		}
+	}
+	return resolved, nil
 }
 
 // inspectRunning gates on a live VM and returns a fresh vm.info for conflict/memory/device-id lookups.

--- a/hypervisor/cloudhypervisor/extend.go
+++ b/hypervisor/cloudhypervisor/extend.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/projecteru2/core/log"
+
 	"github.com/cocoonstack/cocoon/extend/disk"
 	"github.com/cocoonstack/cocoon/extend/fs"
 	"github.com/cocoonstack/cocoon/extend/netresize"
@@ -37,49 +39,81 @@ func (ch *CloudHypervisor) DiskAttach(ctx context.Context, vmRef string, spec di
 	if _, err := os.Stat(spec.Path); err != nil {
 		return "", fmt.Errorf("disk path: %w", err)
 	}
-	vm, err := ch.Inspect(ctx, vmRef)
+	hc, info, vmID, rec, unlock, err := ch.lockedDeviceOpWithRecord(ctx, vmRef)
 	if err != nil {
 		return "", err
 	}
+	defer unlock()
+	if err = ensureNotPaused(info); err != nil {
+		return "", err
+	}
+	id := disk.DeriveID(spec.Name)
+	for _, ex := range info.Config.Disks {
+		if ex.ID == id {
+			return "", fmt.Errorf("disk name %q already attached", spec.Name)
+		}
+		// Record data disks carry CH auto ids — match serials too, else two
+		// devices race for one /dev/disk/by-id/virtio-<name>.
+		if ex.Serial == spec.Name {
+			return "", fmt.Errorf("disk serial %q already used by disk %q", spec.Name, ex.ID)
+		}
+		if ex.Path == spec.Path {
+			return "", fmt.Errorf("disk path %q already attached as %q", spec.Path, ex.ID)
+		}
+	}
+	// FSType none: the external file's filesystem is user-managed, mkfs and
+	// cloud-init mounts never apply to it.
+	sc := &types.StorageConfig{
+		Role: types.StorageRoleData, Path: spec.Path, Serial: spec.Name, RO: spec.ReadOnly,
+		DirectIO: spec.DirectIO, External: true, FSType: "none",
+	}
 	// The CH fork refuses disks without an explicit image_type; DirectIO/queue
 	// semantics must match create-path data disks.
-	d := storageConfigToDisk(&types.StorageConfig{
-		Role: types.StorageRoleData, Path: spec.Path, Serial: spec.Name, RO: spec.ReadOnly,
-		DirectIO: spec.DirectIO,
-	}, vm.Config.CPU, vm.Config.DiskQueueSize, vm.Config.NoDirectIO)
-	id := disk.DeriveID(spec.Name)
-	d.ID = id
-	return ch.attachWith(ctx, vmRef, "vm.add-disk", d, id, func(info *chVMInfoResponse) error {
-		for _, ex := range info.Config.Disks {
-			if ex.ID == id {
-				return fmt.Errorf("disk name %q already attached", spec.Name)
-			}
-			// Record data disks carry CH auto ids — match serials too, else two
-			// devices race for one /dev/disk/by-id/virtio-<name>.
-			if ex.Serial == spec.Name {
-				return fmt.Errorf("disk serial %q already used by disk %q", spec.Name, ex.ID)
-			}
-			if ex.Path == spec.Path {
-				return fmt.Errorf("disk path %q already attached as %q", spec.Path, ex.ID)
-			}
+	d := storageConfigToDisk(sc, rec.Config.CPU, rec.Config.DiskQueueSize, rec.Config.NoDirectIO)
+	if err = addDiskVM(ctx, hc, d); err != nil {
+		return "", fmt.Errorf("vm.add-disk: %w", err)
+	}
+	// Persist so the volume survives stop/start and rides hibernate/wake; on
+	// persist failure remove the live device (netresize rollback pattern).
+	if err = ch.appendStorageConfig(ctx, vmID, sc); err != nil {
+		if rmErr := removeDeviceVM(ctx, hc, d.ID); rmErr != nil {
+			log.WithFunc("cloudhypervisor.DiskAttach").Warnf(ctx, "rollback vm.remove-device %s after persist failure: %v", d.ID, rmErr)
 		}
-		return nil
-	})
+		return "", fmt.Errorf("persist disk %s: %w", spec.Name, err)
+	}
+	return d.ID, nil
 }
 
 func (ch *CloudHypervisor) DiskDetach(ctx context.Context, vmRef, name string) error {
 	if name == "" {
 		return fmt.Errorf("name is required")
 	}
+	hc, info, vmID, _, unlock, err := ch.lockedDeviceOpWithRecord(ctx, vmRef)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	if err = ensureNotPaused(info); err != nil {
+		return err
+	}
 	id := disk.DeriveID(name)
-	return ch.detachWith(ctx, vmRef, func(info *chVMInfoResponse) (string, error) {
-		for _, ex := range info.Config.Disks {
-			if ex.ID == id {
-				return ex.ID, nil
-			}
+	found := false
+	for _, ex := range info.Config.Disks {
+		if ex.ID == id {
+			found = true
+			break
 		}
-		return "", fmt.Errorf("disk %q not attached", name)
-	})
+	}
+	if !found {
+		return fmt.Errorf("disk %q not attached", name)
+	}
+	if err := removeDeviceVM(ctx, hc, id); err != nil {
+		return fmt.Errorf("vm.remove-device %s: %w", id, err)
+	}
+	if err := ch.removeStorageConfig(ctx, vmID, name); err != nil {
+		return fmt.Errorf("device removed but record retained for %s: %w", name, err)
+	}
+	return nil
 }
 
 func (ch *CloudHypervisor) DiskList(ctx context.Context, vmRef string) ([]disk.Attached, error) {
@@ -211,15 +245,85 @@ func (ch *CloudHypervisor) inspectRunning(ctx context.Context, vmRef string) (*h
 	return hc, info, nil
 }
 
+// lockedDeviceOpWithRecord is lockedDeviceOp for callers that also need the
+// VM id and record (the disk verbs persist to it).
+func (ch *CloudHypervisor) lockedDeviceOpWithRecord(ctx context.Context, vmRef string) (*http.Client, *chVMInfoResponse, string, hypervisor.VMRecord, func(), error) {
+	hc, vmID, rec, err := ch.runningVMClientWithRecord(ctx, vmRef)
+	if err != nil {
+		return nil, nil, "", hypervisor.VMRecord{}, nil, err
+	}
+	unlock, err := ch.LockVMOps(ctx, vmID)
+	if err != nil {
+		return nil, nil, "", hypervisor.VMRecord{}, nil, err
+	}
+	info, err := getVMInfo(ctx, hc)
+	if err != nil {
+		unlock()
+		return nil, nil, "", hypervisor.VMRecord{}, nil, err
+	}
+	return hc, info, vmID, rec, unlock, nil
+}
+
+func (ch *CloudHypervisor) appendStorageConfig(ctx context.Context, vmID string, sc *types.StorageConfig) error {
+	return ch.DB.Update(ctx, func(idx *hypervisor.VMIndex) error {
+		r, err := idx.GetRecord(vmID)
+		if err != nil {
+			return err
+		}
+		r.StorageConfigs = append(r.StorageConfigs, sc)
+		return nil
+	})
+}
+
+func (ch *CloudHypervisor) removeStorageConfig(ctx context.Context, vmID, serial string) error {
+	return ch.DB.Update(ctx, func(idx *hypervisor.VMIndex) error {
+		r, err := idx.GetRecord(vmID)
+		if err != nil {
+			return err
+		}
+		kept := r.StorageConfigs[:0]
+		for _, sc := range r.StorageConfigs {
+			if sc.Role != types.StorageRoleData || !sc.External || sc.Serial != serial {
+				kept = append(kept, sc)
+			}
+		}
+		r.StorageConfigs = kept
+		return nil
+	})
+}
+
+// lockedDeviceOp serializes device-set mutations per VM across processes and
+// hands back a vm.info snapshot taken UNDER the lock, so precheck-then-call
+// is atomic against concurrent attach/detach (two attaches of one path with
+// different names both passed the old unlocked precheck). Callers unlock
+// after their API call; the flock dies with the process, so no stale locks.
+func (ch *CloudHypervisor) lockedDeviceOp(ctx context.Context, vmRef string) (*http.Client, *chVMInfoResponse, func(), error) {
+	hc, vmID, _, err := ch.runningVMClientWithRecord(ctx, vmRef)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	unlock, err := ch.LockVMOps(ctx, vmID)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	info, err := getVMInfo(ctx, hc)
+	if err != nil {
+		unlock()
+		return nil, nil, nil, err
+	}
+	return hc, info, unlock, nil
+}
+
 func (ch *CloudHypervisor) attachWith(
 	ctx context.Context, vmRef, endpoint string,
 	body any, fallbackID string,
 	preCheck func(*chVMInfoResponse) error,
 ) (string, error) {
-	hc, info, err := ch.inspectRunning(ctx, vmRef)
+	hc, info, unlock, err := ch.lockedDeviceOp(ctx, vmRef)
 	if err != nil {
 		return "", err
 	}
+	defer unlock()
 	if err = ensureNotPaused(info); err != nil {
 		return "", err
 	}
@@ -253,10 +357,11 @@ func (ch *CloudHypervisor) detachWith(
 	ctx context.Context, vmRef string,
 	findID func(*chVMInfoResponse) (string, error),
 ) error {
-	hc, info, err := ch.inspectRunning(ctx, vmRef)
+	hc, info, unlock, err := ch.lockedDeviceOp(ctx, vmRef)
 	if err != nil {
 		return err
 	}
+	defer unlock()
 	if err = ensureNotPaused(info); err != nil {
 		return err
 	}

--- a/hypervisor/cloudhypervisor/extend.go
+++ b/hypervisor/cloudhypervisor/extend.go
@@ -40,63 +40,52 @@ func (ch *CloudHypervisor) DiskAttach(ctx context.Context, vmRef string, spec di
 	}
 	// A volume under a cocoon-managed root would be deleted by vm rm / GC,
 	// breaking the never-deletes contract.
-	if hypervisor.IsUnderDir(spec.Path, ch.conf.RootDir) || hypervisor.IsUnderDir(spec.Path, ch.conf.Config.RunDir) {
+	if hypervisor.IsUnderDir(spec.Path, ch.conf.RootDir) || hypervisor.IsUnderDir(spec.Path, ch.conf.Config.RunDir) ||
+		hypervisor.IsUnderDir(spec.Path, ch.conf.Config.LogDir) {
 		return "", fmt.Errorf("external volume path %s is inside a cocoon-managed directory", spec.Path)
 	}
-	hc, info, rec, unlock, err := ch.lockedDeviceOpWithRecord(ctx, vmRef)
+	// Config CPU/queue fields are frozen while the VM runs (restore rewrites
+	// them but holds the same ops lock), so the pre-lock record is safe here.
+	_, _, rec, err := ch.runningVMClientWithRecord(ctx, vmRef)
 	if err != nil {
 		return "", err
 	}
-	defer unlock()
-	if err = ensureNotPaused(info); err != nil {
-		return "", err
-	}
 	id := disk.DeriveID(spec.Name)
-	for _, ex := range info.Config.Disks {
-		if ex.ID == id {
-			return "", fmt.Errorf("disk name %q already attached", spec.Name)
-		}
-		// Record data disks carry CH auto ids — match serials too, else two
-		// devices race for one /dev/disk/by-id/virtio-<name>.
-		if ex.Serial == spec.Name {
-			return "", fmt.Errorf("disk serial %q already used by disk %q", spec.Name, ex.ID)
-		}
-		if ex.Path == spec.Path {
-			return "", fmt.Errorf("disk path %q already attached as %q", spec.Path, ex.ID)
-		}
-	}
 	// The CH fork refuses disks without an explicit image_type; DirectIO/queue
 	// semantics must match create-path data disks.
 	d := storageConfigToDisk(&types.StorageConfig{
 		Role: types.StorageRoleData, Path: spec.Path, Serial: spec.Name, RO: spec.ReadOnly, DirectIO: spec.DirectIO,
 	}, rec.Config.CPU, rec.Config.DiskQueueSize, rec.Config.NoDirectIO)
 	d.ID = id
-	if err = addDiskVM(ctx, hc, d); err != nil {
-		return "", fmt.Errorf("vm.add-disk: %w", err)
-	}
-	return d.ID, nil
+	return ch.attachWith(ctx, vmRef, "vm.add-disk", d, id, func(info *chVMInfoResponse) error {
+		for _, ex := range info.Config.Disks {
+			if ex.ID == id {
+				return fmt.Errorf("disk name %q already attached", spec.Name)
+			}
+			// Record data disks carry CH auto ids — match serials too, else two
+			// devices race for one /dev/disk/by-id/virtio-<name>.
+			if ex.Serial == spec.Name {
+				return fmt.Errorf("disk serial %q already used by disk %q", spec.Name, ex.ID)
+			}
+			if ex.Path == spec.Path {
+				return fmt.Errorf("disk path %q already attached as %q", spec.Path, ex.ID)
+			}
+		}
+		return nil
+	})
 }
 
 func (ch *CloudHypervisor) DiskDetach(ctx context.Context, vmRef, name string) error {
 	if name == "" {
 		return fmt.Errorf("name is required")
 	}
-	hc, info, unlock, err := ch.lockedDeviceOp(ctx, vmRef)
-	if err != nil {
-		return err
-	}
-	defer unlock()
-	if err = ensureNotPaused(info); err != nil {
-		return err
-	}
 	id := disk.DeriveID(name)
-	if !slices.ContainsFunc(info.Config.Disks, func(d chDisk) bool { return d.ID == id }) {
-		return fmt.Errorf("disk %q not attached", name)
-	}
-	if err := removeDeviceVM(ctx, hc, id); err != nil {
-		return fmt.Errorf("vm.remove-device %s: %w", id, err)
-	}
-	return nil
+	return ch.detachWith(ctx, vmRef, func(info *chVMInfoResponse) (string, error) {
+		if slices.ContainsFunc(info.Config.Disks, func(d chDisk) bool { return d.ID == id }) {
+			return id, nil
+		}
+		return "", fmt.Errorf("disk %q not attached", name)
+	})
 }
 
 func (ch *CloudHypervisor) DiskList(ctx context.Context, vmRef string) ([]disk.Attached, error) {
@@ -228,33 +217,26 @@ func (ch *CloudHypervisor) inspectRunning(ctx context.Context, vmRef string) (*h
 	return hc, info, nil
 }
 
-// lockedDeviceOpWithRecord serializes device-set mutations per VM across
-// processes and hands back a vm.info snapshot taken UNDER the lock, so
-// precheck-then-call is atomic against concurrent attach/detach (two attaches
-// of one path with different names both passed the old unlocked precheck).
-// Callers unlock after their API call; the flock dies with the process, so no
-// stale locks.
-func (ch *CloudHypervisor) lockedDeviceOpWithRecord(ctx context.Context, vmRef string) (*http.Client, *chVMInfoResponse, hypervisor.VMRecord, func(), error) {
-	hc, vmID, rec, err := ch.runningVMClientWithRecord(ctx, vmRef)
+// lockedDeviceOp serializes device-set mutations per VM across processes and
+// hands back a vm.info snapshot taken UNDER the lock, so precheck-then-call
+// is atomic against concurrent attach/detach (two attaches of one path with
+// different names both passed the old unlocked precheck). Callers unlock
+// after their API call; the flock dies with the process, so no stale locks.
+func (ch *CloudHypervisor) lockedDeviceOp(ctx context.Context, vmRef string) (*http.Client, *chVMInfoResponse, func(), error) {
+	hc, vmID, _, err := ch.runningVMClientWithRecord(ctx, vmRef)
 	if err != nil {
-		return nil, nil, hypervisor.VMRecord{}, nil, err
+		return nil, nil, nil, err
 	}
 	unlock, err := ch.LockVMOps(ctx, vmID)
 	if err != nil {
-		return nil, nil, hypervisor.VMRecord{}, nil, err
+		return nil, nil, nil, err
 	}
 	info, err := getVMInfo(ctx, hc)
 	if err != nil {
 		unlock()
-		return nil, nil, hypervisor.VMRecord{}, nil, err
+		return nil, nil, nil, err
 	}
-	return hc, info, rec, unlock, nil
-}
-
-// lockedDeviceOp is lockedDeviceOpWithRecord for callers that don't need the record.
-func (ch *CloudHypervisor) lockedDeviceOp(ctx context.Context, vmRef string) (*http.Client, *chVMInfoResponse, func(), error) {
-	hc, info, _, unlock, err := ch.lockedDeviceOpWithRecord(ctx, vmRef)
-	return hc, info, unlock, err
+	return hc, info, unlock, nil
 }
 
 func (ch *CloudHypervisor) attachWith(

--- a/hypervisor/cloudhypervisor/extend_test.go
+++ b/hypervisor/cloudhypervisor/extend_test.go
@@ -1,0 +1,71 @@
+package cloudhypervisor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cocoonstack/cocoon/config"
+)
+
+func TestResolveExternalVolume(t *testing.T) {
+	base := t.TempDir()
+	rootDir := filepath.Join(base, "root")
+	runDir := filepath.Join(base, "run")
+	logDir := filepath.Join(base, "log")
+	volDir := filepath.Join(base, "vols")
+	for _, d := range []string{rootDir, filepath.Join(runDir, "cloudhypervisor", "vm1"), logDir, volDir} {
+		if err := os.MkdirAll(d, 0o750); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	okVol := filepath.Join(volDir, "ok.raw")
+	managed := filepath.Join(runDir, "cloudhypervisor", "vm1", "data-x.raw")
+	for _, f := range []string{okVol, managed} {
+		if err := os.WriteFile(f, []byte("x"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", f, err)
+		}
+	}
+	smuggled := filepath.Join(volDir, "smuggled.raw")
+	if err := os.Symlink(managed, smuggled); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	ch := &CloudHypervisor{conf: NewConfig(&config.Config{RootDir: rootDir, RunDir: runDir, LogDir: logDir})}
+
+	// t.TempDir may itself sit behind symlinks (macOS /var); expected values resolve too.
+	wantOK, err := filepath.EvalSymlinks(okVol)
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		want    string
+		wantErr string
+	}{
+		{name: "plain external volume", path: okVol, want: wantOK},
+		{name: "direct managed path refused", path: managed, wantErr: "cocoon-managed"},
+		{name: "symlink into managed dir refused", path: smuggled, wantErr: "cocoon-managed"},
+		{name: "missing path refused", path: filepath.Join(volDir, "absent.raw"), wantErr: "disk path"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ch.resolveExternalVolume(tt.path)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/hypervisor/cloudhypervisor/netresize.go
+++ b/hypervisor/cloudhypervisor/netresize.go
@@ -37,6 +37,13 @@ func (ch *CloudHypervisor) NetResize(ctx context.Context, vmRef string, spec net
 	if rec, err = ch.LoadRecord(ctx, vmID); err != nil {
 		return netresize.Result{}, err
 	}
+	info, err := getVMInfo(ctx, hc)
+	if err != nil {
+		return netresize.Result{}, err
+	}
+	if err = ensureNotPaused(info); err != nil {
+		return netresize.Result{}, err
+	}
 	current := len(rec.NetworkConfigs)
 	res := netresize.Result{Before: current, After: current}
 	switch {
@@ -45,10 +52,6 @@ func (ch *CloudHypervisor) NetResize(ctx context.Context, vmRef string, spec net
 	case spec.Target > current:
 		return ch.netResizeAdd(ctx, hc, vmID, &rec.Config, plumbing, current, spec.Target, res)
 	default:
-		info, infoErr := getVMInfo(ctx, hc)
-		if infoErr != nil {
-			return res, infoErr
-		}
 		return ch.netResizeRemove(ctx, hc, info, vmID, rec.NetworkConfigs, plumbing, current, spec.Target, res)
 	}
 }

--- a/hypervisor/cloudhypervisor/netresize.go
+++ b/hypervisor/cloudhypervisor/netresize.go
@@ -27,6 +27,11 @@ func (ch *CloudHypervisor) NetResize(ctx context.Context, vmRef string, spec net
 	if err != nil {
 		return netresize.Result{}, err
 	}
+	unlock, err := ch.LockVMOps(ctx, vmID)
+	if err != nil {
+		return netresize.Result{}, err
+	}
+	defer unlock()
 	current := len(rec.NetworkConfigs)
 	res := netresize.Result{Before: current, After: current}
 	switch {

--- a/hypervisor/cloudhypervisor/netresize.go
+++ b/hypervisor/cloudhypervisor/netresize.go
@@ -55,6 +55,11 @@ func (ch *CloudHypervisor) NetResize(ctx context.Context, vmRef string, spec net
 
 func (ch *CloudHypervisor) netResizeAdd(ctx context.Context, hc *http.Client, vmID string, vmCfg *types.VMConfig, plumbing netresize.Plumbing, from, target int, res netresize.Result) (netresize.Result, error) {
 	logger := log.WithFunc("cloudhypervisor.NetResize.add")
+	rollbackPlumbing := func(i int) {
+		if rmErr := plumbing.Remove(ctx, vmID, i); rmErr != nil {
+			logger.Warnf(ctx, "rollback host plumbing for nic %d: %v", i, rmErr)
+		}
+	}
 	res.Added = make([]netresize.NIC, 0, target-from)
 	for i := from; i < target; i++ {
 		ncs, err := plumbing.Add(ctx, vmID, vmCfg, network.AddSpec{Index: i})
@@ -67,9 +72,7 @@ func (ch *CloudHypervisor) netResizeAdd(ctx context.Context, hc *http.Client, vm
 		nc := ncs[0]
 		chID, err := addCocoonNIC(ctx, hc, nc)
 		if err != nil {
-			if rmErr := plumbing.Remove(ctx, vmID, i); rmErr != nil {
-				logger.Warnf(ctx, "rollback host plumbing for nic %d: %v", i, rmErr)
-			}
+			rollbackPlumbing(i)
 			return res, fmt.Errorf("vm.add-net nic %d: %w", i, err)
 		}
 		if err := ch.appendNetworkConfig(ctx, vmID, nc); err != nil {
@@ -79,9 +82,7 @@ func (ch *CloudHypervisor) netResizeAdd(ctx context.Context, hc *http.Client, vm
 			} else if wErr := waitDeviceEjected(ctx, hc, chID, ejectWaitTimeout); wErr != nil {
 				logger.Warnf(ctx, "rollback wait eject %s after persist failure: %v", chID, wErr)
 			}
-			if rmErr := plumbing.Remove(ctx, vmID, i); rmErr != nil {
-				logger.Warnf(ctx, "rollback host plumbing for nic %d: %v", i, rmErr)
-			}
+			rollbackPlumbing(i)
 			return res, fmt.Errorf("persist nic %d: %w", i, err)
 		}
 		res.Added = append(res.Added, netresize.NIC{Index: i, TAP: nc.TAP, MAC: nc.MAC})

--- a/hypervisor/cloudhypervisor/netresize.go
+++ b/hypervisor/cloudhypervisor/netresize.go
@@ -32,6 +32,11 @@ func (ch *CloudHypervisor) NetResize(ctx context.Context, vmRef string, spec net
 		return netresize.Result{}, err
 	}
 	defer unlock()
+	// Reload under the lock: a resize that won the lock first may have
+	// changed the NIC set after this one loaded the record.
+	if rec, err = ch.LoadRecord(ctx, vmID); err != nil {
+		return netresize.Result{}, err
+	}
 	current := len(rec.NetworkConfigs)
 	res := netresize.Result{Before: current, After: current}
 	switch {

--- a/hypervisor/cloudhypervisor/netresize.go
+++ b/hypervisor/cloudhypervisor/netresize.go
@@ -132,22 +132,14 @@ func (ch *CloudHypervisor) netResizeRemove(ctx context.Context, hc *http.Client,
 }
 
 func (ch *CloudHypervisor) appendNetworkConfig(ctx context.Context, vmID string, nc *types.NetworkConfig) error {
-	return ch.DB.Update(ctx, func(idx *hypervisor.VMIndex) error {
-		r, err := idx.GetRecord(vmID)
-		if err != nil {
-			return err
-		}
+	return ch.UpdateRecord(ctx, vmID, func(r *hypervisor.VMRecord) error {
 		r.NetworkConfigs = append(r.NetworkConfigs, nc)
 		return nil
 	})
 }
 
 func (ch *CloudHypervisor) truncateNetworkConfigs(ctx context.Context, vmID string, length int) error {
-	return ch.DB.Update(ctx, func(idx *hypervisor.VMIndex) error {
-		r, err := idx.GetRecord(vmID)
-		if err != nil {
-			return err
-		}
+	return ch.UpdateRecord(ctx, vmID, func(r *hypervisor.VMRecord) error {
 		if length < len(r.NetworkConfigs) {
 			r.NetworkConfigs = r.NetworkConfigs[:length]
 		}

--- a/hypervisor/cloudhypervisor/restore.go
+++ b/hypervisor/cloudhypervisor/restore.go
@@ -48,7 +48,7 @@ func (ch *CloudHypervisor) restoreAfterExtract(ctx context.Context, vmID string,
 
 	chConfigPath := filepath.Join(rec.RunDir, configJSONName)
 	// rec may have trailing cidata absent from the snapshot (cloudimg post-first-boot); slice to sidecar length.
-	meta, metaErr := hypervisor.LoadAndValidateMeta(rec.RunDir, ch.conf.RootDir, ch.conf.Config.RunDir, hypervisor.ExternalPathSet(rec.StorageConfigs))
+	meta, metaErr := hypervisor.LoadAndValidateMeta(rec.RunDir, ch.conf.RootDir, ch.conf.Config.RunDir, hypervisor.ExternalTrustSet(rec.StorageConfigs))
 	if metaErr != nil {
 		return nil, fmt.Errorf("load snapshot meta: %w", metaErr)
 	}

--- a/hypervisor/cloudhypervisor/restore.go
+++ b/hypervisor/cloudhypervisor/restore.go
@@ -48,7 +48,7 @@ func (ch *CloudHypervisor) restoreAfterExtract(ctx context.Context, vmID string,
 
 	chConfigPath := filepath.Join(rec.RunDir, configJSONName)
 	// rec may have trailing cidata absent from the snapshot (cloudimg post-first-boot); slice to sidecar length.
-	meta, metaErr := hypervisor.LoadAndValidateMeta(rec.RunDir, ch.conf.RootDir, ch.conf.Config.RunDir)
+	meta, metaErr := hypervisor.LoadAndValidateMeta(rec.RunDir, ch.conf.RootDir, ch.conf.Config.RunDir, hypervisor.ExternalPathSet(rec.StorageConfigs))
 	if metaErr != nil {
 		return nil, fmt.Errorf("load snapshot meta: %w", metaErr)
 	}

--- a/hypervisor/cloudhypervisor/restore.go
+++ b/hypervisor/cloudhypervisor/restore.go
@@ -22,7 +22,7 @@ func (ch *CloudHypervisor) Restore(ctx context.Context, vmRef string, vmCfg *typ
 		Preflight:        ch.preflightRestore,
 		Kill:             ch.killForRestore,
 		AfterExtract: func(ctx context.Context, vmID string, vmCfg *types.VMConfig, rec *hypervisor.VMRecord) (*types.VM, error) {
-			directBoot := isDirectBoot(rec.BootConfig)
+			directBoot := hypervisor.IsDirectBoot(rec.BootConfig)
 			return ch.restoreAfterExtract(ctx, vmID, vmCfg, rec, directBoot)
 		},
 	})

--- a/hypervisor/cloudhypervisor/restore.go
+++ b/hypervisor/cloudhypervisor/restore.go
@@ -21,6 +21,11 @@ func (ch *CloudHypervisor) Restore(ctx context.Context, vmRef string, vmCfg *typ
 		SourceSnapshotID: sourceSnapshotID,
 		Preflight:        ch.preflightRestore,
 		Kill:             ch.killForRestore,
+		// Same sweep as DirectRestore's Populate: stale snapshot files (data-*.raw,
+		// memory ranges) from a previous incarnation must not survive the merge.
+		BeforeMerge: func(rec *hypervisor.VMRecord) error {
+			return cleanSnapshotFiles(rec.RunDir)
+		},
 		AfterExtract: func(ctx context.Context, vmID string, vmCfg *types.VMConfig, rec *hypervisor.VMRecord) (*types.VM, error) {
 			directBoot := hypervisor.IsDirectBoot(rec.BootConfig)
 			return ch.restoreAfterExtract(ctx, vmID, vmCfg, rec, directBoot)

--- a/hypervisor/cloudhypervisor/restore.go
+++ b/hypervisor/cloudhypervisor/restore.go
@@ -48,7 +48,7 @@ func (ch *CloudHypervisor) restoreAfterExtract(ctx context.Context, vmID string,
 
 	chConfigPath := filepath.Join(rec.RunDir, configJSONName)
 	// rec may have trailing cidata absent from the snapshot (cloudimg post-first-boot); slice to sidecar length.
-	meta, metaErr := hypervisor.LoadAndValidateMeta(rec.RunDir, ch.conf.RootDir, ch.conf.Config.RunDir, hypervisor.ExternalTrustSet(rec.StorageConfigs))
+	meta, metaErr := hypervisor.LoadAndValidateMeta(rec.RunDir, ch.conf.RootDir, ch.conf.Config.RunDir)
 	if metaErr != nil {
 		return nil, fmt.Errorf("load snapshot meta: %w", metaErr)
 	}

--- a/hypervisor/cloudhypervisor/snapshot.go
+++ b/hypervisor/cloudhypervisor/snapshot.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/cocoonstack/cocoon/extend/disk"
 	"github.com/cocoonstack/cocoon/hypervisor"
 	"github.com/cocoonstack/cocoon/types"
 	"github.com/cocoonstack/cocoon/utils"
@@ -75,6 +76,9 @@ func buildSnapshotMeta(rec *hypervisor.VMRecord, tmpDir string) (*hypervisor.Sna
 	for _, d := range chCfg.Disks {
 		sc, ok := byPath[d.Path]
 		if !ok {
+			if name := disk.NameFromID(d.ID); name != "" {
+				return nil, fmt.Errorf("hot-attached disk %q: detach before snapshot or hibernate", name)
+			}
 			return nil, fmt.Errorf("snapshot config has disk %q not present in VM record", d.Path)
 		}
 		ordered = append(ordered, sc)

--- a/hypervisor/cloudhypervisor/snapshot.go
+++ b/hypervisor/cloudhypervisor/snapshot.go
@@ -38,7 +38,7 @@ func (ch *CloudHypervisor) snapshotSpec(ctx context.Context) hypervisor.Snapshot
 			if err := snapshotVM(ctx, hc, tmpDir); err != nil {
 				return fmt.Errorf("snapshot: %w", err)
 			}
-			directBoot := isDirectBoot(rec.BootConfig)
+			directBoot := hypervisor.IsDirectBoot(rec.BootConfig)
 			cowPath := ch.cowPath(rec.ID, directBoot)
 			if err := utils.ReflinkCopy(filepath.Join(tmpDir, filepath.Base(cowPath)), cowPath); err != nil {
 				return fmt.Errorf("copy COW: %w", err)
@@ -46,7 +46,7 @@ func (ch *CloudHypervisor) snapshotSpec(ctx context.Context) hypervisor.Snapshot
 			return hypervisor.ReflinkDataDisks(tmpDir, rec.StorageConfigs)
 		},
 		AfterCapture: func(rec *hypervisor.VMRecord, tmpDir string) error {
-			if isDirectBoot(rec.BootConfig) || rec.Config.Windows {
+			if hypervisor.IsDirectBoot(rec.BootConfig) || rec.Config.Windows {
 				return nil
 			}
 			cidataSrc := ch.conf.CidataPath(rec.ID)

--- a/hypervisor/cloudhypervisor/snapshot_test.go
+++ b/hypervisor/cloudhypervisor/snapshot_test.go
@@ -1,0 +1,36 @@
+package cloudhypervisor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cocoonstack/cocoon/hypervisor"
+	"github.com/cocoonstack/cocoon/types"
+)
+
+func TestBuildSnapshotMetaRefusesUnrecordedDisk(t *testing.T) {
+	tests := []struct {
+		name    string
+		diskID  string
+		wantErr string
+	}{
+		{"hot-attached gets the detach hint", "cocoon-disk-vol1", "detach before snapshot or hibernate"},
+		{"foreign unknown disk keeps the record error", "other-id", "not present in VM record"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			cfg := `{"disks":[{"path":"/vols/a.raw","id":"` + tt.diskID + `"}]}`
+			if err := os.WriteFile(filepath.Join(dir, configJSONName), []byte(cfg), 0o600); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+			rec := &hypervisor.VMRecord{VM: types.VM{ID: "vm1"}}
+			_, err := buildSnapshotMeta(rec, dir)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("err = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/hypervisor/cloudhypervisor/snapshot_test.go
+++ b/hypervisor/cloudhypervisor/snapshot_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/cocoonstack/cocoon/hypervisor"
-	"github.com/cocoonstack/cocoon/types"
 )
 
 func TestBuildSnapshotMetaRefusesUnrecordedDisk(t *testing.T) {
@@ -26,7 +25,7 @@ func TestBuildSnapshotMetaRefusesUnrecordedDisk(t *testing.T) {
 			if err := os.WriteFile(filepath.Join(dir, configJSONName), []byte(cfg), 0o600); err != nil {
 				t.Fatalf("write config: %v", err)
 			}
-			rec := &hypervisor.VMRecord{VM: types.VM{ID: "vm1"}}
+			rec := &hypervisor.VMRecord{}
 			_, err := buildSnapshotMeta(rec, dir)
 			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 				t.Fatalf("err = %v, want %q", err, tt.wantErr)

--- a/hypervisor/cloudhypervisor/start.go
+++ b/hypervisor/cloudhypervisor/start.go
@@ -15,7 +15,7 @@ func (ch *CloudHypervisor) Start(ctx context.Context, refs []string) ([]string, 
 	return ch.StartAll(ctx, refs, ch.startOne)
 }
 
-func (ch *CloudHypervisor) startOne(ctx context.Context, id string) (bool, error) {
+func (ch *CloudHypervisor) startOne(ctx context.Context, id string) error {
 	return ch.StartSequence(ctx, id, hypervisor.StartSpec{
 		RuntimeFiles: runtimeFiles,
 		Launch: func(ctx context.Context, rec *hypervisor.VMRecord, sockPath string) (int, error) {

--- a/hypervisor/cloudhypervisor/stop.go
+++ b/hypervisor/cloudhypervisor/stop.go
@@ -8,7 +8,6 @@ import (
 	"github.com/projecteru2/core/log"
 
 	"github.com/cocoonstack/cocoon/hypervisor"
-	"github.com/cocoonstack/cocoon/types"
 	"github.com/cocoonstack/cocoon/utils"
 )
 
@@ -27,15 +26,14 @@ func (ch *CloudHypervisor) stopOneLocked(ctx context.Context, id string) error {
 }
 
 func (ch *CloudHypervisor) stopSpec() hypervisor.StopSpec {
-	stopTimeout := time.Duration(ch.conf.StopTimeoutSeconds) * time.Second
 	return hypervisor.StopSpec{
 		RuntimeFiles: runtimeFiles,
 		Shutdown: func(ctx context.Context, rec *hypervisor.VMRecord, sockPath string, pid int) error {
 			hc := utils.NewSocketHTTPClient(sockPath)
-			if isDirectBoot(rec.BootConfig) || stopTimeout < 0 /* --force */ {
+			if hypervisor.IsDirectBoot(rec.BootConfig) || ch.conf.ForceStop() {
 				return ch.forceTerminate(ctx, hc, rec.ID, sockPath, pid)
 			}
-			return ch.shutdownUEFI(ctx, hc, rec.ID, sockPath, pid, stopTimeout)
+			return ch.shutdownUEFI(ctx, hc, rec.ID, sockPath, pid, ch.conf.StopTimeout())
 		},
 	}
 }
@@ -54,8 +52,4 @@ func (ch *CloudHypervisor) forceTerminate(ctx context.Context, hc *http.Client, 
 		log.WithFunc("cloudhypervisor.forceTerminate").Warnf(ctx, "vm.shutdown %s: %v", vmID, err)
 	}
 	return utils.TerminateProcess(ctx, pid, ch.conf.BinaryName(), socketPath, ch.conf.TerminateGracePeriod())
-}
-
-func isDirectBoot(boot *types.BootConfig) bool {
-	return boot != nil && boot.KernelPath != ""
 }

--- a/hypervisor/cloudhypervisor/stop.go
+++ b/hypervisor/cloudhypervisor/stop.go
@@ -18,8 +18,17 @@ func (ch *CloudHypervisor) Stop(ctx context.Context, refs []string) ([]string, e
 }
 
 func (ch *CloudHypervisor) stopOne(ctx context.Context, id string) error {
+	return ch.StopOneSequence(ctx, id, ch.stopSpec())
+}
+
+// stopOneLocked is stopOne for callers already holding the VM's ops lock (DeleteAll).
+func (ch *CloudHypervisor) stopOneLocked(ctx context.Context, id string) error {
+	return ch.StopOneLocked(ctx, id, ch.stopSpec())
+}
+
+func (ch *CloudHypervisor) stopSpec() hypervisor.StopSpec {
 	stopTimeout := time.Duration(ch.conf.StopTimeoutSeconds) * time.Second
-	return ch.StopOneSequence(ctx, id, hypervisor.StopSpec{
+	return hypervisor.StopSpec{
 		RuntimeFiles: runtimeFiles,
 		Shutdown: func(ctx context.Context, rec *hypervisor.VMRecord, sockPath string, pid int) error {
 			hc := utils.NewSocketHTTPClient(sockPath)
@@ -28,7 +37,7 @@ func (ch *CloudHypervisor) stopOne(ctx context.Context, id string) error {
 			}
 			return ch.shutdownUEFI(ctx, hc, rec.ID, sockPath, pid, stopTimeout)
 		},
-	})
+	}
 }
 
 // shutdownUEFI shuts down a UEFI-boot VM via ACPI power-button with poll-and-escalate handled by the shared GracefulStop helper.

--- a/hypervisor/firecracker/api.go
+++ b/hypervisor/firecracker/api.go
@@ -21,8 +21,6 @@ const (
 	driveIDFmt = "drive_%d"
 	ifaceIDFmt = "eth%d"
 
-	cowFileName = "cow.raw"
-
 	hugePagesNone = "None"
 	hugePages2M   = "2M"
 	ioEngineAsync = "Async" // io_uring
@@ -122,20 +120,25 @@ func putJSON[T any](ctx context.Context, hc *http.Client, endpoint string, paylo
 	return fcAPI(ctx, hc, endpoint, body)
 }
 
+// sendJSONOnce is putJSON's no-retry twin over fcAPIOnce for non-idempotent endpoints.
+func sendJSONOnce[T any](ctx context.Context, hc *http.Client, method, endpoint string, payload T, kind string, successCodes ...int) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", kind, err)
+	}
+	return fcAPIOnce(ctx, hc, method, endpoint, body, successCodes...)
+}
+
 func putMachineConfig(ctx context.Context, hc *http.Client, cfg fcMachineConfig) error {
 	return putJSON(ctx, hc, "/machine-config", cfg, "machine-config")
 }
 
 // patchDrivePath repoints a block device's backing file on a booted VM.
 func patchDrivePath(ctx context.Context, hc *http.Client, driveID, pathOnHost string) error {
-	body, err := json.Marshal(struct {
+	return sendJSONOnce(ctx, hc, http.MethodPatch, "/drives/"+driveID, struct {
 		DriveID    string `json:"drive_id"`
 		PathOnHost string `json:"path_on_host"`
-	}{DriveID: driveID, PathOnHost: pathOnHost})
-	if err != nil {
-		return fmt.Errorf("marshal drive patch: %w", err)
-	}
-	return fcAPIOnce(ctx, hc, http.MethodPatch, "/drives/"+driveID, body)
+	}{DriveID: driveID, PathOnHost: pathOnHost}, "drive patch")
 }
 
 func putBootSource(ctx context.Context, hc *http.Client, boot fcBootSource) error {
@@ -163,37 +166,22 @@ func putVsock(ctx context.Context, hc *http.Client, vsock fcVsock) error {
 }
 
 func instanceStart(ctx context.Context, hc *http.Client) error {
-	body, err := json.Marshal(fcAction{ActionType: actionInstanceStart})
-	if err != nil {
-		return fmt.Errorf("marshal action: %w", err)
-	}
-	return fcAPIOnce(ctx, hc, http.MethodPut, "/actions", body, http.StatusNoContent, http.StatusOK)
+	return sendJSONOnce(ctx, hc, http.MethodPut, "/actions", fcAction{ActionType: actionInstanceStart}, "action",
+		http.StatusNoContent, http.StatusOK)
 }
 
 func sendCtrlAltDel(ctx context.Context, hc *http.Client) error {
-	body, err := json.Marshal(fcAction{ActionType: actionSendCtrlAltDel})
-	if err != nil {
-		return fmt.Errorf("marshal action: %w", err)
-	}
-	return fcAPIOnce(ctx, hc, http.MethodPut, "/actions", body)
+	return sendJSONOnce(ctx, hc, http.MethodPut, "/actions", fcAction{ActionType: actionSendCtrlAltDel}, "action")
 }
 
 // pauseVM pauses a running FC instance via PATCH /vm. Idempotent: FC's vCPU event loop acks Pause from the paused state without error (vstate/vcpu.rs).
 func pauseVM(ctx context.Context, hc *http.Client) error {
-	body, err := json.Marshal(map[string]string{"state": vmStatePaused})
-	if err != nil {
-		return fmt.Errorf("marshal pause request: %w", err)
-	}
-	return fcAPIOnce(ctx, hc, http.MethodPatch, "/vm", body)
+	return sendJSONOnce(ctx, hc, http.MethodPatch, "/vm", map[string]string{"state": vmStatePaused}, "pause request")
 }
 
 // resumeVM resumes a paused FC instance via PATCH /vm. Idempotent like pauseVM.
 func resumeVM(ctx context.Context, hc *http.Client) error {
-	body, err := json.Marshal(map[string]string{"state": vmStateResumed})
-	if err != nil {
-		return fmt.Errorf("marshal resume request: %w", err)
-	}
-	return fcAPIOnce(ctx, hc, http.MethodPatch, "/vm", body)
+	return sendJSONOnce(ctx, hc, http.MethodPatch, "/vm", map[string]string{"state": vmStateResumed}, "resume request")
 }
 
 // createSnapshotFC writes vmstate + memory to destDir; no retry — resending would re-transfer multi-GiB and clobber a partial state.json.

--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -35,7 +35,7 @@ func (fc *Firecracker) cloneAfterExtract(ctx context.Context, vmID string, vmCfg
 	networkConfigs := net.NetworkConfigs
 	logger := log.WithFunc("firecracker.Clone")
 
-	meta, err := hypervisor.LoadAndValidateMeta(runDir, fc.conf.RootDir, fc.conf.Config.RunDir)
+	meta, err := hypervisor.LoadAndValidateMeta(runDir, fc.conf.RootDir, fc.conf.Config.RunDir, nil)
 	if err != nil {
 		return nil, fmt.Errorf("load snapshot metadata: %w", err)
 	}

--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -35,7 +35,7 @@ func (fc *Firecracker) cloneAfterExtract(ctx context.Context, vmID string, vmCfg
 	networkConfigs := net.NetworkConfigs
 	logger := log.WithFunc("firecracker.Clone")
 
-	meta, err := hypervisor.LoadAndValidateMeta(runDir, fc.conf.RootDir, fc.conf.Config.RunDir, nil)
+	meta, err := hypervisor.LoadAndValidateMeta(runDir, fc.conf.RootDir, fc.conf.Config.RunDir)
 	if err != nil {
 		return nil, fmt.Errorf("load snapshot metadata: %w", err)
 	}

--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -41,7 +41,7 @@ func (fc *Firecracker) cloneAfterExtract(ctx context.Context, vmID string, vmCfg
 	}
 
 	cowPath := fc.conf.COWRawPath(vmID)
-	snapshotCOW := filepath.Join(runDir, cowFileName)
+	snapshotCOW := filepath.Join(runDir, hypervisor.COWRawFileName)
 	if renameErr := os.Rename(snapshotCOW, cowPath); renameErr != nil {
 		return nil, fmt.Errorf("move COW to canonical path: %w", renameErr)
 	}

--- a/hypervisor/firecracker/config.go
+++ b/hypervisor/firecracker/config.go
@@ -22,5 +22,5 @@ func (c *Config) BinaryName() string { return filepath.Base(c.FCBinary) }
 func (c *Config) PIDFileName() string { return pidFileName }
 
 func (c *Config) COWRawPath(vmID string) string {
-	return filepath.Join(c.VMRunDir(vmID), cowFileName)
+	return filepath.Join(c.VMRunDir(vmID), hypervisor.COWRawFileName)
 }

--- a/hypervisor/firecracker/create_test.go
+++ b/hypervisor/firecracker/create_test.go
@@ -33,38 +33,6 @@ func TestDevPath(t *testing.T) {
 	}
 }
 
-func fakeELF() []byte {
-	out := []byte{0x7f, 'E', 'L', 'F'}
-	out = append(out, bytes.Repeat([]byte{0x00}, 60)...)
-	return out
-}
-
-func gzipCompress(t *testing.T, data []byte) []byte {
-	t.Helper()
-	var buf bytes.Buffer
-	gw := gzip.NewWriter(&buf)
-	if _, err := gw.Write(data); err != nil {
-		t.Fatalf("gzip write: %v", err)
-	}
-	if err := gw.Close(); err != nil {
-		t.Fatalf("gzip close: %v", err)
-	}
-	return buf.Bytes()
-}
-
-func zstdCompress(t *testing.T, data []byte) []byte {
-	t.Helper()
-	enc, err := zstd.NewWriter(nil)
-	if err != nil {
-		t.Fatalf("zstd writer: %v", err)
-	}
-	out := enc.EncodeAll(data, nil)
-	if err := enc.Close(); err != nil {
-		t.Fatalf("zstd close: %v", err)
-	}
-	return out
-}
-
 func TestDecompressKernel(t *testing.T) {
 	elf := fakeELF()
 
@@ -118,4 +86,36 @@ func TestDecompressKernel(t *testing.T) {
 			}
 		})
 	}
+}
+
+func fakeELF() []byte {
+	out := []byte{0x7f, 'E', 'L', 'F'}
+	out = append(out, bytes.Repeat([]byte{0x00}, 60)...)
+	return out
+}
+
+func gzipCompress(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	if _, err := gw.Write(data); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func zstdCompress(t *testing.T, data []byte) []byte {
+	t.Helper()
+	enc, err := zstd.NewWriter(nil)
+	if err != nil {
+		t.Fatalf("zstd writer: %v", err)
+	}
+	out := enc.EncodeAll(data, nil)
+	if err := enc.Close(); err != nil {
+		t.Fatalf("zstd close: %v", err)
+	}
+	return out
 }

--- a/hypervisor/firecracker/direct.go
+++ b/hypervisor/firecracker/direct.go
@@ -46,7 +46,7 @@ func cloneSnapshotFiles(dstDir, srcDir string) error {
 func cleanSnapshotFiles(runDir string) error {
 	return hypervisor.CleanSnapshotFiles(runDir, func(name string) bool {
 		switch name {
-		case snapshotVMStateFile, snapshotMemFile, cowFileName, hypervisor.SnapshotMetaFile:
+		case snapshotVMStateFile, snapshotMemFile, hypervisor.COWRawFileName, hypervisor.SnapshotMetaFile:
 			return true
 		}
 		return hypervisor.IsDataDiskFile(name)

--- a/hypervisor/firecracker/firecracker.go
+++ b/hypervisor/firecracker/firecracker.go
@@ -39,5 +39,5 @@ func New(conf *config.Config, rec metering.Recorder) (*Firecracker, error) {
 
 // Delete removes VMs. Running VMs require force=true (stops them first).
 func (fc *Firecracker) Delete(ctx context.Context, refs []string, force bool) ([]string, error) {
-	return fc.DeleteAll(ctx, refs, force, fc.stopOne)
+	return fc.DeleteAll(ctx, refs, force, fc.stopOneLocked)
 }

--- a/hypervisor/firecracker/restore.go
+++ b/hypervisor/firecracker/restore.go
@@ -23,7 +23,7 @@ func (fc *Firecracker) Restore(ctx context.Context, vmRef string, vmCfg *types.V
 		Kill:             fc.killForRestore,
 		Wrap:             fc.wrapSourceLocked,
 		BeforeMerge: func(rec *hypervisor.VMRecord) error {
-			_ = os.Remove(filepath.Join(rec.RunDir, cowFileName))
+			_ = os.Remove(filepath.Join(rec.RunDir, hypervisor.COWRawFileName))
 			return nil
 		},
 		AfterExtract: fc.restoreAfterExtractCOW,
@@ -54,7 +54,7 @@ func (fc *Firecracker) terminateVMM(ctx context.Context, rec *hypervisor.VMRecor
 func (fc *Firecracker) restoreAfterExtract(ctx context.Context, vmID string, vmCfg *types.VMConfig, rec *hypervisor.VMRecord, cowPath string) (_ *types.VM, err error) {
 	logger := log.WithFunc("firecracker.Restore")
 
-	snapshotCOW := filepath.Join(rec.RunDir, cowFileName)
+	snapshotCOW := filepath.Join(rec.RunDir, hypervisor.COWRawFileName)
 	if snapshotCOW != cowPath {
 		if _, statErr := os.Stat(snapshotCOW); statErr == nil {
 			if renameErr := os.Rename(snapshotCOW, cowPath); renameErr != nil {

--- a/hypervisor/firecracker/restore.go
+++ b/hypervisor/firecracker/restore.go
@@ -22,9 +22,10 @@ func (fc *Firecracker) Restore(ctx context.Context, vmRef string, vmCfg *types.V
 		Preflight:        fc.preflightRestore,
 		Kill:             fc.killForRestore,
 		Wrap:             fc.wrapSourceLocked,
+		// Same sweep as DirectRestore's Populate: stale vmstate/mem/data-*.raw
+		// from a previous incarnation must not survive the merge.
 		BeforeMerge: func(rec *hypervisor.VMRecord) error {
-			_ = os.Remove(filepath.Join(rec.RunDir, hypervisor.COWRawFileName))
-			return nil
+			return cleanSnapshotFiles(rec.RunDir)
 		},
 		AfterExtract: fc.restoreAfterExtractCOW,
 	})

--- a/hypervisor/firecracker/snapshot.go
+++ b/hypervisor/firecracker/snapshot.go
@@ -44,7 +44,7 @@ func (fc *Firecracker) snapshotSpec(ctx context.Context) hypervisor.SnapshotSpec
 			if err := createSnapshotFC(ctx, sockPath, tmpDir); err != nil {
 				return fmt.Errorf("snapshot: %w", err)
 			}
-			if err := utils.ReflinkCopy(filepath.Join(tmpDir, cowFileName), fc.conf.COWRawPath(rec.ID)); err != nil {
+			if err := utils.ReflinkCopy(filepath.Join(tmpDir, hypervisor.COWRawFileName), fc.conf.COWRawPath(rec.ID)); err != nil {
 				return fmt.Errorf("copy COW: %w", err)
 			}
 			return hypervisor.ReflinkDataDisks(tmpDir, rec.StorageConfigs)

--- a/hypervisor/firecracker/start.go
+++ b/hypervisor/firecracker/start.go
@@ -23,7 +23,7 @@ func (fc *Firecracker) Start(ctx context.Context, refs []string) ([]string, erro
 	return fc.StartAll(ctx, refs, fc.startOne)
 }
 
-func (fc *Firecracker) startOne(ctx context.Context, id string) (bool, error) {
+func (fc *Firecracker) startOne(ctx context.Context, id string) error {
 	return fc.StartSequence(ctx, id, hypervisor.StartSpec{
 		RuntimeFiles: runtimeFiles,
 		Launch: func(ctx context.Context, rec *hypervisor.VMRecord, sockPath string) (int, error) {

--- a/hypervisor/firecracker/stop.go
+++ b/hypervisor/firecracker/stop.go
@@ -24,14 +24,13 @@ func (fc *Firecracker) stopOneLocked(ctx context.Context, id string) error {
 }
 
 func (fc *Firecracker) stopSpec() hypervisor.StopSpec {
-	stopTimeout := time.Duration(fc.conf.StopTimeoutSeconds) * time.Second
 	return hypervisor.StopSpec{
 		RuntimeFiles: runtimeFiles,
 		Shutdown: func(ctx context.Context, rec *hypervisor.VMRecord, sockPath string, pid int) error {
-			if stopTimeout < 0 { // --force
+			if fc.conf.ForceStop() {
 				return fc.forceTerminate(ctx, sockPath, pid)
 			}
-			return fc.gracefulStop(ctx, utils.NewSocketHTTPClient(sockPath), rec.ID, sockPath, pid, stopTimeout)
+			return fc.gracefulStop(ctx, utils.NewSocketHTTPClient(sockPath), rec.ID, sockPath, pid, fc.conf.StopTimeout())
 		},
 	}
 }

--- a/hypervisor/firecracker/stop.go
+++ b/hypervisor/firecracker/stop.go
@@ -15,8 +15,17 @@ func (fc *Firecracker) Stop(ctx context.Context, refs []string) ([]string, error
 }
 
 func (fc *Firecracker) stopOne(ctx context.Context, id string) error {
+	return fc.StopOneSequence(ctx, id, fc.stopSpec())
+}
+
+// stopOneLocked is stopOne for callers already holding the VM's ops lock (DeleteAll).
+func (fc *Firecracker) stopOneLocked(ctx context.Context, id string) error {
+	return fc.StopOneLocked(ctx, id, fc.stopSpec())
+}
+
+func (fc *Firecracker) stopSpec() hypervisor.StopSpec {
 	stopTimeout := time.Duration(fc.conf.StopTimeoutSeconds) * time.Second
-	return fc.StopOneSequence(ctx, id, hypervisor.StopSpec{
+	return hypervisor.StopSpec{
 		RuntimeFiles: runtimeFiles,
 		Shutdown: func(ctx context.Context, rec *hypervisor.VMRecord, sockPath string, pid int) error {
 			if stopTimeout < 0 { // --force
@@ -24,7 +33,7 @@ func (fc *Firecracker) stopOne(ctx context.Context, id string) error {
 			}
 			return fc.gracefulStop(ctx, utils.NewSocketHTTPClient(sockPath), rec.ID, sockPath, pid, stopTimeout)
 		},
-	})
+	}
 }
 
 // gracefulStop sends SendCtrlAltDel with poll-and-escalate handled by the shared GracefulStop helper.

--- a/hypervisor/hibernate_test.go
+++ b/hypervisor/hibernate_test.go
@@ -17,14 +17,6 @@ import (
 	"github.com/cocoonstack/cocoon/utils"
 )
 
-// hibernateTestConfig extends the metering stub with a real VMRunDir so prepareSnapshot can MkdirTemp.
-type hibernateTestConfig struct {
-	stubBackendConfig
-	vmRunRoot string
-}
-
-func (c hibernateTestConfig) VMRunDir(string) string { return c.vmRunRoot }
-
 type hibernateCalls struct {
 	resumed    bool
 	terminated bool
@@ -129,11 +121,6 @@ func TestHibernateSequenceTerminateFailureMarksError(t *testing.T) {
 func newHibernateTestVM(t *testing.T) (*Backend, string) {
 	t.Helper()
 	b, _ := newMeteringTestBackend(t)
-	b.Conf = hibernateTestConfig{
-		stubBackendConfig: stubBackendConfig{},
-		vmRunRoot:         t.TempDir(),
-	}
-
 	const id = "vm-hibernate-test"
 	runDir := t.TempDir()
 	seedVMRecord(t, b, id, 1, 512, 1024, true)

--- a/hypervisor/hibernate_test.go
+++ b/hypervisor/hibernate_test.go
@@ -130,7 +130,7 @@ func newHibernateTestVM(t *testing.T) (*Backend, string) {
 	t.Helper()
 	b, _ := newMeteringTestBackend(t)
 	b.Conf = hibernateTestConfig{
-		stubBackendConfig: b.Conf.(stubBackendConfig),
+		stubBackendConfig: stubBackendConfig{},
 		vmRunRoot:         t.TempDir(),
 	}
 

--- a/hypervisor/hibernate_test.go
+++ b/hypervisor/hibernate_test.go
@@ -122,7 +122,7 @@ func newHibernateTestVM(t *testing.T) (*Backend, string) {
 	t.Helper()
 	b, _ := newMeteringTestBackend(t)
 	const id = "vm-hibernate-test"
-	runDir := t.TempDir()
+	runDir := shortTempDir(t)
 	seedVMRecord(t, b, id, 1, 512, 1024, true)
 	if err := b.DB.Update(t.Context(), func(idx *VMIndex) error {
 		idx.VMs[id].State = types.VMStateRunning
@@ -141,9 +141,16 @@ func newHibernateTestVM(t *testing.T) (*Backend, string) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start stub vmm: %v", err)
 	}
+	// Background reaper: a test-killed stub must not linger as a zombie, or
+	// TerminateProcess's IsProcessAlive polling never sees it exit.
+	waitDone := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(waitDone)
+	}()
 	t.Cleanup(func() {
 		_ = cmd.Process.Kill()
-		_, _ = cmd.Process.Wait()
+		<-waitDone
 	})
 	// cmd.Start returns before bash execs into tail; wait until the cmdline check would pass.
 	deadline := time.Now().Add(2 * time.Second)

--- a/hypervisor/inspect.go
+++ b/hypervisor/inspect.go
@@ -21,7 +21,7 @@ func (b *Backend) Inspect(ctx context.Context, ref string) (*types.VM, error) {
 	})
 }
 
-// List snapshots all records under the DB lock then runs ToVM (which does file IO) outside the lock so concurrent writers don't queue behind status polls. Mutable map fields are cloned inside the lock to avoid a concurrent-read race with RecordSnapshot etc.
+// List snapshots all records under the DB lock then runs ToVM (which does per-running-VM file IO) outside the lock and in parallel, so concurrent writers don't queue behind status polls and poll latency stays bounded by pool size, not fleet size. Mutable map fields are cloned inside the lock to avoid a concurrent-read race with RecordSnapshot etc.
 func (b *Backend) List(ctx context.Context) ([]*types.VM, error) {
 	var recs []*VMRecord
 	if err := b.DB.With(ctx, func(idx *VMIndex) error {
@@ -34,11 +34,9 @@ func (b *Backend) List(ctx context.Context) ([]*types.VM, error) {
 	}); err != nil {
 		return nil, err
 	}
-	result := make([]*types.VM, len(recs))
-	for i, r := range recs {
-		result[i] = b.ToVM(r)
-	}
-	return result, nil
+	return utils.Map(ctx, recs, func(_ context.Context, _ int, r *VMRecord) (*types.VM, error) {
+		return b.ToVM(r), nil
+	}, b.Conf.EffectivePoolSize())
 }
 
 func (b *Backend) ToVM(rec *VMRecord) *types.VM {

--- a/hypervisor/inspect.go
+++ b/hypervisor/inspect.go
@@ -102,6 +102,17 @@ func (b *Backend) ResolveAndLoad(ctx context.Context, ref string) (string, VMRec
 	})
 }
 
+// UpdateRecord runs mutate on the VM's live record inside one DB transaction.
+func (b *Backend) UpdateRecord(ctx context.Context, vmID string, mutate func(*VMRecord) error) error {
+	return b.DB.Update(ctx, func(idx *VMIndex) error {
+		r, err := idx.GetRecord(vmID)
+		if err != nil {
+			return err
+		}
+		return mutate(r)
+	})
+}
+
 func isVsockBound(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil

--- a/hypervisor/restore.go
+++ b/hypervisor/restore.go
@@ -56,11 +56,7 @@ func (b *Backend) ResolveForRestore(ctx context.Context, vmRef string) (string, 
 
 func (b *Backend) FinalizeRestore(ctx context.Context, vmID string, vmCfg *types.VMConfig, rec *VMRecord, pid int) (*types.VM, error) {
 	now := time.Now()
-	if err := b.DB.Update(ctx, func(idx *VMIndex) error {
-		r, err := idx.GetRecord(vmID)
-		if err != nil {
-			return err
-		}
+	if err := b.UpdateRecord(ctx, vmID, func(r *VMRecord) error {
 		r.Config = *vmCfg
 		r.State = types.VMStateRunning
 		r.StartedAt = &now
@@ -95,6 +91,11 @@ func (b *Backend) RestoreSequence(ctx context.Context, vmRef string, spec Restor
 		return nil, err
 	}
 	defer unlock()
+	// Revalidate under the lock: the pre-lock record may predate a concurrent
+	// mutating verb, and preflight anchors the external trust set to it.
+	if vmID, rec, err = b.ResolveForRestore(ctx, vmID); err != nil {
+		return nil, err
+	}
 
 	stagingDir, cleanupStaging, err := PrepareStagingDir(rec.RunDir, spec.Snapshot)
 	if err != nil {
@@ -150,6 +151,11 @@ func (b *Backend) DirectRestoreSequence(ctx context.Context, vmRef string, spec 
 		return nil, err
 	}
 	defer unlock()
+	// Revalidate under the lock: the pre-lock record may predate a concurrent
+	// mutating verb, and preflight anchors the external trust set to it.
+	if vmID, rec, err = b.ResolveForRestore(ctx, vmID); err != nil {
+		return nil, err
+	}
 
 	if preflightErr := spec.Preflight(spec.SrcDir, rec); preflightErr != nil {
 		return nil, fmt.Errorf("snapshot preflight: %w", preflightErr)

--- a/hypervisor/restore.go
+++ b/hypervisor/restore.go
@@ -39,11 +39,7 @@ func (b *Backend) FailRestore(ctx context.Context, vmID string, origin types.VMS
 }
 
 func (b *Backend) ResolveForRestore(ctx context.Context, vmRef string) (string, *VMRecord, error) {
-	vmID, err := b.ResolveRef(ctx, vmRef)
-	if err != nil {
-		return "", nil, err
-	}
-	rec, err := b.LoadRecord(ctx, vmID)
+	vmID, rec, err := b.ResolveAndLoad(ctx, vmRef)
 	if err != nil {
 		return "", nil, err
 	}
@@ -82,20 +78,11 @@ func (b *Backend) RestoreSequence(ctx context.Context, vmRef string, spec Restor
 	if err := ValidateHostCPU(spec.VMCfg.CPU); err != nil {
 		return nil, err
 	}
-	vmID, rec, err := b.ResolveForRestore(ctx, vmRef)
-	if err != nil {
-		return nil, err
-	}
-	unlock, err := b.LockVMOps(ctx, vmID)
+	vmID, rec, unlock, err := b.prepareRestore(ctx, vmRef)
 	if err != nil {
 		return nil, err
 	}
 	defer unlock()
-	// Revalidate under the lock: the pre-lock record may predate a concurrent
-	// mutating verb, and preflight anchors the external trust set to it.
-	if vmID, rec, err = b.ResolveForRestore(ctx, vmID); err != nil {
-		return nil, err
-	}
 
 	stagingDir, cleanupStaging, err := PrepareStagingDir(rec.RunDir, spec.Snapshot)
 	if err != nil {
@@ -142,20 +129,11 @@ func (b *Backend) DirectRestoreSequence(ctx context.Context, vmRef string, spec 
 	if err := ValidateHostCPU(spec.VMCfg.CPU); err != nil {
 		return nil, err
 	}
-	vmID, rec, err := b.ResolveForRestore(ctx, vmRef)
-	if err != nil {
-		return nil, err
-	}
-	unlock, err := b.LockVMOps(ctx, vmID)
+	vmID, rec, unlock, err := b.prepareRestore(ctx, vmRef)
 	if err != nil {
 		return nil, err
 	}
 	defer unlock()
-	// Revalidate under the lock: the pre-lock record may predate a concurrent
-	// mutating verb, and preflight anchors the external trust set to it.
-	if vmID, rec, err = b.ResolveForRestore(ctx, vmID); err != nil {
-		return nil, err
-	}
 
 	if preflightErr := spec.Preflight(spec.SrcDir, rec); preflightErr != nil {
 		return nil, fmt.Errorf("snapshot preflight: %w", preflightErr)
@@ -184,6 +162,35 @@ func (b *Backend) DirectRestoreSequence(ctx context.Context, vmRef string, spec 
 	}
 	b.emitRestoreSuccess(ctx, result, oldShape, spec.SourceSnapshotID)
 	return result, nil
+}
+
+// prepareRestore resolves ref, takes the VM ops lock, re-resolves under it, and validates the record (mirrors prepareSnapshot/StartSequence); the caller defers the returned unlock.
+func (b *Backend) prepareRestore(ctx context.Context, vmRef string) (string, *VMRecord, func(), error) {
+	vmID, _, err := b.ResolveForRestore(ctx, vmRef)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	unlock, err := b.LockVMOps(ctx, vmID)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	fail := func(err error) (string, *VMRecord, func(), error) {
+		unlock()
+		return "", nil, nil, err
+	}
+	// Revalidate under the lock: the pre-lock record may predate a concurrent
+	// mutating verb, and preflight anchors the external trust set to it.
+	vmID, rec, err := b.ResolveForRestore(ctx, vmID)
+	if err != nil {
+		return fail(err)
+	}
+	if vErr := types.ValidateStorageConfigs(rec.StorageConfigs); vErr != nil {
+		return fail(fmt.Errorf("storage invariants violated: %w", vErr))
+	}
+	if vErr := types.ValidateNetworkConfigs(rec.NetworkConfigs); vErr != nil {
+		return fail(fmt.Errorf("network invariants violated: %w", vErr))
+	}
+	return vmID, rec, unlock, nil
 }
 
 // emitRestoreComputeStop closes the compute interval after a confirmed kill; fail-closed on DB error and skip on vanished record so the ledger never gets a phantom entry.

--- a/hypervisor/restore.go
+++ b/hypervisor/restore.go
@@ -90,6 +90,11 @@ func (b *Backend) RestoreSequence(ctx context.Context, vmRef string, spec Restor
 	if err != nil {
 		return nil, err
 	}
+	unlock, err := b.LockVMOps(ctx, vmID)
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
 
 	stagingDir, cleanupStaging, err := PrepareStagingDir(rec.RunDir, spec.Snapshot)
 	if err != nil {
@@ -140,6 +145,11 @@ func (b *Backend) DirectRestoreSequence(ctx context.Context, vmRef string, spec 
 	if err != nil {
 		return nil, err
 	}
+	unlock, err := b.LockVMOps(ctx, vmID)
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
 
 	if preflightErr := spec.Preflight(spec.SrcDir, rec); preflightErr != nil {
 		return nil, fmt.Errorf("snapshot preflight: %w", preflightErr)

--- a/hypervisor/restore_test.go
+++ b/hypervisor/restore_test.go
@@ -240,3 +240,40 @@ func TestKillForRestoreFailureKeepsOriginContract(t *testing.T) {
 		})
 	}
 }
+
+// A corrupt persisted record (null storage/NIC entry) must fail restore preflight
+// with a clean invariants error, not panic in ValidateMetaPaths/ValidateRoleSequence.
+func TestPrepareRestoreRejectsCorruptRecord(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*VMRecord)
+		wantErr string
+	}{
+		{"nil storage config", func(r *VMRecord) { r.StorageConfigs = []*types.StorageConfig{nil} }, "storage invariants violated"},
+		{"nil network config", func(r *VMRecord) {
+			r.StorageConfigs = nil
+			r.NetworkConfigs = []*types.NetworkConfig{nil}
+		}, "network invariants violated"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, _ := newMeteringTestBackend(t)
+			ctx := t.Context()
+			const id = "vm-corrupt"
+			seedStoppedVMWithDirs(t, b, id)
+			if err := b.DB.Update(ctx, func(idx *VMIndex) error {
+				tt.mutate(idx.VMs[id])
+				return nil
+			}); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+			_, _, unlock, err := b.prepareRestore(ctx, id)
+			if unlock != nil {
+				unlock()
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("err = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/hypervisor/restore_test.go
+++ b/hypervisor/restore_test.go
@@ -145,24 +145,6 @@ func TestRestorePartialMergeQuarantinesEvenStoppedOrigin(t *testing.T) {
 	}
 }
 
-func tarWithFiles(t *testing.T, names ...string) io.Reader {
-	t.Helper()
-	var buf bytes.Buffer
-	tw := tar.NewWriter(&buf)
-	for _, name := range names {
-		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o600, Size: 1}); err != nil {
-			t.Fatalf("tar hdr %s: %v", name, err)
-		}
-		if _, err := tw.Write([]byte("y")); err != nil {
-			t.Fatalf("tar body %s: %v", name, err)
-		}
-	}
-	if err := tw.Close(); err != nil {
-		t.Fatalf("tar close: %v", err)
-	}
-	return &buf
-}
-
 func TestResolveForRestoreStates(t *testing.T) {
 	b, _ := newMeteringTestBackend(t)
 	tests := []struct {
@@ -276,4 +258,22 @@ func TestPrepareRestoreRejectsCorruptRecord(t *testing.T) {
 			}
 		})
 	}
+}
+
+func tarWithFiles(t *testing.T, names ...string) io.Reader {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for _, name := range names {
+		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o600, Size: 1}); err != nil {
+			t.Fatalf("tar hdr %s: %v", name, err)
+		}
+		if _, err := tw.Write([]byte("y")); err != nil {
+			t.Fatalf("tar body %s: %v", name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar close: %v", err)
+	}
+	return &buf
 }

--- a/hypervisor/snapshot.go
+++ b/hypervisor/snapshot.go
@@ -223,7 +223,7 @@ func LoadSnapshotMeta(dir string) (*SnapshotMeta, error) {
 	return &meta, nil
 }
 
-func LoadAndValidateMeta(dir, rootDir, runDir string, trustedExternal map[string]struct{}) (*SnapshotMeta, error) {
+func LoadAndValidateMeta(dir, rootDir, runDir string, trustedExternal map[string]ExternalTrust) (*SnapshotMeta, error) {
 	meta, err := LoadSnapshotMeta(dir)
 	if err != nil {
 		return nil, err
@@ -234,17 +234,25 @@ func LoadAndValidateMeta(dir, rootDir, runDir string, trustedExternal map[string
 	return meta, nil
 }
 
-// ExternalPathSet collects the record's external volume paths — the trust
-// anchor for sidecar external entries (a foreign snapshot cannot name a host
-// file the live record does not already reference).
-func ExternalPathSet(configs []*types.StorageConfig) map[string]struct{} {
-	var set map[string]struct{}
+// ExternalTrust is the identity a sidecar external entry must match exactly;
+// path membership alone would let a tampered sidecar flip RO or the guest
+// serial on a file the record legitimately references.
+type ExternalTrust struct {
+	Serial string
+	RO     bool
+}
+
+// ExternalTrustSet collects the record's external volumes — the trust anchor
+// for sidecar external entries (a foreign snapshot cannot name a host file
+// the live record does not already reference, nor alter its identity).
+func ExternalTrustSet(configs []*types.StorageConfig) map[string]ExternalTrust {
+	var set map[string]ExternalTrust
 	for _, sc := range configs {
 		if sc != nil && sc.External {
 			if set == nil {
-				set = make(map[string]struct{})
+				set = make(map[string]ExternalTrust)
 			}
-			set[sc.Path] = struct{}{}
+			set[sc.Path] = ExternalTrust{Serial: sc.Serial, RO: sc.RO}
 		}
 	}
 	return set
@@ -263,7 +271,7 @@ func PopulateFromSrc(runDir, srcDir string, clean func(string) error, clone func
 
 // PreflightRestore: load+validate sidecar, run backend-specific integrity, assert snapshot role sequence is a prefix of rec.
 func PreflightRestore(srcDir, rootDir, runDir string, rec *VMRecord, integrity func(srcDir string, sidecar []*types.StorageConfig) error) error {
-	meta, err := LoadAndValidateMeta(srcDir, rootDir, runDir, ExternalPathSet(rec.StorageConfigs))
+	meta, err := LoadAndValidateMeta(srcDir, rootDir, runDir, ExternalTrustSet(rec.StorageConfigs))
 	if err != nil {
 		return err
 	}
@@ -298,11 +306,20 @@ func IsUnderDir(path, dir string) bool {
 // ValidateMetaPaths rejects sidecar paths escaping cocoon-managed roots; an imported snapshot's cocoon.json is otherwise untrusted.
 // External volume entries are trusted only when the live record already references the same path (trustedExternal) — this both
 // blocks a foreign sidecar from naming arbitrary host files and refuses clones of volume-referencing snapshots (clones pass nil).
-func ValidateMetaPaths(meta *SnapshotMeta, rootDir, runDir string, trustedExternal map[string]struct{}) error {
+func ValidateMetaPaths(meta *SnapshotMeta, rootDir, runDir string, trustedExternal map[string]ExternalTrust) error {
 	for _, sc := range meta.StorageConfigs {
 		if sc.External {
-			if _, ok := trustedExternal[sc.Path]; !ok {
+			t, ok := trustedExternal[sc.Path]
+			if !ok {
 				return fmt.Errorf("snapshot references external volume %q (%s) not present on the VM record", sc.Serial, sc.Path)
+			}
+			if sc.Serial != t.Serial || sc.RO != t.RO {
+				return fmt.Errorf("snapshot external volume %q (%s) does not match the VM record's identity (serial/readonly)", sc.Serial, sc.Path)
+			}
+			// External paths inside cocoon-managed roots are contradictions:
+			// rm/GC may delete them with the run dir.
+			if IsUnderDir(sc.Path, rootDir) || IsUnderDir(sc.Path, runDir) {
+				return fmt.Errorf("external volume %q path %s is inside a cocoon-managed directory", sc.Serial, sc.Path)
 			}
 			continue
 		}

--- a/hypervisor/snapshot.go
+++ b/hypervisor/snapshot.go
@@ -274,7 +274,10 @@ func IsUnderDir(path, dir string) bool {
 // ValidateMetaPaths rejects sidecar paths escaping cocoon-managed roots; an imported snapshot's cocoon.json is otherwise untrusted.
 // External volumes never reach a snapshot (snapshot/hibernate refuse them), so every sidecar path must be under a managed root.
 func ValidateMetaPaths(meta *SnapshotMeta, rootDir, runDir string) error {
-	for _, sc := range meta.StorageConfigs {
+	for i, sc := range meta.StorageConfigs {
+		if sc == nil {
+			return fmt.Errorf("nil storage config %d in snapshot metadata", i)
+		}
 		if !IsUnderDir(sc.Path, rootDir) && !IsUnderDir(sc.Path, runDir) {
 			return fmt.Errorf("untrusted storage path in snapshot metadata: %s", sc.Path)
 		}

--- a/hypervisor/snapshot.go
+++ b/hypervisor/snapshot.go
@@ -73,10 +73,11 @@ func (b *Backend) BuildSnapshotConfig(snapID string, rec *VMRecord) *types.Snaps
 
 // SnapshotSequence is the shared capture skeleton; only capture runs in the pause window — AfterCapture (e.g. cidata copy) runs outside.
 func (b *Backend) SnapshotSequence(ctx context.Context, ref string, spec SnapshotSpec) (_ *types.SnapshotConfig, _ io.ReadCloser, err error) {
-	vmID, rec, tmpDir, err := b.prepareSnapshot(ctx, ref)
+	vmID, rec, tmpDir, unlock, err := b.prepareSnapshot(ctx, ref)
 	if err != nil {
 		return nil, nil, err
 	}
+	defer unlock()
 	defer func() {
 		if err != nil {
 			os.RemoveAll(tmpDir) //nolint:errcheck,gosec
@@ -103,10 +104,11 @@ func (b *Backend) SnapshotSequence(ctx context.Context, ref string, spec Snapsho
 
 // HibernateSequence is SnapshotSequence with persist inside the pause window and terminate instead of resume: the snapshot point and the stop coincide, any failure before terminate resumes the VM, and a failed terminate marks it error.
 func (b *Backend) HibernateSequence(ctx context.Context, ref string, spec HibernateSpec, persist func(cfg *types.SnapshotConfig, stream io.ReadCloser) error) (err error) {
-	vmID, rec, tmpDir, err := b.prepareSnapshot(ctx, ref)
+	vmID, rec, tmpDir, unlock, err := b.prepareSnapshot(ctx, ref)
 	if err != nil {
 		return err
 	}
+	defer unlock()
 	defer func() {
 		if err != nil {
 			os.RemoveAll(tmpDir) //nolint:errcheck,gosec
@@ -161,23 +163,31 @@ func (b *Backend) HibernateSequence(ctx context.Context, ref string, spec Hibern
 }
 
 // prepareSnapshot resolves ref and stages a capture dir inside the VM's run dir.
-func (b *Backend) prepareSnapshot(ctx context.Context, ref string) (string, VMRecord, string, error) {
+func (b *Backend) prepareSnapshot(ctx context.Context, ref string) (string, VMRecord, string, func(), error) {
 	vmID, err := b.ResolveRef(ctx, ref)
 	if err != nil {
-		return "", VMRecord{}, "", err
+		return "", VMRecord{}, "", nil, err
+	}
+	unlock, err := b.LockVMOps(ctx, vmID)
+	if err != nil {
+		return "", VMRecord{}, "", nil, err
+	}
+	fail := func(err error) (string, VMRecord, string, func(), error) {
+		unlock()
+		return "", VMRecord{}, "", nil, err
 	}
 	rec, err := b.LoadRecord(ctx, vmID)
 	if err != nil {
-		return "", VMRecord{}, "", err
+		return fail(err)
 	}
 	if vErr := types.ValidateStorageConfigs(rec.StorageConfigs); vErr != nil {
-		return "", VMRecord{}, "", fmt.Errorf("storage invariants violated: %w", vErr)
+		return fail(fmt.Errorf("storage invariants violated: %w", vErr))
 	}
 	tmpDir, err := os.MkdirTemp(b.Conf.VMRunDir(vmID), "snapshot-")
 	if err != nil {
-		return "", VMRecord{}, "", fmt.Errorf("create temp dir: %w", err)
+		return fail(fmt.Errorf("create temp dir: %w", err))
 	}
-	return vmID, rec, tmpDir, nil
+	return vmID, rec, tmpDir, unlock, nil
 }
 
 // finalizeSnapshot writes the sidecar metadata and registers the snapshot on the VM record.
@@ -213,15 +223,31 @@ func LoadSnapshotMeta(dir string) (*SnapshotMeta, error) {
 	return &meta, nil
 }
 
-func LoadAndValidateMeta(dir, rootDir, runDir string) (*SnapshotMeta, error) {
+func LoadAndValidateMeta(dir, rootDir, runDir string, trustedExternal map[string]struct{}) (*SnapshotMeta, error) {
 	meta, err := LoadSnapshotMeta(dir)
 	if err != nil {
 		return nil, err
 	}
-	if err := ValidateMetaPaths(meta, rootDir, runDir); err != nil {
+	if err := ValidateMetaPaths(meta, rootDir, runDir, trustedExternal); err != nil {
 		return nil, err
 	}
 	return meta, nil
+}
+
+// ExternalPathSet collects the record's external volume paths — the trust
+// anchor for sidecar external entries (a foreign snapshot cannot name a host
+// file the live record does not already reference).
+func ExternalPathSet(configs []*types.StorageConfig) map[string]struct{} {
+	var set map[string]struct{}
+	for _, sc := range configs {
+		if sc != nil && sc.External {
+			if set == nil {
+				set = make(map[string]struct{})
+			}
+			set[sc.Path] = struct{}{}
+		}
+	}
+	return set
 }
 
 // PopulateFromSrc cleans runDir of old snapshot files then copies fresh ones from srcDir (used by DirectRestore).
@@ -237,7 +263,7 @@ func PopulateFromSrc(runDir, srcDir string, clean func(string) error, clone func
 
 // PreflightRestore: load+validate sidecar, run backend-specific integrity, assert snapshot role sequence is a prefix of rec.
 func PreflightRestore(srcDir, rootDir, runDir string, rec *VMRecord, integrity func(srcDir string, sidecar []*types.StorageConfig) error) error {
-	meta, err := LoadAndValidateMeta(srcDir, rootDir, runDir)
+	meta, err := LoadAndValidateMeta(srcDir, rootDir, runDir, ExternalPathSet(rec.StorageConfigs))
 	if err != nil {
 		return err
 	}
@@ -270,8 +296,16 @@ func IsUnderDir(path, dir string) bool {
 }
 
 // ValidateMetaPaths rejects sidecar paths escaping cocoon-managed roots; an imported snapshot's cocoon.json is otherwise untrusted.
-func ValidateMetaPaths(meta *SnapshotMeta, rootDir, runDir string) error {
+// External volume entries are trusted only when the live record already references the same path (trustedExternal) — this both
+// blocks a foreign sidecar from naming arbitrary host files and refuses clones of volume-referencing snapshots (clones pass nil).
+func ValidateMetaPaths(meta *SnapshotMeta, rootDir, runDir string, trustedExternal map[string]struct{}) error {
 	for _, sc := range meta.StorageConfigs {
+		if sc.External {
+			if _, ok := trustedExternal[sc.Path]; !ok {
+				return fmt.Errorf("snapshot references external volume %q (%s) not present on the VM record", sc.Serial, sc.Path)
+			}
+			continue
+		}
 		if !IsUnderDir(sc.Path, rootDir) && !IsUnderDir(sc.Path, runDir) {
 			return fmt.Errorf("untrusted storage path in snapshot metadata: %s", sc.Path)
 		}

--- a/hypervisor/snapshot.go
+++ b/hypervisor/snapshot.go
@@ -30,11 +30,7 @@ type SnapshotMeta struct {
 // RecordSnapshot generates a snapshot ID and records it on the VM's record.
 func (b *Backend) RecordSnapshot(ctx context.Context, vmID string) (string, error) {
 	snapID := utils.GenerateID()
-	if err := b.DB.Update(ctx, func(idx *VMIndex) error {
-		r, err := idx.GetRecord(vmID)
-		if err != nil {
-			return err
-		}
+	if err := b.UpdateRecord(ctx, vmID, func(r *VMRecord) error {
 		if r.SnapshotIDs == nil {
 			r.SnapshotIDs = make(map[string]struct{})
 		}
@@ -48,11 +44,7 @@ func (b *Backend) RecordSnapshot(ctx context.Context, vmID string) (string, erro
 
 // UnrecordSnapshot drops a snapshot id from the VM's record (persist-failure rollback); best-effort, a leftover id is cosmetic.
 func (b *Backend) UnrecordSnapshot(ctx context.Context, vmID, snapID string) {
-	if err := b.DB.Update(ctx, func(idx *VMIndex) error {
-		r, err := idx.GetRecord(vmID)
-		if err != nil {
-			return err
-		}
+	if err := b.UpdateRecord(ctx, vmID, func(r *VMRecord) error {
 		delete(r.SnapshotIDs, snapID)
 		return nil
 	}); err != nil {

--- a/hypervisor/snapshot.go
+++ b/hypervisor/snapshot.go
@@ -175,14 +175,6 @@ func (b *Backend) prepareSnapshot(ctx context.Context, ref string) (string, VMRe
 	if vErr := types.ValidateStorageConfigs(rec.StorageConfigs); vErr != nil {
 		return fail(fmt.Errorf("storage invariants violated: %w", vErr))
 	}
-	// External volumes are runtime-only: snapshot/hibernate would freeze a
-	// mount the capture cannot own, so the decision is surfaced here, not
-	// deferred to clone/restore. Detach (and umount in-guest) first.
-	for _, sc := range rec.StorageConfigs {
-		if sc.External {
-			return fail(fmt.Errorf("detach external volume %q before snapshot or hibernate", sc.Serial))
-		}
-	}
 	tmpDir, err := os.MkdirTemp(b.Conf.VMRunDir(vmID), "snapshot-")
 	if err != nil {
 		return fail(fmt.Errorf("create temp dir: %w", err))

--- a/hypervisor/snapshot.go
+++ b/hypervisor/snapshot.go
@@ -175,6 +175,14 @@ func (b *Backend) prepareSnapshot(ctx context.Context, ref string) (string, VMRe
 	if vErr := types.ValidateStorageConfigs(rec.StorageConfigs); vErr != nil {
 		return fail(fmt.Errorf("storage invariants violated: %w", vErr))
 	}
+	// External volumes are runtime-only: snapshot/hibernate would freeze a
+	// mount the capture cannot own, so the decision is surfaced here, not
+	// deferred to clone/restore. Detach (and umount in-guest) first.
+	for _, sc := range rec.StorageConfigs {
+		if sc.External {
+			return fail(fmt.Errorf("detach external volume %q before snapshot or hibernate", sc.Serial))
+		}
+	}
 	tmpDir, err := os.MkdirTemp(b.Conf.VMRunDir(vmID), "snapshot-")
 	if err != nil {
 		return fail(fmt.Errorf("create temp dir: %w", err))
@@ -215,39 +223,15 @@ func LoadSnapshotMeta(dir string) (*SnapshotMeta, error) {
 	return &meta, nil
 }
 
-func LoadAndValidateMeta(dir, rootDir, runDir string, trustedExternal map[string]ExternalTrust) (*SnapshotMeta, error) {
+func LoadAndValidateMeta(dir, rootDir, runDir string) (*SnapshotMeta, error) {
 	meta, err := LoadSnapshotMeta(dir)
 	if err != nil {
 		return nil, err
 	}
-	if err := ValidateMetaPaths(meta, rootDir, runDir, trustedExternal); err != nil {
+	if err := ValidateMetaPaths(meta, rootDir, runDir); err != nil {
 		return nil, err
 	}
 	return meta, nil
-}
-
-// ExternalTrust is the identity a sidecar external entry must match exactly;
-// path membership alone would let a tampered sidecar flip RO or the guest
-// serial on a file the record legitimately references.
-type ExternalTrust struct {
-	Serial string
-	RO     bool
-}
-
-// ExternalTrustSet collects the record's external volumes — the trust anchor
-// for sidecar external entries (a foreign snapshot cannot name a host file
-// the live record does not already reference, nor alter its identity).
-func ExternalTrustSet(configs []*types.StorageConfig) map[string]ExternalTrust {
-	var set map[string]ExternalTrust
-	for _, sc := range configs {
-		if sc != nil && sc.External {
-			if set == nil {
-				set = make(map[string]ExternalTrust)
-			}
-			set[sc.Path] = ExternalTrust{Serial: sc.Serial, RO: sc.RO}
-		}
-	}
-	return set
 }
 
 // PopulateFromSrc cleans runDir of old snapshot files then copies fresh ones from srcDir (used by DirectRestore).
@@ -263,7 +247,7 @@ func PopulateFromSrc(runDir, srcDir string, clean func(string) error, clone func
 
 // PreflightRestore: load+validate sidecar, run backend-specific integrity, assert snapshot role sequence is a prefix of rec.
 func PreflightRestore(srcDir, rootDir, runDir string, rec *VMRecord, integrity func(srcDir string, sidecar []*types.StorageConfig) error) error {
-	meta, err := LoadAndValidateMeta(srcDir, rootDir, runDir, ExternalTrustSet(rec.StorageConfigs))
+	meta, err := LoadAndValidateMeta(srcDir, rootDir, runDir)
 	if err != nil {
 		return err
 	}
@@ -296,25 +280,9 @@ func IsUnderDir(path, dir string) bool {
 }
 
 // ValidateMetaPaths rejects sidecar paths escaping cocoon-managed roots; an imported snapshot's cocoon.json is otherwise untrusted.
-// External volume entries are trusted only when the live record already references the same path (trustedExternal) — this both
-// blocks a foreign sidecar from naming arbitrary host files and refuses clones of volume-referencing snapshots (clones pass nil).
-func ValidateMetaPaths(meta *SnapshotMeta, rootDir, runDir string, trustedExternal map[string]ExternalTrust) error {
+// External volumes never reach a snapshot (snapshot/hibernate refuse them), so every sidecar path must be under a managed root.
+func ValidateMetaPaths(meta *SnapshotMeta, rootDir, runDir string) error {
 	for _, sc := range meta.StorageConfigs {
-		if sc.External {
-			t, ok := trustedExternal[sc.Path]
-			if !ok {
-				return fmt.Errorf("snapshot references external volume %q (%s) not present on the VM record", sc.Serial, sc.Path)
-			}
-			if sc.Serial != t.Serial || sc.RO != t.RO {
-				return fmt.Errorf("snapshot external volume %q (%s) does not match the VM record's identity (serial/readonly)", sc.Serial, sc.Path)
-			}
-			// External paths inside cocoon-managed roots are contradictions:
-			// rm/GC may delete them with the run dir.
-			if IsUnderDir(sc.Path, rootDir) || IsUnderDir(sc.Path, runDir) {
-				return fmt.Errorf("external volume %q path %s is inside a cocoon-managed directory", sc.Serial, sc.Path)
-			}
-			continue
-		}
 		if !IsUnderDir(sc.Path, rootDir) && !IsUnderDir(sc.Path, runDir) {
 			return fmt.Errorf("untrusted storage path in snapshot metadata: %s", sc.Path)
 		}

--- a/hypervisor/snapshot_test.go
+++ b/hypervisor/snapshot_test.go
@@ -83,6 +83,13 @@ func TestValidateMetaPaths_RejectsInitrdEscape(t *testing.T) {
 	}
 }
 
+func TestValidateMetaPaths_RejectsNilStorage(t *testing.T) {
+	meta := &SnapshotMeta{StorageConfigs: []*types.StorageConfig{nil}}
+	if err := ValidateMetaPaths(meta, "/srv/cocoon", "/run/cocoon"); err == nil {
+		t.Fatal("nil storage config in an imported snapshot must be rejected, not panic")
+	}
+}
+
 func TestCloneStorageConfigs_DeepCopy(t *testing.T) {
 	src := []*types.StorageConfig{
 		{Path: "/a", Serial: "s1"},

--- a/hypervisor/snapshot_test.go
+++ b/hypervisor/snapshot_test.go
@@ -44,7 +44,7 @@ func TestValidateMetaPaths_Accepts(t *testing.T) {
 			InitrdPath: filepath.Join(rootDir, "oci/.../boot/initrd"),
 		},
 	}
-	if err := ValidateMetaPaths(meta, rootDir, runDir); err != nil {
+	if err := ValidateMetaPaths(meta, rootDir, runDir, nil); err != nil {
 		t.Fatalf("ValidateMetaPaths: %v", err)
 	}
 }
@@ -57,7 +57,7 @@ func TestValidateMetaPaths_RejectsTraversal(t *testing.T) {
 			{Path: "/etc/shadow"},
 		},
 	}
-	if err := ValidateMetaPaths(meta, rootDir, runDir); err == nil {
+	if err := ValidateMetaPaths(meta, rootDir, runDir, nil); err == nil {
 		t.Fatal("expected ValidateMetaPaths to reject /etc/shadow")
 	}
 }
@@ -66,7 +66,7 @@ func TestValidateMetaPaths_RejectsKernelEscape(t *testing.T) {
 	meta := &SnapshotMeta{
 		BootConfig: &types.BootConfig{KernelPath: "/usr/bin/sudo"},
 	}
-	if err := ValidateMetaPaths(meta, "/srv/cocoon", "/run/cocoon"); err == nil {
+	if err := ValidateMetaPaths(meta, "/srv/cocoon", "/run/cocoon", nil); err == nil {
 		t.Fatal("expected kernel path outside rootDir to be rejected")
 	}
 }
@@ -78,7 +78,7 @@ func TestValidateMetaPaths_RejectsInitrdEscape(t *testing.T) {
 			InitrdPath: "/etc/passwd",
 		},
 	}
-	if err := ValidateMetaPaths(meta, "/srv/cocoon", "/run/cocoon"); err == nil {
+	if err := ValidateMetaPaths(meta, "/srv/cocoon", "/run/cocoon", nil); err == nil {
 		t.Fatal("expected initrd path outside rootDir to be rejected")
 	}
 }
@@ -146,5 +146,18 @@ func TestReverseLayers_NoLayers(t *testing.T) {
 	got := ReverseLayers(configs, func(_ int, sc *types.StorageConfig) string { return sc.Serial })
 	if len(got) != 0 {
 		t.Errorf("got %d, want 0", len(got))
+	}
+}
+
+func TestValidateMetaPaths_External(t *testing.T) {
+	meta := &SnapshotMeta{StorageConfigs: []*types.StorageConfig{
+		{Path: "/vols/a.raw", Serial: "vola", Role: types.StorageRoleData, External: true},
+	}}
+	if err := ValidateMetaPaths(meta, "/srv/cocoon", "/run/cocoon", nil); err == nil {
+		t.Fatal("untrusted external should be refused")
+	}
+	trusted := map[string]struct{}{"/vols/a.raw": {}}
+	if err := ValidateMetaPaths(meta, "/srv/cocoon", "/run/cocoon", trusted); err != nil {
+		t.Fatalf("record-trusted external should pass: %v", err)
 	}
 }

--- a/hypervisor/snapshot_test.go
+++ b/hypervisor/snapshot_test.go
@@ -44,7 +44,7 @@ func TestValidateMetaPaths_Accepts(t *testing.T) {
 			InitrdPath: filepath.Join(rootDir, "oci/.../boot/initrd"),
 		},
 	}
-	if err := ValidateMetaPaths(meta, rootDir, runDir, nil); err != nil {
+	if err := ValidateMetaPaths(meta, rootDir, runDir); err != nil {
 		t.Fatalf("ValidateMetaPaths: %v", err)
 	}
 }
@@ -57,7 +57,7 @@ func TestValidateMetaPaths_RejectsTraversal(t *testing.T) {
 			{Path: "/etc/shadow"},
 		},
 	}
-	if err := ValidateMetaPaths(meta, rootDir, runDir, nil); err == nil {
+	if err := ValidateMetaPaths(meta, rootDir, runDir); err == nil {
 		t.Fatal("expected ValidateMetaPaths to reject /etc/shadow")
 	}
 }
@@ -66,7 +66,7 @@ func TestValidateMetaPaths_RejectsKernelEscape(t *testing.T) {
 	meta := &SnapshotMeta{
 		BootConfig: &types.BootConfig{KernelPath: "/usr/bin/sudo"},
 	}
-	if err := ValidateMetaPaths(meta, "/srv/cocoon", "/run/cocoon", nil); err == nil {
+	if err := ValidateMetaPaths(meta, "/srv/cocoon", "/run/cocoon"); err == nil {
 		t.Fatal("expected kernel path outside rootDir to be rejected")
 	}
 }
@@ -78,7 +78,7 @@ func TestValidateMetaPaths_RejectsInitrdEscape(t *testing.T) {
 			InitrdPath: "/etc/passwd",
 		},
 	}
-	if err := ValidateMetaPaths(meta, "/srv/cocoon", "/run/cocoon", nil); err == nil {
+	if err := ValidateMetaPaths(meta, "/srv/cocoon", "/run/cocoon"); err == nil {
 		t.Fatal("expected initrd path outside rootDir to be rejected")
 	}
 }
@@ -149,30 +149,14 @@ func TestReverseLayers_NoLayers(t *testing.T) {
 	}
 }
 
-func TestValidateMetaPaths_External(t *testing.T) {
+// External volumes never reach a snapshot (snapshot/hibernate refuse them);
+// a sidecar carrying one — its path outside the managed roots — is rejected
+// as an untrusted path, the same as any escape.
+func TestValidateMetaPaths_RejectsExternalPath(t *testing.T) {
 	meta := &SnapshotMeta{StorageConfigs: []*types.StorageConfig{
 		{Path: "/vols/a.raw", Serial: "vola", Role: types.StorageRoleData, External: true},
 	}}
-	if err := ValidateMetaPaths(meta, "/srv/cocoon", "/run/cocoon", nil); err == nil {
-		t.Fatal("untrusted external should be refused")
-	}
-	trusted := map[string]ExternalTrust{"/vols/a.raw": {Serial: "vola", RO: false}}
-	if err := ValidateMetaPaths(meta, "/srv/cocoon", "/run/cocoon", trusted); err != nil {
-		t.Fatalf("record-trusted external should pass: %v", err)
-	}
-	tamperedSerial := map[string]ExternalTrust{"/vols/a.raw": {Serial: "other", RO: false}}
-	if err := ValidateMetaPaths(meta, "/srv/cocoon", "/run/cocoon", tamperedSerial); err == nil {
-		t.Fatal("serial mismatch should be refused")
-	}
-	tamperedRO := map[string]ExternalTrust{"/vols/a.raw": {Serial: "vola", RO: true}}
-	if err := ValidateMetaPaths(meta, "/srv/cocoon", "/run/cocoon", tamperedRO); err == nil {
-		t.Fatal("readonly flip should be refused")
-	}
-	inRoot := &SnapshotMeta{StorageConfigs: []*types.StorageConfig{
-		{Path: "/srv/cocoon/run/vm1/x.raw", Serial: "volb", Role: types.StorageRoleData, External: true},
-	}}
-	inRootTrust := map[string]ExternalTrust{"/srv/cocoon/run/vm1/x.raw": {Serial: "volb"}}
-	if err := ValidateMetaPaths(inRoot, "/srv/cocoon", "/run/cocoon", inRootTrust); err == nil {
-		t.Fatal("external inside a managed root should be refused")
+	if err := ValidateMetaPaths(meta, "/srv/cocoon", "/run/cocoon"); err == nil {
+		t.Fatal("external path outside managed roots should be refused")
 	}
 }

--- a/hypervisor/snapshot_test.go
+++ b/hypervisor/snapshot_test.go
@@ -156,8 +156,23 @@ func TestValidateMetaPaths_External(t *testing.T) {
 	if err := ValidateMetaPaths(meta, "/srv/cocoon", "/run/cocoon", nil); err == nil {
 		t.Fatal("untrusted external should be refused")
 	}
-	trusted := map[string]struct{}{"/vols/a.raw": {}}
+	trusted := map[string]ExternalTrust{"/vols/a.raw": {Serial: "vola", RO: false}}
 	if err := ValidateMetaPaths(meta, "/srv/cocoon", "/run/cocoon", trusted); err != nil {
 		t.Fatalf("record-trusted external should pass: %v", err)
+	}
+	tamperedSerial := map[string]ExternalTrust{"/vols/a.raw": {Serial: "other", RO: false}}
+	if err := ValidateMetaPaths(meta, "/srv/cocoon", "/run/cocoon", tamperedSerial); err == nil {
+		t.Fatal("serial mismatch should be refused")
+	}
+	tamperedRO := map[string]ExternalTrust{"/vols/a.raw": {Serial: "vola", RO: true}}
+	if err := ValidateMetaPaths(meta, "/srv/cocoon", "/run/cocoon", tamperedRO); err == nil {
+		t.Fatal("readonly flip should be refused")
+	}
+	inRoot := &SnapshotMeta{StorageConfigs: []*types.StorageConfig{
+		{Path: "/srv/cocoon/run/vm1/x.raw", Serial: "volb", Role: types.StorageRoleData, External: true},
+	}}
+	inRootTrust := map[string]ExternalTrust{"/srv/cocoon/run/vm1/x.raw": {Serial: "volb"}}
+	if err := ValidateMetaPaths(inRoot, "/srv/cocoon", "/run/cocoon", inRootTrust); err == nil {
+		t.Fatal("external inside a managed root should be refused")
 	}
 }

--- a/hypervisor/snapshot_test.go
+++ b/hypervisor/snapshot_test.go
@@ -148,15 +148,3 @@ func TestReverseLayers_NoLayers(t *testing.T) {
 		t.Errorf("got %d, want 0", len(got))
 	}
 }
-
-// External volumes never reach a snapshot (snapshot/hibernate refuse them);
-// a sidecar carrying one — its path outside the managed roots — is rejected
-// as an untrusted path, the same as any escape.
-func TestValidateMetaPaths_RejectsExternalPath(t *testing.T) {
-	meta := &SnapshotMeta{StorageConfigs: []*types.StorageConfig{
-		{Path: "/vols/a.raw", Serial: "vola", Role: types.StorageRoleData, External: true},
-	}}
-	if err := ValidateMetaPaths(meta, "/srv/cocoon", "/run/cocoon"); err == nil {
-		t.Fatal("external path outside managed roots should be refused")
-	}
-}

--- a/hypervisor/start.go
+++ b/hypervisor/start.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"sync"
 
 	"github.com/projecteru2/core/log"
 
@@ -13,67 +12,55 @@ import (
 	"github.com/cocoonstack/cocoon/utils"
 )
 
-// StartAll runs startOne per ref; only launched=true ids reach BatchMarkStarted.
-func (b *Backend) StartAll(ctx context.Context, refs []string, startOne func(context.Context, string) (bool, error)) ([]string, error) {
+// StartAll runs startOne per ref; each start flips its own state under its VM's ops lock.
+func (b *Backend) StartAll(ctx context.Context, refs []string, startOne func(context.Context, string) error) ([]string, error) {
 	ids, err := b.ResolveRefs(ctx, refs)
 	if err != nil {
 		return nil, err
 	}
-	var (
-		mu       sync.Mutex
-		launched []string
-	)
-	wrapped := func(ctx context.Context, id string) error {
-		wasLaunched, sErr := startOne(ctx, id)
-		if sErr != nil {
-			return sErr
-		}
-		if wasLaunched {
-			mu.Lock()
-			launched = append(launched, id)
-			mu.Unlock()
-		}
-		return nil
-	}
-	succeeded, forEachErr := b.ForEachVM(ctx, ids, "Start", wrapped)
-	if batchErr := b.BatchMarkStarted(ctx, launched); batchErr != nil {
-		log.WithFunc(b.Typ+".Start").Warnf(ctx, "batch state update: %v", batchErr)
-	}
-	return succeeded, forEachErr
+	return b.ForEachVM(ctx, ids, "Start", startOne)
 }
 
-// StartSequence runs the shared start skeleton under the VM's ops lock (a concurrent rm --force must not delete the record/dirs mid-launch and orphan the VMM); returns whether a fresh process was launched.
-func (b *Backend) StartSequence(ctx context.Context, id string, spec StartSpec) (bool, error) {
+// StartSequence runs the shared start skeleton under the VM's ops lock: a concurrent rm --force must not delete the record/dirs mid-launch, and the Running flip lands before the lock is released so a stop queued behind this start can't be overwritten by a late state write.
+func (b *Backend) StartSequence(ctx context.Context, id string, spec StartSpec) error {
 	unlock, err := b.LockVMOps(ctx, id)
 	if err != nil {
-		return false, err
+		return err
 	}
 	defer unlock()
 	rec, err := b.PrepareStart(ctx, id, spec.RuntimeFiles)
 	if err != nil {
-		return false, err
+		return err
 	}
 	if rec == nil {
-		return false, nil
+		return nil
 	}
 	if vErr := types.ValidateStorageConfigs(rec.StorageConfigs); vErr != nil {
 		b.MarkError(ctx, id)
-		return false, fmt.Errorf("storage invariants violated: %w", vErr)
+		return fmt.Errorf("storage invariants violated: %w", vErr)
+	}
+	if vErr := types.ValidateNetworkConfigs(rec.NetworkConfigs); vErr != nil {
+		b.MarkError(ctx, id)
+		return fmt.Errorf("network invariants violated: %w", vErr)
 	}
 	sockPath := SocketPath(rec.RunDir)
 	pid, err := spec.Launch(ctx, rec, sockPath)
 	if err != nil {
 		b.MarkError(ctx, id)
-		return false, fmt.Errorf("launch VM: %w", err)
+		return fmt.Errorf("launch VM: %w", err)
 	}
 	if spec.PostLaunch != nil {
 		if err := spec.PostLaunch(ctx, rec, sockPath, pid); err != nil {
 			b.AbortLaunch(ctx, pid, sockPath, rec.RunDir, spec.RuntimeFiles)
 			b.MarkError(ctx, id)
-			return false, fmt.Errorf("configure VM: %w", err)
+			return fmt.Errorf("configure VM: %w", err)
 		}
 	}
-	return true, nil
+	// Warn-and-continue: the VMM is up and self-heals the record on the next reconcile.
+	if err := b.BatchMarkStarted(ctx, []string{id}); err != nil {
+		log.WithFunc(b.Typ+".StartSequence").Warnf(ctx, "mark started %s: %v", id, err)
+	}
+	return nil
 }
 
 // PrepareStart loads the record, verifies not-running, ensures dirs exist.

--- a/hypervisor/start.go
+++ b/hypervisor/start.go
@@ -42,8 +42,13 @@ func (b *Backend) StartAll(ctx context.Context, refs []string, startOne func(con
 	return succeeded, forEachErr
 }
 
-// StartSequence runs the shared start skeleton; returns whether a fresh process was launched.
+// StartSequence runs the shared start skeleton under the VM's ops lock (a concurrent rm --force must not delete the record/dirs mid-launch and orphan the VMM); returns whether a fresh process was launched.
 func (b *Backend) StartSequence(ctx context.Context, id string, spec StartSpec) (bool, error) {
+	unlock, err := b.LockVMOps(ctx, id)
+	if err != nil {
+		return false, err
+	}
+	defer unlock()
 	rec, err := b.PrepareStart(ctx, id, spec.RuntimeFiles)
 	if err != nil {
 		return false, err

--- a/hypervisor/start_test.go
+++ b/hypervisor/start_test.go
@@ -1,0 +1,76 @@
+package hypervisor
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cocoonstack/cocoon/types"
+)
+
+func TestStartSequenceFlipsRunningUnderLock(t *testing.T) {
+	b, rec := newMeteringTestBackend(t)
+	ctx := t.Context()
+	const id = "vm-start"
+	seedStoppedVMWithDirs(t, b, id)
+
+	err := b.StartSequence(ctx, id, StartSpec{
+		Launch: func(context.Context, *VMRecord, string) (int, error) { return 4242, nil },
+	})
+	if err != nil {
+		t.Fatalf("StartSequence: %v", err)
+	}
+	loaded, err := b.LoadRecord(ctx, id)
+	if err != nil {
+		t.Fatalf("LoadRecord: %v", err)
+	}
+	if loaded.State != types.VMStateRunning {
+		t.Errorf("state = %s, want running (flip must land inside the sequence)", loaded.State)
+	}
+	entries := rec.Entries()
+	if len(entries) != 1 || entries[0].VMID != id {
+		t.Fatalf("got %+v, want one compute.start for %s", entries, id)
+	}
+}
+
+func TestStartSequenceRejectsNilNIC(t *testing.T) {
+	b, _ := newMeteringTestBackend(t)
+	ctx := t.Context()
+	const id = "vm-nil-nic"
+	seedStoppedVMWithDirs(t, b, id)
+	if err := b.DB.Update(ctx, func(idx *VMIndex) error {
+		idx.VMs[id].NetworkConfigs = []*types.NetworkConfig{nil}
+		return nil
+	}); err != nil {
+		t.Fatalf("seed nil NIC: %v", err)
+	}
+
+	err := b.StartSequence(ctx, id, StartSpec{
+		Launch: func(context.Context, *VMRecord, string) (int, error) {
+			t.Fatal("Launch must not run with a nil NIC in the record")
+			return 0, nil
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "network invariants violated") {
+		t.Fatalf("err = %v, want network invariants violation", err)
+	}
+	loaded, _ := b.LoadRecord(ctx, id)
+	if loaded.State != types.VMStateError {
+		t.Errorf("state = %s, want error", loaded.State)
+	}
+}
+
+// seedStoppedVMWithDirs seeds a stopped record whose run/log dirs exist (PrepareStart requires them).
+func seedStoppedVMWithDirs(t *testing.T, b *Backend, id string) {
+	t.Helper()
+	seedVMRecord(t, b, id, 1, 1<<30, 10<<30, true)
+	dir := shortTempDir(t)
+	if err := b.DB.Update(t.Context(), func(idx *VMIndex) error {
+		idx.VMs[id].State = types.VMStateStopped
+		idx.VMs[id].RunDir = dir
+		idx.VMs[id].LogDir = dir
+		return nil
+	}); err != nil {
+		t.Fatalf("seed dirs: %v", err)
+	}
+}

--- a/hypervisor/state_test.go
+++ b/hypervisor/state_test.go
@@ -334,9 +334,9 @@ func TestDirectRestoreSequenceEmitsOnlyComputeStopOnPopulateFailure(t *testing.T
 func TestStartAllOnlyEmitsForActuallyLaunched(t *testing.T) {
 	// Three records distinguish the three cases that must end up correctly in
 	// the ledger:
-	//   - vm-stopped: DB Stopped, process dead → launched=true → emit
-	//   - vm-running: DB Running, process alive → launched=false → no emit
-	//   - vm-stale:   DB Running, process dead, relaunched → launched=true → emit
+	//   - vm-stopped: DB Stopped, process dead → launched → emit
+	//   - vm-running: DB Running, process alive → no launch → no emit
+	//   - vm-stale:   DB Running, process dead, relaunched → emit
 	// The bug being locked down: an earlier impl had BatchMarkStarted skip
 	// anything with r.State==Running, which silently dropped vm-stale.
 	b, rec := newMeteringTestBackend(t)
@@ -345,14 +345,15 @@ func TestStartAllOnlyEmitsForActuallyLaunched(t *testing.T) {
 	seedRunningVM(t, b, "vm-running", 1, 1<<30, 10<<30)
 	seedRunningVM(t, b, "vm-stale", 2, 2<<30, 20<<30)
 
-	startOne := func(_ context.Context, id string) (bool, error) {
+	// Mimics StartSequence's per-VM contract: only an actual launch flips state.
+	startOne := func(ctx context.Context, id string) error {
 		switch id {
 		case "vm-stopped", "vm-stale":
-			return true, nil
+			return b.BatchMarkStarted(ctx, []string{id})
 		case "vm-running":
-			return false, nil
+			return nil
 		}
-		return false, fmt.Errorf("unexpected id: %s", id)
+		return fmt.Errorf("unexpected id: %s", id)
 	}
 
 	succeeded, err := b.StartAll(ctx, []string{"vm-stopped", "vm-running", "vm-stale"}, startOne)

--- a/hypervisor/state_test.go
+++ b/hypervisor/state_test.go
@@ -563,6 +563,15 @@ func (stubBackendConfig) LogDir() string                      { panic("LogDir: n
 func (stubBackendConfig) VMRunDir(string) string              { panic("VMRunDir: not implemented in stub") }
 func (stubBackendConfig) VMLogDir(string) string              { panic("VMLogDir: not implemented in stub") }
 
+// meteringStubConfig gives the metering stub a real VMRunDir so sequences
+// can take the per-VM ops lock and MkdirTemp under it.
+type meteringStubConfig struct {
+	stubBackendConfig
+	vmRunRoot string
+}
+
+func (c meteringStubConfig) VMRunDir(string) string { return c.vmRunRoot }
+
 func newMeteringTestBackend(t *testing.T) (*Backend, *meteringcapture.Recorder) {
 	t.Helper()
 	dir := t.TempDir()
@@ -571,7 +580,7 @@ func newMeteringTestBackend(t *testing.T) (*Backend, *meteringcapture.Recorder) 
 	rec := meteringcapture.New()
 	return &Backend{
 		Typ:      "test-hv",
-		Conf:     stubBackendConfig{},
+		Conf:     meteringStubConfig{vmRunRoot: dir},
 		DB:       store,
 		Locker:   locker,
 		Metering: rec,

--- a/hypervisor/stop.go
+++ b/hypervisor/stop.go
@@ -35,6 +35,11 @@ func (b *Backend) GracefulStop(ctx context.Context, vmID string, pid int, timeou
 
 // StopOneSequence runs the shared per-id stop skeleton (LoadRecord → WithRunningVM(Shutdown) → HandleStopResult) so backends only express their force-vs-graceful choice.
 func (b *Backend) StopOneSequence(ctx context.Context, id string, spec StopSpec) error {
+	unlock, err := b.LockVMOps(ctx, id)
+	if err != nil {
+		return err
+	}
+	defer unlock()
 	rec, err := b.LoadRecord(ctx, id)
 	if err != nil {
 		return err

--- a/hypervisor/stop.go
+++ b/hypervisor/stop.go
@@ -43,7 +43,7 @@ func (b *Backend) StopOneSequence(ctx context.Context, id string, spec StopSpec)
 	return b.StopOneLocked(ctx, id, spec)
 }
 
-// StopOneLocked is StopOneSequence minus the lock; DeleteAll calls it with the VM's ops lock already held (re-locking would deadlock).
+// StopOneLocked is StopOneSequence minus the lock; DeleteAll calls it with the VM's ops lock already held (re-locking would deadlock). The Stopped flip lands inside the caller's lock so a start queued behind this stop can't interleave between the kill and the state write.
 func (b *Backend) StopOneLocked(ctx context.Context, id string, spec StopSpec) error {
 	rec, err := b.LoadRecord(ctx, id)
 	if err != nil {
@@ -53,20 +53,23 @@ func (b *Backend) StopOneLocked(ctx context.Context, id string, spec StopSpec) e
 	shutdownErr := b.WithRunningVM(ctx, &rec, func(pid int) error {
 		return spec.Shutdown(ctx, &rec, sockPath, pid)
 	})
-	return b.HandleStopResult(ctx, id, rec.RunDir, spec.RuntimeFiles, shutdownErr)
+	if err := b.HandleStopResult(ctx, id, rec.RunDir, spec.RuntimeFiles, shutdownErr); err != nil {
+		return err
+	}
+	// Warn-and-continue: the VMM is dead and the flip self-heals on the next reconcile.
+	if err := b.UpdateStates(ctx, []string{id}, types.VMStateStopped); err != nil {
+		log.WithFunc(b.Typ+".StopOneLocked").Warnf(ctx, "mark stopped %s: %v", id, err)
+	}
+	return nil
 }
 
-// StopAll mirrors StartAll: stopOne per ref, batch-flip succeeded to Stopped.
+// StopAll mirrors StartAll: stopOne per ref, each flipping its own state under its VM's ops lock.
 func (b *Backend) StopAll(ctx context.Context, refs []string, stopOne func(context.Context, string) error) ([]string, error) {
 	ids, err := b.ResolveRefs(ctx, refs)
 	if err != nil {
 		return nil, err
 	}
-	succeeded, forEachErr := b.ForEachVM(ctx, ids, "Stop", stopOne)
-	if batchErr := b.UpdateStates(ctx, succeeded, types.VMStateStopped); batchErr != nil {
-		log.WithFunc(b.Typ+".Stop").Warnf(ctx, "batch state update: %v", batchErr)
-	}
-	return succeeded, forEachErr
+	return b.ForEachVM(ctx, ids, "Stop", stopOne)
 }
 
 // DeleteAll removes VMs by ref; each VM's stop+probe+delete runs under its ops lock (#103), so stopLocked must not re-take it.

--- a/hypervisor/stop.go
+++ b/hypervisor/stop.go
@@ -33,13 +33,18 @@ func (b *Backend) GracefulStop(ctx context.Context, vmID string, pid int, timeou
 	return escalate()
 }
 
-// StopOneSequence runs the shared per-id stop skeleton (LoadRecord → WithRunningVM(Shutdown) → HandleStopResult) so backends only express their force-vs-graceful choice.
+// StopOneSequence runs the shared per-id stop skeleton (LoadRecord → WithRunningVM(Shutdown) → HandleStopResult) under the VM's ops lock so backends only express their force-vs-graceful choice.
 func (b *Backend) StopOneSequence(ctx context.Context, id string, spec StopSpec) error {
 	unlock, err := b.LockVMOps(ctx, id)
 	if err != nil {
 		return err
 	}
 	defer unlock()
+	return b.StopOneLocked(ctx, id, spec)
+}
+
+// StopOneLocked is StopOneSequence minus the lock; DeleteAll calls it with the VM's ops lock already held (re-locking would deadlock).
+func (b *Backend) StopOneLocked(ctx context.Context, id string, spec StopSpec) error {
 	rec, err := b.LoadRecord(ctx, id)
 	if err != nil {
 		return err
@@ -64,8 +69,8 @@ func (b *Backend) StopAll(ctx context.Context, refs []string, stopOne func(conte
 	return succeeded, forEachErr
 }
 
-// DeleteAll removes VMs by ref; dir cleanup before DB delete keeps a failed cleanup retry-able.
-func (b *Backend) DeleteAll(ctx context.Context, refs []string, force bool, stopOne func(context.Context, string) error) ([]string, error) {
+// DeleteAll removes VMs by ref; each VM's stop+probe+delete runs under its ops lock (#103), so stopLocked must not re-take it.
+func (b *Backend) DeleteAll(ctx context.Context, refs []string, force bool, stopLocked func(context.Context, string) error) ([]string, error) {
 	ids, err := b.ResolveRefs(ctx, refs)
 	if err != nil {
 		return nil, err
@@ -76,6 +81,11 @@ func (b *Backend) DeleteAll(ctx context.Context, refs []string, force bool, stop
 		return nil, fmt.Errorf("refuse delete: /proc scan errored: %w (resolve the host issue and retry)", scanErr)
 	}
 	return b.ForEachVM(ctx, ids, "Delete", func(ctx context.Context, id string) error {
+		unlock, lockErr := b.LockVMOps(ctx, id)
+		if lockErr != nil {
+			return lockErr
+		}
+		defer unlock()
 		rec, loadErr := b.LoadRecord(ctx, id)
 		if loadErr != nil {
 			return loadErr
@@ -87,7 +97,7 @@ func (b *Backend) DeleteAll(ctx context.Context, refs []string, force bool, stop
 				return fmt.Errorf("running (force required)")
 			}
 			stoppedByUs = true
-			return stopOne(ctx, id)
+			return stopLocked(ctx, id)
 		}); runningErr != nil && !errors.Is(runningErr, ErrNotRunning) {
 			return fmt.Errorf("stop before delete: %w", runningErr)
 		}
@@ -102,7 +112,7 @@ func (b *Backend) DeleteAll(ctx context.Context, refs []string, force bool, stop
 			return fmt.Errorf("refuse delete: api socket %s still responsive (suspected orphan vmm; kill the vmm process then retry)", sockPath)
 		}
 		for _, pid := range procScan.Find(sockPath) {
-			// procScan is a pre-stopOne snapshot: a just-force-stopped VM is already gone.
+			// procScan is a pre-stop snapshot: a just-force-stopped VM is already gone.
 			// Only a still-live match is a real orphan worth killing and logging.
 			if !utils.IsProcessAlive(pid) {
 				continue
@@ -112,14 +122,15 @@ func (b *Backend) DeleteAll(ctx context.Context, refs []string, force bool, stop
 			}
 			log.WithFunc(b.Typ+".Delete").Warnf(ctx, "killed orphan VMM pid=%d for VM %s", pid, id)
 		}
-		if rmErr := RemoveVMDirs(rec.RunDir, rec.LogDir); rmErr != nil {
-			return fmt.Errorf("cleanup VM dirs: %w", rmErr)
-		}
 		var (
 			shape              metering.Shape
 			hadRunningInterval bool
 		)
-		// Capture in the same transaction as delete so a concurrent UpdateStates can't shift the truth.
+		// Record goes first: dir removal deletes the ops.lock file, and a later
+		// locker on the recreated file is a fresh inode that does not contend —
+		// with the record already gone its resolve fails instead of reviving the
+		// VM. Capture in the same transaction so a concurrent UpdateStates can't
+		// shift the truth; a failed dir removal below leaves orphans for GC.
 		if err := b.DB.Update(ctx, func(idx *VMIndex) error {
 			r := idx.VMs[id]
 			if r == nil {
@@ -138,6 +149,9 @@ func (b *Backend) DeleteAll(ctx context.Context, refs []string, force bool, stop
 			computeReason = metering.ReasonStopUser
 		}
 		b.emitDeleteClose(ctx, id, shape, computeReason, hadRunningInterval)
+		if rmErr := RemoveVMDirs(rec.RunDir, rec.LogDir); rmErr != nil {
+			return fmt.Errorf("cleanup VM dirs: %w", rmErr)
+		}
 		return nil
 	})
 }

--- a/hypervisor/stop_test.go
+++ b/hypervisor/stop_test.go
@@ -1,0 +1,126 @@
+package hypervisor
+
+import (
+	"context"
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cocoonstack/cocoon/metering"
+	"github.com/cocoonstack/cocoon/types"
+	"github.com/cocoonstack/cocoon/utils"
+)
+
+func TestDeleteAllStoppedVM(t *testing.T) {
+	b, rec := newMeteringTestBackend(t)
+	ctx := t.Context()
+	const id = "vm-del"
+	seedVMRecord(t, b, id, 2, 1<<30, 10<<30, true)
+	runDir, logDir := shortTempDir(t), shortTempDir(t)
+	if err := b.DB.Update(ctx, func(idx *VMIndex) error {
+		idx.VMs[id].State = types.VMStateStopped
+		idx.VMs[id].RunDir = runDir
+		idx.VMs[id].LogDir = logDir
+		return nil
+	}); err != nil {
+		t.Fatalf("seed dirs: %v", err)
+	}
+
+	deleted, err := b.DeleteAll(ctx, []string{id}, false, func(context.Context, string) error {
+		t.Fatal("stopLocked must not run for a stopped VM")
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("DeleteAll: %v", err)
+	}
+	if len(deleted) != 1 || deleted[0] != id {
+		t.Fatalf("deleted = %v, want [%s]", deleted, id)
+	}
+	if _, err := b.LoadRecord(ctx, id); err == nil {
+		t.Error("record should be gone after delete")
+	}
+	for _, dir := range []string{runDir, logDir} {
+		if _, statErr := os.Stat(dir); !os.IsNotExist(statErr) {
+			t.Errorf("dir %s should be removed, stat err: %v", dir, statErr)
+		}
+	}
+	entries := rec.Entries()
+	if len(entries) != 1 || entries[0].Kind != metering.KindVMStorageStop {
+		t.Fatalf("got %+v, want one storage.stop (no open compute interval)", entries)
+	}
+}
+
+// TestDeleteAllForceStopsUnderLock drives the full force path against a live
+// stub VMM: the delete body holds the ops lock while stopLocked runs, so this
+// deadlocks (and times out) if the stop variant re-takes the lock.
+func TestDeleteAllForceStopsUnderLock(t *testing.T) {
+	b, id := newHibernateTestVM(t)
+	ctx := t.Context()
+
+	if _, err := b.DeleteAll(ctx, []string{id}, false, func(context.Context, string) error { return nil }); err == nil ||
+		!strings.Contains(err.Error(), "running (force required)") {
+		t.Fatalf("DeleteAll without force: %v, want running-requires-force error", err)
+	}
+
+	stopLocked := func(ctx context.Context, id string) error {
+		return b.StopOneLocked(ctx, id, StopSpec{
+			RuntimeFiles: []string{APISocketName},
+			Shutdown: func(ctx context.Context, rec *VMRecord, sockPath string, pid int) error {
+				return utils.TerminateProcess(ctx, pid, b.Conf.BinaryName(), sockPath, time.Second)
+			},
+		})
+	}
+	deleted, err := b.DeleteAll(ctx, []string{id}, true, stopLocked)
+	if err != nil {
+		t.Fatalf("DeleteAll --force: %v", err)
+	}
+	if len(deleted) != 1 || deleted[0] != id {
+		t.Fatalf("deleted = %v, want [%s]", deleted, id)
+	}
+	if _, err := b.LoadRecord(ctx, id); err == nil {
+		t.Error("record should be gone after force delete")
+	}
+}
+
+func TestDeleteAllRefusesLiveAPISocket(t *testing.T) {
+	b, _ := newMeteringTestBackend(t)
+	ctx := t.Context()
+	const id = "vm-live-sock"
+	seedVMRecord(t, b, id, 1, 1<<30, 10<<30, true)
+	runDir := shortTempDir(t)
+	if err := b.DB.Update(ctx, func(idx *VMIndex) error {
+		idx.VMs[id].State = types.VMStateStopped
+		idx.VMs[id].RunDir = runDir
+		idx.VMs[id].LogDir = runDir
+		return nil
+	}); err != nil {
+		t.Fatalf("seed dirs: %v", err)
+	}
+	ln, err := net.Listen("unix", SocketPath(runDir))
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close() //nolint:errcheck
+
+	_, err = b.DeleteAll(ctx, []string{id}, true, func(context.Context, string) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "still responsive") {
+		t.Fatalf("DeleteAll: %v, want live-socket refusal", err)
+	}
+	if _, loadErr := b.LoadRecord(ctx, id); loadErr != nil {
+		t.Error("record must survive a refused delete")
+	}
+}
+
+// shortTempDir is a /tmp-based TempDir: unix socket paths built under
+// t.TempDir() can exceed the ~104-byte sockaddr cap (EINVAL on dial).
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "cocoon-test-")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}

--- a/hypervisor/utils.go
+++ b/hypervisor/utils.go
@@ -27,9 +27,6 @@ import (
 type SnapshotFileKind int
 
 const (
-	// OpsLockName is the per-VM cross-process mutation lock file (in the VM run dir).
-	OpsLockName = "ops.lock"
-
 	// SnapshotFileMemory is a read-only memory/state file (hard link or symlink).
 	SnapshotFileMemory SnapshotFileKind = iota
 	// SnapshotFileCOW is a writable disk that must be copied (reflink/sparse).
@@ -38,6 +35,9 @@ const (
 	SnapshotFileMeta
 	// SnapshotFileSkip means the file should not be cloned.
 	SnapshotFileSkip
+
+	// OpsLockName is the per-VM cross-process mutation lock file (in the VM run dir).
+	OpsLockName = "ops.lock"
 
 	// MinDataDiskSize is the minimum user data disk size; mkfs.ext4 is unstable below this on small sparse files.
 	MinDataDiskSize int64 = 16 << 20
@@ -51,8 +51,7 @@ const (
 // The flock dies with the process, so a crashed holder never wedges the VM.
 func (b *Backend) LockVMOps(ctx context.Context, vmID string) (func(), error) {
 	runDir := b.Conf.VMRunDir(vmID)
-	// The dir can be gone on crash-leftover cleanup paths; the lock must not
-	// block the cleanup that would remove it.
+	// Recreate if missing so stop/delete on a crash-leftover VM can still lock.
 	if err := os.MkdirAll(runDir, 0o750); err != nil {
 		return nil, fmt.Errorf("ops lock dir: %w", err)
 	}

--- a/hypervisor/utils.go
+++ b/hypervisor/utils.go
@@ -265,7 +265,7 @@ func IsDataDiskFile(name string) bool {
 // ReflinkDataDisks reflinks every Role==Data disk into dstDir under data-<serial>.raw (CH+FC use it inside the snapshot pause window).
 func ReflinkDataDisks(dstDir string, configs []*types.StorageConfig) error {
 	for _, sc := range configs {
-		if sc.Role != types.StorageRoleData || sc.External {
+		if sc.Role != types.StorageRoleData {
 			continue
 		}
 		dst := filepath.Join(dstDir, DataDiskBaseName(sc.Serial))
@@ -343,14 +343,6 @@ func ValidateSnapshotIntegrity(srcDir string, sidecar []*types.StorageConfig) er
 		return fmt.Errorf("sidecar invalid: %w", err)
 	}
 	for _, sc := range sidecar {
-		if sc.External {
-			// The backing file is reference-only: never captured, must still
-			// exist at its absolute path for the restore to resume onto it.
-			if _, err := os.Stat(sc.Path); err != nil {
-				return fmt.Errorf("external volume %s missing: %w", sc.Serial, err)
-			}
-			continue
-		}
 		fname := snapshotResidentBasename(sc)
 		if fname == "" {
 			continue
@@ -544,9 +536,6 @@ func createSparseFile(path string, size int64) error {
 func snapshotResidentBasename(sc *types.StorageConfig) string {
 	switch sc.Role {
 	case types.StorageRoleData:
-		if sc.External {
-			return ""
-		}
 		return DataDiskBaseName(sc.Serial)
 	case types.StorageRoleCOW, types.StorageRoleCidata:
 		return filepath.Base(sc.Path)

--- a/hypervisor/utils.go
+++ b/hypervisor/utils.go
@@ -359,7 +359,7 @@ func ValidateSnapshotIntegrity(srcDir string, sidecar []*types.StorageConfig) er
 	return nil
 }
 
-// ValidateRoleSequence checks sidecar is a role-by-role prefix of rec; rec may carry trailing cidata (cloudimg post-first-boot) — the only allowed extension.
+// ValidateRoleSequence checks sidecar is a role+serial prefix of rec (an imported sidecar is untrusted — a swapped serial must not survive preflight); rec may carry trailing cidata (cloudimg post-first-boot) — the only allowed extension.
 func ValidateRoleSequence(sidecar, rec []*types.StorageConfig) error {
 	if len(sidecar) > len(rec) {
 		return fmt.Errorf("snapshot has %d disks, record only %d", len(sidecar), len(rec))
@@ -367,6 +367,9 @@ func ValidateRoleSequence(sidecar, rec []*types.StorageConfig) error {
 	for i, sc := range sidecar {
 		if rec[i].Role != sc.Role {
 			return fmt.Errorf("disk[%d] role mismatch: snapshot=%s record=%s", i, sc.Role, rec[i].Role)
+		}
+		if rec[i].Serial != sc.Serial {
+			return fmt.Errorf("disk[%d] serial mismatch: snapshot=%q record=%q", i, sc.Serial, rec[i].Serial)
 		}
 	}
 	for i := len(sidecar); i < len(rec); i++ {

--- a/hypervisor/utils.go
+++ b/hypervisor/utils.go
@@ -18,6 +18,7 @@ import (
 	"github.com/projecteru2/core/log"
 	"github.com/vishvananda/netns"
 
+	"github.com/cocoonstack/cocoon/lock/flock"
 	"github.com/cocoonstack/cocoon/types"
 	"github.com/cocoonstack/cocoon/utils"
 )
@@ -26,6 +27,9 @@ import (
 type SnapshotFileKind int
 
 const (
+	// OpsLockName is the per-VM cross-process mutation lock file (in the VM run dir).
+	OpsLockName = "ops.lock"
+
 	// SnapshotFileMemory is a read-only memory/state file (hard link or symlink).
 	SnapshotFileMemory SnapshotFileKind = iota
 	// SnapshotFileCOW is a writable disk that must be copied (reflink/sparse).
@@ -41,6 +45,23 @@ const (
 	// socketReadyPollInterval is the WaitForSocket poll cadence — VMM socket usually appears within a few ms after process start.
 	socketReadyPollInterval = 1 * time.Millisecond
 )
+
+// LockVMOps serializes mutating verbs on one VM across processes (#103):
+// device attach/detach, net resize, snapshot, hibernate, restore, stop.
+// The flock dies with the process, so a crashed holder never wedges the VM.
+func (b *Backend) LockVMOps(ctx context.Context, vmID string) (func(), error) {
+	runDir := b.Conf.VMRunDir(vmID)
+	// The dir can be gone on crash-leftover cleanup paths; the lock must not
+	// block the cleanup that would remove it.
+	if err := os.MkdirAll(runDir, 0o750); err != nil {
+		return nil, fmt.Errorf("ops lock dir: %w", err)
+	}
+	l := flock.New(filepath.Join(runDir, OpsLockName))
+	if err := l.Lock(ctx); err != nil {
+		return nil, err
+	}
+	return func() { _ = l.Unlock(ctx) }, nil
+}
 
 func (b *Backend) PIDFilePath(runDir string) string {
 	return filepath.Join(runDir, b.Conf.PIDFileName())
@@ -245,7 +266,7 @@ func IsDataDiskFile(name string) bool {
 // ReflinkDataDisks reflinks every Role==Data disk into dstDir under data-<serial>.raw (CH+FC use it inside the snapshot pause window).
 func ReflinkDataDisks(dstDir string, configs []*types.StorageConfig) error {
 	for _, sc := range configs {
-		if sc.Role != types.StorageRoleData {
+		if sc.Role != types.StorageRoleData || sc.External {
 			continue
 		}
 		dst := filepath.Join(dstDir, DataDiskBaseName(sc.Serial))
@@ -323,6 +344,14 @@ func ValidateSnapshotIntegrity(srcDir string, sidecar []*types.StorageConfig) er
 		return fmt.Errorf("sidecar invalid: %w", err)
 	}
 	for _, sc := range sidecar {
+		if sc.External {
+			// The backing file is reference-only: never captured, must still
+			// exist at its absolute path for the restore to resume onto it.
+			if _, err := os.Stat(sc.Path); err != nil {
+				return fmt.Errorf("external volume %s missing: %w", sc.Serial, err)
+			}
+			continue
+		}
 		fname := snapshotResidentBasename(sc)
 		if fname == "" {
 			continue
@@ -516,6 +545,9 @@ func createSparseFile(path string, size int64) error {
 func snapshotResidentBasename(sc *types.StorageConfig) string {
 	switch sc.Role {
 	case types.StorageRoleData:
+		if sc.External {
+			return ""
+		}
 		return DataDiskBaseName(sc.Serial)
 	case types.StorageRoleCOW, types.StorageRoleCidata:
 		return filepath.Base(sc.Path)

--- a/hypervisor/utils.go
+++ b/hypervisor/utils.go
@@ -108,6 +108,11 @@ func BalloonSize(memoryBytes int64, windows bool) (int64, bool) {
 	return memoryBytes / DefaultBalloonDiv, true
 }
 
+// IsDirectBoot reports whether boot uses a direct kernel (OCI) rather than UEFI firmware (cloudimg).
+func IsDirectBoot(boot *types.BootConfig) bool {
+	return boot != nil && boot.KernelPath != ""
+}
+
 func RemoveVMDirs(runDir, logDir string) error {
 	return errors.Join(
 		os.RemoveAll(runDir),

--- a/hypervisor/utils_test.go
+++ b/hypervisor/utils_test.go
@@ -127,6 +127,16 @@ func TestValidateRoleSequence(t *testing.T) {
 			wantErr: "role mismatch",
 		},
 		{
+			name: "serial mismatch at index (tampered sidecar)",
+			sidecar: []*types.StorageConfig{
+				{Role: types.StorageRoleData, Serial: "evil"},
+			},
+			rec: []*types.StorageConfig{
+				{Role: types.StorageRoleData, Serial: "data1"},
+			},
+			wantErr: "serial mismatch",
+		},
+		{
 			name:    "rec extension is not cidata",
 			sidecar: []*types.StorageConfig{{Role: types.StorageRoleCOW}},
 			rec: []*types.StorageConfig{

--- a/images/cloudimg/image.go
+++ b/images/cloudimg/image.go
@@ -10,17 +10,9 @@ type imageIndex struct {
 	images.Index[imageEntry]
 }
 
-// Lookup finds an entry by URL or content digest.
+// Lookup finds an entry by URL or content digest (exact or prefix).
 func (idx *imageIndex) Lookup(id string) (string, *imageEntry, bool) {
-	if entry, ok := idx.Images[id]; ok && entry != nil {
-		return id, entry, true
-	}
-	for ref, entry := range idx.Images {
-		if entry != nil && (entry.ContentSum.String() == id || entry.ContentSum.Hex() == id) {
-			return ref, entry, true
-		}
-	}
-	return "", nil, false
+	return images.LookupOne(idx.Images, id)
 }
 
 func (idx *imageIndex) LookupRefs(id string) []string {

--- a/images/cloudimg/import.go
+++ b/images/cloudimg/import.go
@@ -55,13 +55,11 @@ func importQcow2File(ctx context.Context, conf *Config, store storage.Store[imag
 		return fmt.Errorf("seek %s: %w", filePath, err)
 	}
 
-	tmpFile, err := os.CreateTemp(conf.TempDir(), "import-*.img")
+	tmpFile, tmpPath, cleanup, err := newTempImage(conf, "import-*.img")
 	if err != nil {
-		return fmt.Errorf("create temp file: %w", err)
+		return err
 	}
-	tmpPath := tmpFile.Name()
-	defer os.Remove(tmpPath) //nolint:errcheck,gosec
-	defer tmpFile.Close()    //nolint:errcheck,gosec
+	defer cleanup()
 
 	// Rehash the copy pass so in-place source changes fail closed.
 	verifyHash := sha256.New()
@@ -93,13 +91,11 @@ func importQcow2Reader(ctx context.Context, conf *Config, store storage.Store[im
 		return fmt.Errorf("import %s: %w", name, sniffErr)
 	}
 
-	tmpFile, err := os.CreateTemp(conf.TempDir(), "import-*.img")
+	tmpFile, tmpPath, cleanup, err := newTempImage(conf, "import-*.img")
 	if err != nil {
-		return fmt.Errorf("create temp file: %w", err)
+		return err
 	}
-	tmpPath := tmpFile.Name()
-	defer os.Remove(tmpPath) //nolint:errcheck,gosec
-	defer tmpFile.Close()    //nolint:errcheck,gosec
+	defer cleanup()
 
 	h := sha256.New()
 	if _, err := io.Copy(io.MultiWriter(tmpFile, h), full); err != nil {
@@ -129,13 +125,11 @@ func importQcow2Concat(ctx context.Context, conf *Config, store storage.Store[im
 
 	tracker.OnEvent(cloudimgProgress.Event{Phase: cloudimgProgress.PhaseDownload})
 
-	tmpFile, err := os.CreateTemp(conf.TempDir(), "import-*.img")
+	tmpFile, tmpPath, cleanup, err := newTempImage(conf, "import-*.img")
 	if err != nil {
-		return fmt.Errorf("create temp file: %w", err)
+		return err
 	}
-	tmpPath := tmpFile.Name()
-	defer os.Remove(tmpPath) //nolint:errcheck,gosec
-	defer tmpFile.Close()    //nolint:errcheck,gosec
+	defer cleanup()
 
 	h := sha256.New()
 	w := io.MultiWriter(tmpFile, h)

--- a/images/cloudimg/pull.go
+++ b/images/cloudimg/pull.go
@@ -124,13 +124,11 @@ func withDownload(
 	tracker progress.Tracker,
 	fn func(f *os.File, tmpPath, digestHex string) error,
 ) error {
-	tmpFile, err := os.CreateTemp(conf.TempDir(), "pull-*.img")
+	tmpFile, tmpPath, cleanup, err := newTempImage(conf, "pull-*.img")
 	if err != nil {
-		return fmt.Errorf("create temp file: %w", err)
+		return err
 	}
-	tmpPath := tmpFile.Name()
-	defer os.Remove(tmpPath) //nolint:errcheck,gosec
-	defer tmpFile.Close()    //nolint:errcheck,gosec
+	defer cleanup()
 
 	digestHex, err := downloadToFile(ctx, url, tmpFile, tracker, conf.PullConns)
 	if err != nil {

--- a/images/cloudimg/pull_test.go
+++ b/images/cloudimg/pull_test.go
@@ -98,95 +98,6 @@ func TestDownloadToFileEmitsFinalProgressEvent(t *testing.T) {
 	}
 }
 
-// rangeHandler serves data with full HTTP Range support; fail, if non-nil, lets a test force a
-// specific requested range to error out (simulating a mid-download server failure).
-func rangeHandler(data []byte, fail func(start, end int64) bool) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		rangeHeader := r.Header.Get("Range")
-		if rangeHeader == "" {
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write(data)
-			return
-		}
-
-		start, end, ok := parseTestRange(rangeHeader, int64(len(data)))
-		if !ok {
-			http.Error(w, "bad range", http.StatusRequestedRangeNotSatisfiable)
-			return
-		}
-		if fail != nil && fail(start, end) {
-			http.Error(w, "injected failure", http.StatusInternalServerError)
-			return
-		}
-
-		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(data)))
-		w.WriteHeader(http.StatusPartialContent)
-		_, _ = w.Write(data[start : end+1])
-	})
-}
-
-func parseTestRange(h string, size int64) (start, end int64, ok bool) {
-	h = strings.TrimPrefix(h, "bytes=")
-	parts := strings.SplitN(h, "-", 2)
-	if len(parts) != 2 {
-		return 0, 0, false
-	}
-	start, err := strconv.ParseInt(parts[0], 10, 64)
-	if err != nil {
-		return 0, 0, false
-	}
-	end, err = strconv.ParseInt(parts[1], 10, 64)
-	if err != nil {
-		return 0, 0, false
-	}
-	if end >= size {
-		end = size - 1
-	}
-	return start, end, true
-}
-
-func testPayload(size int) []byte {
-	data := make([]byte, size)
-	for i := range data {
-		data[i] = byte(i % 251)
-	}
-	return data
-}
-
-func sha256Hex(data []byte) string {
-	sum := sha256.Sum256(data)
-	return hex.EncodeToString(sum[:])
-}
-
-func createTempFile(t *testing.T) *os.File {
-	t.Helper()
-	f, err := os.CreateTemp(t.TempDir(), "dst-*.img")
-	if err != nil {
-		t.Fatalf("CreateTemp(): %v", err)
-	}
-	t.Cleanup(func() { _ = f.Close() })
-	return f
-}
-
-func assertFileContent(t *testing.T, f *os.File, want []byte) {
-	t.Helper()
-	if _, err := f.Seek(0, io.SeekStart); err != nil {
-		t.Fatalf("Seek(): %v", err)
-	}
-	got, err := io.ReadAll(f)
-	if err != nil {
-		t.Fatalf("ReadAll(): %v", err)
-	}
-	if len(got) != len(want) {
-		t.Fatalf("file size = %d, want %d", len(got), len(want))
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("file content mismatch at byte %d: got %d, want %d", i, got[i], want[i])
-		}
-	}
-}
-
 func TestDownloadToFileUnevenLastRange(t *testing.T) {
 	data := testPayload(257*1024 + 7) // not divisible by 4: exercises the short final range
 	server := httptest.NewServer(rangeHandler(data, nil))
@@ -279,5 +190,94 @@ func TestDownloadToFileMismatchedContentRangeFails(t *testing.T) {
 	dst := createTempFile(t)
 	if _, err := downloadToFile(t.Context(), server.URL, dst, progress.Nop, 4); err == nil {
 		t.Fatal("expected error for mismatched content-range, got nil")
+	}
+}
+
+// rangeHandler serves data with full HTTP Range support; fail, if non-nil, lets a test force a
+// specific requested range to error out (simulating a mid-download server failure).
+func rangeHandler(data []byte, fail func(start, end int64) bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rangeHeader := r.Header.Get("Range")
+		if rangeHeader == "" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(data)
+			return
+		}
+
+		start, end, ok := parseTestRange(rangeHeader, int64(len(data)))
+		if !ok {
+			http.Error(w, "bad range", http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
+		if fail != nil && fail(start, end) {
+			http.Error(w, "injected failure", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(data)))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(data[start : end+1])
+	})
+}
+
+func parseTestRange(h string, size int64) (start, end int64, ok bool) {
+	h = strings.TrimPrefix(h, "bytes=")
+	parts := strings.SplitN(h, "-", 2)
+	if len(parts) != 2 {
+		return 0, 0, false
+	}
+	start, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	end, err = strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	if end >= size {
+		end = size - 1
+	}
+	return start, end, true
+}
+
+func testPayload(size int) []byte {
+	data := make([]byte, size)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+	return data
+}
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func createTempFile(t *testing.T) *os.File {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "dst-*.img")
+	if err != nil {
+		t.Fatalf("CreateTemp(): %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	return f
+}
+
+func assertFileContent(t *testing.T, f *os.File, want []byte) {
+	t.Helper()
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		t.Fatalf("Seek(): %v", err)
+	}
+	got, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatalf("ReadAll(): %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("file size = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("file content mismatch at byte %d: got %d, want %d", i, got[i], want[i])
+		}
 	}
 }

--- a/images/cloudimg/utils.go
+++ b/images/cloudimg/utils.go
@@ -1,0 +1,19 @@
+package cloudimg
+
+import (
+	"fmt"
+	"os"
+)
+
+// newTempImage creates a temp image file under conf.TempDir(); cleanup closes and removes it.
+func newTempImage(conf *Config, pattern string) (f *os.File, path string, cleanup func(), err error) {
+	f, err = os.CreateTemp(conf.TempDir(), pattern)
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("create temp file: %w", err)
+	}
+	cleanup = func() {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+	}
+	return f, f.Name(), cleanup, nil
+}

--- a/images/index.go
+++ b/images/index.go
@@ -48,6 +48,16 @@ func ReferencedDigests[E Entry](images map[string]*E) map[string]struct{} {
 	return refs
 }
 
+// LookupOne resolves id to a single entry via LookupRefs' rules, so backend Config
+// and the shared Inspect share one notion of "found" (including digest prefixes).
+func LookupOne[E Entry](images map[string]*E, id string, normalizers ...func(string) (string, bool)) (string, *E, bool) {
+	refs := LookupRefs(images, id, normalizers...)
+	if len(refs) == 0 {
+		return "", nil, false
+	}
+	return refs[0], images[refs[0]], true
+}
+
 // LookupRefs returns all ref keys matching id by exact key, normalizer, or digest prefix.
 func LookupRefs[E Entry](images map[string]*E, id string, normalizers ...func(string) (string, bool)) []string {
 	if entry, ok := images[id]; ok && entry != nil {

--- a/images/index.go
+++ b/images/index.go
@@ -48,11 +48,10 @@ func ReferencedDigests[E Entry](images map[string]*E) map[string]struct{} {
 	return refs
 }
 
-// LookupOne resolves id to a single entry via LookupRefs' rules, so backend Config
-// and the shared Inspect share one notion of "found" (including digest prefixes).
-// Multiple refs are fine only while they name the same image (tag aliases of one
-// digest); a prefix spanning distinct digests is ambiguous and resolves to nothing
-// rather than to map-iteration luck.
+// LookupOne resolves id to a single entry via LookupRefs' matching rules (exact
+// ref, normalizers, digest exact/prefix). Multiple refs are fine only while they
+// name the same image (tag aliases of one digest); a prefix spanning distinct
+// digests resolves to nothing rather than to map-iteration luck.
 func LookupOne[E Entry](images map[string]*E, id string, normalizers ...func(string) (string, bool)) (string, *E, bool) {
 	refs := LookupRefs(images, id, normalizers...)
 	if len(refs) == 0 {

--- a/images/index.go
+++ b/images/index.go
@@ -50,12 +50,22 @@ func ReferencedDigests[E Entry](images map[string]*E) map[string]struct{} {
 
 // LookupOne resolves id to a single entry via LookupRefs' rules, so backend Config
 // and the shared Inspect share one notion of "found" (including digest prefixes).
+// Multiple refs are fine only while they name the same image (tag aliases of one
+// digest); a prefix spanning distinct digests is ambiguous and resolves to nothing
+// rather than to map-iteration luck.
 func LookupOne[E Entry](images map[string]*E, id string, normalizers ...func(string) (string, bool)) (string, *E, bool) {
 	refs := LookupRefs(images, id, normalizers...)
 	if len(refs) == 0 {
 		return "", nil, false
 	}
-	return refs[0], images[refs[0]], true
+	first := images[refs[0]]
+	for _, ref := range refs[1:] {
+		e := images[ref]
+		if e == nil || (*e).EntryID() != (*first).EntryID() {
+			return "", nil, false
+		}
+	}
+	return refs[0], first, true
 }
 
 // LookupRefs returns all ref keys matching id by exact key, normalizer, or digest prefix.

--- a/images/index_test.go
+++ b/images/index_test.go
@@ -1,0 +1,43 @@
+package images
+
+import (
+	"testing"
+	"time"
+)
+
+type testEntry struct {
+	id  string
+	ref string
+}
+
+func (e testEntry) EntryID() string           { return e.id }
+func (e testEntry) EntryRef() string          { return e.ref }
+func (e testEntry) EntryCreatedAt() time.Time { return time.Time{} }
+func (e testEntry) DigestHexes() []string     { return nil }
+
+func TestLookupOne(t *testing.T) {
+	sameA := &testEntry{id: "sha256:aabb0000111122223333444455556666", ref: "img:v1"}
+	sameB := &testEntry{id: "sha256:aabb0000111122223333444455556666", ref: "img:v2"}
+	other := &testEntry{id: "sha256:aabb9999888877776666555544443333", ref: "other:v1"}
+	images := map[string]*testEntry{
+		"img:v1":   sameA,
+		"img:v2":   sameB,
+		"other:v1": other,
+	}
+
+	if _, e, ok := LookupOne(images, "img:v1"); !ok || e != sameA {
+		t.Errorf("exact ref lookup failed: ok=%v", ok)
+	}
+	// Unique digest prefix resolves.
+	if ref, _, ok := LookupOne(images, "aabb999988887777"); !ok || ref != "other:v1" {
+		t.Errorf("unique prefix: ok=%v ref=%q", ok, ref)
+	}
+	// Tag aliases of one digest are not ambiguous.
+	if _, e, ok := LookupOne(images, "sha256:aabb0000111122223333444455556666"); !ok || (*e).EntryID() != sameA.id {
+		t.Errorf("multi-tag single-digest must resolve: ok=%v", ok)
+	}
+	// A prefix spanning two distinct digests must resolve to nothing.
+	if _, _, ok := LookupOne(images, "aabb"); ok {
+		t.Error("ambiguous cross-digest prefix must not resolve")
+	}
+}

--- a/images/index_test.go
+++ b/images/index_test.go
@@ -16,9 +16,11 @@ func (e testEntry) EntryCreatedAt() time.Time { return time.Time{} }
 func (e testEntry) DigestHexes() []string     { return nil }
 
 func TestLookupOne(t *testing.T) {
-	sameA := &testEntry{id: "sha256:aabb0000111122223333444455556666", ref: "img:v1"}
-	sameB := &testEntry{id: "sha256:aabb0000111122223333444455556666", ref: "img:v2"}
-	other := &testEntry{id: "sha256:aabb9999888877776666555544443333", ref: "other:v1"}
+	// Two distinct digests sharing a 16-hex prefix, so an ambiguous query can
+	// pass LookupRefs' minHexLen guard and reach the cross-digest check.
+	sameA := &testEntry{id: "sha256:aabb000011112222333344445555666a", ref: "img:v1"}
+	sameB := &testEntry{id: "sha256:aabb000011112222333344445555666a", ref: "img:v2"}
+	other := &testEntry{id: "sha256:aabb000011112222bbbbccccddddeeee", ref: "other:v1"}
 	images := map[string]*testEntry{
 		"img:v1":   sameA,
 		"img:v2":   sameB,
@@ -28,16 +30,21 @@ func TestLookupOne(t *testing.T) {
 	if _, e, ok := LookupOne(images, "img:v1"); !ok || e != sameA {
 		t.Errorf("exact ref lookup failed: ok=%v", ok)
 	}
-	// Unique digest prefix resolves.
-	if ref, _, ok := LookupOne(images, "aabb999988887777"); !ok || ref != "other:v1" {
+	// Unique 16-hex digest prefix resolves.
+	if ref, _, ok := LookupOne(images, "aabb000011112222bbbb"); !ok || ref != "other:v1" {
 		t.Errorf("unique prefix: ok=%v ref=%q", ok, ref)
 	}
 	// Tag aliases of one digest are not ambiguous.
-	if _, e, ok := LookupOne(images, "sha256:aabb0000111122223333444455556666"); !ok || (*e).EntryID() != sameA.id {
+	if _, e, ok := LookupOne(images, "sha256:aabb000011112222333344445555666a"); !ok || (*e).EntryID() != sameA.id {
 		t.Errorf("multi-tag single-digest must resolve: ok=%v", ok)
 	}
-	// A prefix spanning two distinct digests must resolve to nothing.
-	if _, _, ok := LookupOne(images, "aabb"); ok {
+	// 16-hex prefix spanning two distinct digests: past the minHexLen guard,
+	// must be refused by the cross-digest check.
+	if _, _, ok := LookupOne(images, "aabb000011112222"); ok {
 		t.Error("ambiguous cross-digest prefix must not resolve")
+	}
+	// Sub-minHexLen prefix never reaches prefix matching at all.
+	if _, _, ok := LookupOne(images, "aabb"); ok {
+		t.Error("short prefix must not resolve")
 	}
 }

--- a/images/oci/commit.go
+++ b/images/oci/commit.go
@@ -87,23 +87,25 @@ func commitAndRecord(conf *Config, idx *imageIndex, ref string, manifestDigest i
 	}
 
 	var totalSize int64
-	for _, le := range layerEntries {
-		size, err := validFileSize(conf.BlobPath(le.Digest.Hex()))
+	addSize := func(path, desc string) error {
+		size, err := validFileSize(path)
 		if err != nil {
-			return fmt.Errorf("blob missing for layer %s (concurrent GC?): %w", le.Digest, err)
+			return fmt.Errorf("%s (concurrent GC?): %w", desc, err)
 		}
 		totalSize += size
+		return nil
 	}
-	size, err := validFileSize(conf.KernelPath(kernelLayer.Hex()))
-	if err != nil {
-		return fmt.Errorf("kernel missing for %s (concurrent GC?): %w", kernelLayer, err)
+	for _, le := range layerEntries {
+		if err := addSize(conf.BlobPath(le.Digest.Hex()), fmt.Sprintf("blob missing for layer %s", le.Digest)); err != nil {
+			return err
+		}
 	}
-	totalSize += size
-	size, err = validFileSize(conf.InitrdPath(initrdLayer.Hex()))
-	if err != nil {
-		return fmt.Errorf("initrd missing for %s (concurrent GC?): %w", initrdLayer, err)
+	if err := addSize(conf.KernelPath(kernelLayer.Hex()), fmt.Sprintf("kernel missing for %s", kernelLayer)); err != nil {
+		return err
 	}
-	totalSize += size
+	if err := addSize(conf.InitrdPath(initrdLayer.Hex()), fmt.Sprintf("initrd missing for %s", initrdLayer)); err != nil {
+		return err
+	}
 
 	idx.Images[ref] = &imageEntry{
 		Ref:            ref,

--- a/images/oci/image.go
+++ b/images/oci/image.go
@@ -12,33 +12,13 @@ type imageIndex struct {
 	images.Index[imageEntry]
 }
 
-// Lookup finds an entry by ref (exact or normalized) or manifest digest.
+// Lookup finds an entry by ref (exact or normalized) or manifest digest (exact or prefix).
 func (idx *imageIndex) Lookup(id string) (string, *imageEntry, bool) {
-	if entry, ok := idx.Images[id]; ok && entry != nil {
-		return id, entry, true
-	}
-	if parsed, err := name.ParseReference(id); err == nil {
-		normalized := parsed.String()
-		if entry, ok := idx.Images[normalized]; ok && entry != nil {
-			return normalized, entry, true
-		}
-	}
-	for ref, entry := range idx.Images {
-		if entry != nil && entry.ManifestDigest.String() == id {
-			return ref, entry, true
-		}
-	}
-	return "", nil, false
+	return images.LookupOne(idx.Images, id, normalizeRef)
 }
 
 func (idx *imageIndex) LookupRefs(id string) []string {
-	return images.LookupRefs(idx.Images, id, func(s string) (string, bool) {
-		parsed, err := name.ParseReference(s)
-		if err != nil {
-			return "", false
-		}
-		return parsed.String(), true
-	})
+	return images.LookupRefs(idx.Images, id, normalizeRef)
 }
 
 // Paths derive from digests at runtime; not stored.
@@ -66,4 +46,13 @@ func (e imageEntry) DigestHexes() []string {
 
 type layerEntry struct {
 	Digest images.Digest `json:"digest"`
+}
+
+// normalizeRef expands a short OCI ref (e.g. "ubuntu:24.04" → "docker.io/library/ubuntu:24.04").
+func normalizeRef(s string) (string, bool) {
+	parsed, err := name.ParseReference(s)
+	if err != nil {
+		return "", false
+	}
+	return parsed.String(), true
 }

--- a/images/oci/import.go
+++ b/images/oci/import.go
@@ -43,11 +43,11 @@ func importTarLayers(ctx context.Context, conf *Config, store storage.Store[imag
 	return store.Update(ctx, func(idx *imageIndex) error {
 		tracker.OnEvent(ociProgress.Event{Phase: ociProgress.PhasePull, Index: -1, Total: len(file)})
 
-		workDir, err := os.MkdirTemp(conf.TempDir(), "import-*")
+		workDir, cleanup, err := newWorkDir(conf, "import-*")
 		if err != nil {
-			return fmt.Errorf("create work dir: %w", err)
+			return err
 		}
-		defer os.RemoveAll(workDir) //nolint:errcheck
+		defer cleanup()
 
 		totalLayers := len(file)
 		results, mapErr := utils.Map(ctx, file, func(ctx context.Context, i int, filePath string) (pullLayerResult, error) {
@@ -81,11 +81,11 @@ func importTarFromReader(ctx context.Context, conf *Config, store storage.Store[
 	return store.Update(ctx, func(idx *imageIndex) error {
 		tracker.OnEvent(ociProgress.Event{Phase: ociProgress.PhasePull, Index: -1, Total: 1})
 
-		workDir, err := os.MkdirTemp(conf.TempDir(), "import-*")
+		workDir, cleanup, err := newWorkDir(conf, "import-*")
 		if err != nil {
-			return fmt.Errorf("create work dir: %w", err)
+			return err
 		}
-		defer os.RemoveAll(workDir) //nolint:errcheck
+		defer cleanup()
 
 		var result pullLayerResult
 		if err := processTarReader(ctx, tarImportJob{

--- a/images/oci/pull.go
+++ b/images/oci/pull.go
@@ -3,7 +3,6 @@ package oci
 import (
 	"context"
 	"fmt"
-	"os"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/projecteru2/core/log"
@@ -41,11 +40,11 @@ func pull(ctx context.Context, conf *Config, store storage.Store[imageIndex], im
 
 		tracker.OnEvent(ociProgress.Event{Phase: ociProgress.PhasePull, Index: -1, Total: len(layers)})
 
-		workDir, mkErr := os.MkdirTemp(conf.TempDir(), "pull-*")
+		workDir, cleanup, mkErr := newWorkDir(conf, "pull-*")
 		if mkErr != nil {
-			return fmt.Errorf("create work dir: %w", mkErr)
+			return mkErr
 		}
-		defer os.RemoveAll(workDir) //nolint:errcheck
+		defer cleanup()
 
 		results, waitErr := processLayers(ctx, conf, layers, workDir, knownBootHexes, tracker)
 		if waitErr != nil {

--- a/images/oci/utils.go
+++ b/images/oci/utils.go
@@ -1,0 +1,15 @@
+package oci
+
+import (
+	"fmt"
+	"os"
+)
+
+// newWorkDir creates a scratch dir under conf.TempDir(); cleanup removes it recursively.
+func newWorkDir(conf *Config, pattern string) (dir string, cleanup func(), err error) {
+	dir, err = os.MkdirTemp(conf.TempDir(), pattern)
+	if err != nil {
+		return "", nil, fmt.Errorf("create work dir: %w", err)
+	}
+	return dir, func() { _ = os.RemoveAll(dir) }, nil
+}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -144,23 +144,25 @@ func Generate(w io.Writer, cfg *Config) error {
 	files := make(map[string][]byte, 3) //nolint:mnd
 
 	var buf bytes.Buffer
-	if err := metaDataTmpl.Execute(&buf, cfg); err != nil {
-		return fmt.Errorf("render meta-data: %w", err)
-	}
-	files["meta-data"] = bytes.Clone(buf.Bytes())
-
-	buf.Reset()
-	if err := userDataTmpl.Execute(&buf, cfg); err != nil {
-		return fmt.Errorf("render user-data: %w", err)
-	}
-	files["user-data"] = bytes.Clone(buf.Bytes())
-
-	if len(cfg.Networks) > 0 {
+	render := func(name string, tmpl *template.Template) error {
 		buf.Reset()
-		if err := networkConfigTmpl.Execute(&buf, cfg); err != nil {
-			return fmt.Errorf("render network-config: %w", err)
+		if err := tmpl.Execute(&buf, cfg); err != nil {
+			return fmt.Errorf("render %s: %w", name, err)
 		}
-		files["network-config"] = bytes.Clone(buf.Bytes())
+		files[name] = bytes.Clone(buf.Bytes())
+		return nil
+	}
+
+	if err := render("meta-data", metaDataTmpl); err != nil {
+		return err
+	}
+	if err := render("user-data", userDataTmpl); err != nil {
+		return err
+	}
+	if len(cfg.Networks) > 0 {
+		if err := render("network-config", networkConfigTmpl); err != nil {
+			return err
+		}
 	}
 
 	return CreateFAT12(w, cidataLabel, files)

--- a/network/bridge/bridge_linux.go
+++ b/network/bridge/bridge_linux.go
@@ -3,7 +3,6 @@
 package bridge
 
 import (
-	"cmp"
 	"context"
 	"crypto/rand"
 	"fmt"
@@ -91,7 +90,7 @@ func (b *Bridge) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, sp
 		if spec.Existing != nil {
 			mac = spec.Existing.MAC
 		}
-		queues := cmp.Or(spec.Queues, network.NetNumQueues(vmCfg.CPU))
+		queues := network.ResolveQueues(spec.Queues, vmCfg.CPU)
 		if cErr := network.CreateTAP(name, queues); cErr != nil {
 			return nil, cErr
 		}

--- a/network/bridge/bridge_linux.go
+++ b/network/bridge/bridge_linux.go
@@ -3,6 +3,7 @@
 package bridge
 
 import (
+	"cmp"
 	"context"
 	"crypto/rand"
 	"fmt"
@@ -90,7 +91,7 @@ func (b *Bridge) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, sp
 		if spec.Existing != nil {
 			mac = spec.Existing.MAC
 		}
-		queues := network.NetNumQueues(vmCfg.CPU)
+		queues := cmp.Or(spec.Queues, network.NetNumQueues(vmCfg.CPU))
 		if cErr := network.CreateTAP(name, queues); cErr != nil {
 			return nil, cErr
 		}

--- a/network/cni/lifecycle.go
+++ b/network/cni/lifecycle.go
@@ -1,7 +1,6 @@
 package cni
 
 import (
-	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -111,7 +110,7 @@ func (c *CNI) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs
 		if spec.Existing != nil {
 			overrideMAC = spec.Existing.MAC
 		}
-		queues := cmp.Or(spec.Queues, network.NetNumQueues(vmCfg.CPU))
+		queues := network.ResolveQueues(spec.Queues, vmCfg.CPU)
 		mac, setupErr := setupTCRedirect(nsPath, ifName, tapName, queues, overrideMAC)
 		if setupErr != nil {
 			return nil, fmt.Errorf("setup tc-redirect %s: %w", vmID, setupErr)

--- a/network/cni/lifecycle.go
+++ b/network/cni/lifecycle.go
@@ -1,6 +1,7 @@
 package cni
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -110,7 +111,8 @@ func (c *CNI) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs
 		if spec.Existing != nil {
 			overrideMAC = spec.Existing.MAC
 		}
-		mac, setupErr := setupTCRedirect(nsPath, ifName, tapName, network.NetNumQueues(vmCfg.CPU), overrideMAC)
+		queues := cmp.Or(spec.Queues, network.NetNumQueues(vmCfg.CPU))
+		mac, setupErr := setupTCRedirect(nsPath, ifName, tapName, queues, overrideMAC)
 		if setupErr != nil {
 			return nil, fmt.Errorf("setup tc-redirect %s: %w", vmID, setupErr)
 		}
@@ -118,7 +120,7 @@ func (c *CNI) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs
 		cfg := &types.NetworkConfig{
 			TAP:       tapName,
 			MAC:       mac,
-			NumQueues: network.NetNumQueues(vmCfg.CPU),
+			NumQueues: queues,
 			QueueSize: network.ResolveQueueSize(vmCfg.QueueSize),
 			Backend:   types.BackendCNI,
 			NetnsPath: nsPath,

--- a/network/network.go
+++ b/network/network.go
@@ -42,7 +42,7 @@ func AddRange(from, count int) []AddSpec {
 	return out
 }
 
-// AddRecover builds AddSpecs for re-creating existing NICs (post-reboot recovery); the persisted queue count is authoritative, not the VM's current CPU. Nil entries (null in persisted network_configs) keep the derive-from-CPU default.
+// AddRecover builds AddSpecs re-creating existing NICs from their persisted state (nil entries fall back to CPU-derived queues).
 func AddRecover(existing []*types.NetworkConfig) []AddSpec {
 	out := make([]AddSpec, len(existing))
 	for i, e := range existing {

--- a/network/network.go
+++ b/network/network.go
@@ -42,11 +42,14 @@ func AddRange(from, count int) []AddSpec {
 	return out
 }
 
-// AddRecover builds AddSpecs for re-creating existing NICs (post-reboot recovery); the persisted queue count is authoritative, not the VM's current CPU.
+// AddRecover builds AddSpecs for re-creating existing NICs (post-reboot recovery); the persisted queue count is authoritative, not the VM's current CPU. Nil entries (null in persisted network_configs) keep the derive-from-CPU default.
 func AddRecover(existing []*types.NetworkConfig) []AddSpec {
 	out := make([]AddSpec, len(existing))
 	for i, e := range existing {
-		out[i] = AddSpec{Index: i, Queues: e.NumQueues, Existing: e}
+		out[i] = AddSpec{Index: i, Existing: e}
+		if e != nil {
+			out[i].Queues = e.NumQueues
+		}
 	}
 	return out
 }

--- a/network/network.go
+++ b/network/network.go
@@ -12,7 +12,10 @@ var ErrNotConfigured = errors.New("network provider not configured")
 
 // AddSpec is one NIC's add request; Existing != nil reuses MAC/IP for recovery.
 type AddSpec struct {
-	Index    int
+	Index int
+	// Queues is the TAP queue count; 0 derives NetNumQueues(vmCfg.CPU). Callers with a
+	// backend-specific size (FC opens the TAP single-queue) set it explicitly.
+	Queues   int
 	Existing *types.NetworkConfig
 }
 
@@ -39,11 +42,11 @@ func AddRange(from, count int) []AddSpec {
 	return out
 }
 
-// AddRecover builds AddSpecs for re-creating existing NICs (post-reboot recovery).
+// AddRecover builds AddSpecs for re-creating existing NICs (post-reboot recovery); the persisted queue count is authoritative, not the VM's current CPU.
 func AddRecover(existing []*types.NetworkConfig) []AddSpec {
 	out := make([]AddSpec, len(existing))
 	for i, e := range existing {
-		out[i] = AddSpec{Index: i, Existing: e}
+		out[i] = AddSpec{Index: i, Queues: e.NumQueues, Existing: e}
 	}
 	return out
 }

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -1,0 +1,40 @@
+package network
+
+import (
+	"testing"
+
+	"github.com/cocoonstack/cocoon/types"
+)
+
+func TestAddRecover(t *testing.T) {
+	existing := []*types.NetworkConfig{
+		{TAP: "tap0", NumQueues: 2},
+		nil, // persisted network_configs may carry null entries
+		{TAP: "tap2", NumQueues: 4},
+	}
+	specs := AddRecover(existing)
+	if len(specs) != 3 {
+		t.Fatalf("got %d specs, want 3", len(specs))
+	}
+	if specs[0].Queues != 2 || specs[2].Queues != 4 {
+		t.Errorf("persisted queue counts not restored: %+v", specs)
+	}
+	if specs[1].Queues != 0 || specs[1].Existing != nil {
+		t.Errorf("nil NIC must keep the derive-from-CPU default: %+v", specs[1])
+	}
+	if specs[1].Index != 1 {
+		t.Errorf("index not preserved for nil entry: %+v", specs[1])
+	}
+}
+
+func TestAddRange(t *testing.T) {
+	specs := AddRange(2, 3)
+	if len(specs) != 3 || specs[0].Index != 2 || specs[2].Index != 4 {
+		t.Fatalf("got %+v", specs)
+	}
+	for _, s := range specs {
+		if s.Queues != 0 || s.Existing != nil {
+			t.Errorf("fresh spec must be zero beyond Index: %+v", s)
+		}
+	}
+}

--- a/network/utils.go
+++ b/network/utils.go
@@ -24,6 +24,11 @@ func ResolveQueueSize(qs int) int {
 	return cmp.Or(qs, NetQueueSize)
 }
 
+// ResolveQueues returns specQueues if set, otherwise the CPU-derived TAP queue count.
+func ResolveQueues(specQueues, cpu int) int {
+	return cmp.Or(specQueues, NetNumQueues(cpu))
+}
+
 // VMIDPrefix returns the first 8 characters of a VM ID, matching the truncation used by both bridge and CNI TAP device naming.
 func VMIDPrefix(vmID string) string {
 	if len(vmID) > vmIDPrefixLen {

--- a/snapshot/localfile/localfile_test.go
+++ b/snapshot/localfile/localfile_test.go
@@ -39,8 +39,6 @@ func TestNew_NilConfig(t *testing.T) {
 	}
 }
 
-// Create
-
 func TestCreateAndDeleteEmitMetering(t *testing.T) {
 	rec := meteringcapture.New()
 	lf := newTestLFWithRecorder(t, rec)
@@ -233,8 +231,6 @@ func TestCreate_InvalidStream(t *testing.T) {
 	}
 }
 
-// List
-
 func TestList_Empty(t *testing.T) {
 	lf := newTestLF(t)
 	ctx := t.Context()
@@ -277,8 +273,6 @@ func TestList(t *testing.T) {
 		}
 	}
 }
-
-// Inspect
 
 func TestInspect_ByID(t *testing.T) {
 	lf := newTestLF(t)
@@ -357,8 +351,6 @@ func TestInspect_NotFound(t *testing.T) {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}
 }
-
-// Delete
 
 func TestDelete(t *testing.T) {
 	lf := newTestLF(t)
@@ -470,8 +462,6 @@ func TestDelete_NotFound(t *testing.T) {
 	}
 }
 
-// Create → Inspect round trip verifies timestamps and fields.
-
 func TestCreate_Inspect_Fields(t *testing.T) {
 	lf := newTestLF(t)
 	ctx := t.Context()
@@ -507,8 +497,6 @@ func TestCreate_Inspect_Fields(t *testing.T) {
 	}
 }
 
-// Delete then recreate with same name should succeed.
-
 func TestDelete_RecreateName(t *testing.T) {
 	lf := newTestLF(t)
 	ctx := t.Context()
@@ -537,8 +525,6 @@ func TestDelete_RecreateName(t *testing.T) {
 		t.Errorf("expected new ID %q, got %q", id2, s.ID)
 	}
 }
-
-// DataDir
 
 func TestDataDir(t *testing.T) {
 	lf := newTestLF(t)
@@ -626,8 +612,6 @@ func TestDataDir_ImageBlobIDsIsolation(t *testing.T) {
 		t.Error("ImageBlobIDs missing 'original' after re-read")
 	}
 }
-
-// Restore
 
 func TestRestore_ConfigRoundtrip(t *testing.T) {
 	lf := newTestLF(t)
@@ -808,8 +792,6 @@ func TestRestore_ImageBlobIDsIsolation(t *testing.T) {
 		t.Error("ImageBlobIDs missing 'orig' after re-read")
 	}
 }
-
-// Export → Import roundtrip
 
 func TestExportImport_Roundtrip(t *testing.T) {
 	lf := newTestLF(t)
@@ -1263,8 +1245,6 @@ func makeTar(t *testing.T, files map[string][]byte) *bytes.Buffer {
 	tw.Close()
 	return &buf
 }
-
-// New
 
 func kinds(entries []metering.Entry) []metering.Kind {
 	out := make([]metering.Kind, len(entries))

--- a/types/network.go
+++ b/types/network.go
@@ -1,5 +1,7 @@
 package types
 
+import "fmt"
+
 // Network backend identifiers stored in NetworkConfig.Backend.
 const (
 	BackendCNI    = "cni"
@@ -31,4 +33,14 @@ type Network struct {
 	IP      string `json:"ip,omitempty"`      // dotted decimal, e.g. "10.0.0.2"
 	Gateway string `json:"gateway,omitempty"` // dotted decimal, e.g. "10.0.0.1"
 	Prefix  int    `json:"prefix,omitempty"`  // CIDR prefix length, e.g. 24
+}
+
+// ValidateNetworkConfigs rejects nil NIC entries (null in a persisted record) at load boundaries so downstream consumers may dereference freely.
+func ValidateNetworkConfigs(configs []*NetworkConfig) error {
+	for i, nc := range configs {
+		if nc == nil {
+			return fmt.Errorf("network config %d: nil", i)
+		}
+	}
+	return nil
 }

--- a/types/network_test.go
+++ b/types/network_test.go
@@ -1,0 +1,15 @@
+package types
+
+import "testing"
+
+func TestValidateNetworkConfigs(t *testing.T) {
+	if err := ValidateNetworkConfigs(nil); err != nil {
+		t.Errorf("empty: %v", err)
+	}
+	if err := ValidateNetworkConfigs([]*NetworkConfig{{TAP: "tap0"}}); err != nil {
+		t.Errorf("valid: %v", err)
+	}
+	if err := ValidateNetworkConfigs([]*NetworkConfig{{TAP: "tap0"}, nil}); err == nil {
+		t.Error("nil entry must be rejected")
+	}
+}

--- a/types/storage.go
+++ b/types/storage.go
@@ -33,6 +33,7 @@ type StorageConfig struct {
 	MountPoint string      `json:"mount_point,omitempty"` // Role==Data only
 	FSType     string      `json:"fstype,omitempty"`      // Role==Data only
 	DirectIO   *bool       `json:"direct_io,omitempty"`   // Role==Data only; nil inherits VM-level NoDirectIO
+	External   bool        `json:"external,omitempty"`    // Role==Data only; backing file outside cocoon's management (never created/copied/deleted/path-rewritten)
 }
 
 // DataDiskSpec is the user-facing description of an extra data disk parsed from --data-disk. Transient — never persisted.
@@ -57,7 +58,8 @@ func ValidateStorageConfigs(configs []*StorageConfig) error {
 				return fmt.Errorf("storage config %d (%s): role %s requires RO=true", i, sc.Path, sc.Role)
 			}
 		case StorageRoleCOW, StorageRoleData:
-			if sc.RO {
+			// External volumes may be attached read-only (shared reference data).
+			if sc.RO && !sc.External {
 				return fmt.Errorf("storage config %d (%s): role %s requires RO=false", i, sc.Path, sc.Role)
 			}
 		default:
@@ -82,6 +84,9 @@ func ValidateStorageConfigs(configs []*StorageConfig) error {
 			if strings.ContainsAny(sc.MountPoint, "\x00\n") {
 				return fmt.Errorf("data disk %s: mount_point contains forbidden characters", sc.Serial)
 			}
+		}
+		if sc.External && !filepath.IsAbs(sc.Path) {
+			return fmt.Errorf("data disk %s: external requires an absolute path, got %q", sc.Serial, sc.Path)
 		}
 		if !ValidDataDiskName(sc.Serial) {
 			return fmt.Errorf("data disk: serial %q does not match name rules", sc.Serial)

--- a/types/storage.go
+++ b/types/storage.go
@@ -33,7 +33,6 @@ type StorageConfig struct {
 	MountPoint string      `json:"mount_point,omitempty"` // Role==Data only
 	FSType     string      `json:"fstype,omitempty"`      // Role==Data only
 	DirectIO   *bool       `json:"direct_io,omitempty"`   // Role==Data only; nil inherits VM-level NoDirectIO
-	External   bool        `json:"external,omitempty"`    // Role==Data only; backing file outside cocoon's management (never created/copied/deleted/path-rewritten)
 }
 
 // DataDiskSpec is the user-facing description of an extra data disk parsed from --data-disk. Transient — never persisted.
@@ -58,8 +57,7 @@ func ValidateStorageConfigs(configs []*StorageConfig) error {
 				return fmt.Errorf("storage config %d (%s): role %s requires RO=true", i, sc.Path, sc.Role)
 			}
 		case StorageRoleCOW, StorageRoleData:
-			// External volumes may be attached read-only (shared reference data).
-			if sc.RO && !sc.External {
+			if sc.RO {
 				return fmt.Errorf("storage config %d (%s): role %s requires RO=false", i, sc.Path, sc.Role)
 			}
 		default:
@@ -84,9 +82,6 @@ func ValidateStorageConfigs(configs []*StorageConfig) error {
 			if strings.ContainsAny(sc.MountPoint, "\x00\n") {
 				return fmt.Errorf("data disk %s: mount_point contains forbidden characters", sc.Serial)
 			}
-		}
-		if sc.External && !filepath.IsAbs(sc.Path) {
-			return fmt.Errorf("data disk %s: external requires an absolute path, got %q", sc.Serial, sc.Path)
 		}
 		if !ValidDataDiskName(sc.Serial) {
 			return fmt.Errorf("data disk: serial %q does not match name rules", sc.Serial)

--- a/types/storage_test.go
+++ b/types/storage_test.go
@@ -109,3 +109,18 @@ func TestValidateStorageConfigs(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateStorageConfigs_External(t *testing.T) {
+	valid := &StorageConfig{Role: StorageRoleData, Path: "/vols/a.raw", Serial: "vola", External: true, FSType: "none"}
+	if err := ValidateStorageConfigs([]*StorageConfig{valid}); err != nil {
+		t.Fatalf("valid external: %v", err)
+	}
+	rel := &StorageConfig{Role: StorageRoleData, Path: "vols/a.raw", Serial: "vola", External: true, FSType: "none"}
+	ro := &StorageConfig{Role: StorageRoleData, Path: "/vols/a.raw", Serial: "vola", External: true, FSType: "none", RO: true}
+	if err := ValidateStorageConfigs([]*StorageConfig{ro}); err != nil {
+		t.Fatalf("readonly external should pass: %v", err)
+	}
+	if err := ValidateStorageConfigs([]*StorageConfig{rel}); err == nil {
+		t.Fatal("relative external path should fail")
+	}
+}

--- a/types/storage_test.go
+++ b/types/storage_test.go
@@ -109,18 +109,3 @@ func TestValidateStorageConfigs(t *testing.T) {
 		})
 	}
 }
-
-func TestValidateStorageConfigs_External(t *testing.T) {
-	valid := &StorageConfig{Role: StorageRoleData, Path: "/vols/a.raw", Serial: "vola", External: true, FSType: "none"}
-	if err := ValidateStorageConfigs([]*StorageConfig{valid}); err != nil {
-		t.Fatalf("valid external: %v", err)
-	}
-	rel := &StorageConfig{Role: StorageRoleData, Path: "vols/a.raw", Serial: "vola", External: true, FSType: "none"}
-	ro := &StorageConfig{Role: StorageRoleData, Path: "/vols/a.raw", Serial: "vola", External: true, FSType: "none", RO: true}
-	if err := ValidateStorageConfigs([]*StorageConfig{ro}); err != nil {
-		t.Fatalf("readonly external should pass: %v", err)
-	}
-	if err := ValidateStorageConfigs([]*StorageConfig{rel}); err == nil {
-		t.Fatal("relative external path should fail")
-	}
-}

--- a/utils/pidfd_linux.go
+++ b/utils/pidfd_linux.go
@@ -32,14 +32,10 @@ func terminateWithPidfd(ctx context.Context, pid int, binaryName, expectArg stri
 		}
 		// SIGTERM via pidfd failed but process is alive; escalate via pidfd.
 		_ = unix.PidfdSendSignal(fd, syscall.SIGKILL, nil, 0)
-		return true, WaitFor(ctx, killWaitTimeout, time.Millisecond, func() (bool, error) {
-			return !IsProcessAlive(pid), nil
-		})
+		return true, waitDead(ctx, pid, killWaitTimeout)
 	}
 
-	if err := WaitFor(ctx, gracePeriod, time.Millisecond, func() (bool, error) {
-		return !IsProcessAlive(pid), nil
-	}); err == nil {
+	if err := waitDead(ctx, pid, gracePeriod); err == nil {
 		return true, nil
 	}
 
@@ -48,7 +44,5 @@ func terminateWithPidfd(ctx context.Context, pid int, binaryName, expectArg stri
 			return true, nil
 		}
 	}
-	return true, WaitFor(ctx, killWaitTimeout, time.Millisecond, func() (bool, error) {
-		return !IsProcessAlive(pid), nil
-	})
+	return true, waitDead(ctx, pid, killWaitTimeout)
 }

--- a/utils/process.go
+++ b/utils/process.go
@@ -72,9 +72,7 @@ func TerminateProcess(ctx context.Context, pid int, binaryName, expectArg string
 		return killAndWait(ctx, proc, pid)
 	}
 
-	if err := WaitFor(ctx, gracePeriod, time.Millisecond, func() (bool, error) {
-		return !IsProcessAlive(pid), nil
-	}); err == nil {
+	if err := waitDead(ctx, pid, gracePeriod); err == nil {
 		return nil
 	}
 
@@ -83,7 +81,12 @@ func TerminateProcess(ctx context.Context, pid int, binaryName, expectArg string
 
 func killAndWait(ctx context.Context, proc *os.Process, pid int) error {
 	_ = proc.Kill()
-	return WaitFor(ctx, killWaitTimeout, time.Millisecond, func() (bool, error) {
+	return waitDead(ctx, pid, killWaitTimeout)
+}
+
+// waitDead polls until pid no longer responds to kill(0), bounded by timeout.
+func waitDead(ctx context.Context, pid int, timeout time.Duration) error {
+	return WaitFor(ctx, timeout, time.Millisecond, func() (bool, error) {
 		return !IsProcessAlive(pid), nil
 	})
 }


### PR DESCRIPTION
Closes #102, closes #103.

## Final design

**`vm disk attach/detach` (CH only) is fully runtime-only — the exact `extend/fs`/`extend/vfio` contract.** Attach hot-adds an existing raw file as `/dev/disk/by-id/virtio-<name>`; detach removes the device and keeps the file. No record entry, no `list` verb (`vm inspect`'s `attached_devices` surfaces all three classes via the backend listers), gone after stop/restart — the volume's lifecycle belongs to the host user, not to cocoon's. `--directio on|off|auto` (shared parser with `--data-disk directio=`), `--readonly` allowed. Attach canonicalizes the path with `EvalSymlinks` on both sides of the managed-root check, so neither a literal path nor a symlink can smuggle a volume under the root/run/log dirs (`vm rm` deletes all three); the duplicate precheck matches id + serial + resolved path under the lock, and the CH disk body is built from the record **reloaded under the ops lock**, so an attach queued behind a restore can't hot-add with pre-restore queue/directio semantics.

**Capture excluded**: `snapshot save` and `vm hibernate` refuse while a volume is attached — `hot-attached disk "x": detach before snapshot or hibernate` (umount in-guest, detach, capture, re-attach after wake/restore). The refusal rides `buildSnapshotMeta`'s record-mismatch check on the artifact CH itself dumped, so a volume-bearing snapshot can never be persisted, registered, or streamed; snapshot failure resumes the VM, hibernate failure resumes inside the pause window. Restore and clone carry zero external-volume reasoning.

**Per-VM ops lock (#103)**: `ops.lock` flock in the run dir — device attach/detach, net resize, snapshot, hibernate, restore, stop, and the **entire `vm rm` body** (stop-before-delete via a `StopOneLocked` variant, socket probe, record delete, dir removal) serialize. Delete removes the DB record before the dirs: dir removal unlinks the lock file, and a later locker on the recreated file is a fresh flock inode that does not contend — with the record already gone its resolve fails instead of reviving a half-deleted VM. Device prechecks and the attach body read `vm.info`/the record UNDER the lock; NetResize and the restore sequences reload/revalidate under the lock. The flock dies with the process.

## Whole-repo review round riding this branch

- **/code line-by-line audit of all 251 Go files** — one layout-normalization commit (Spec method-set atomicity in `extend/{fs,netresize,vfio}`, test helpers below tests, section-label comments deleted); everything else already conformed.
- **4-lens /simplify over the entire repo** (reuse / simplification / efficiency / altitude), 17 findings applied: `newTempImage`/`newWorkDir`/`sendJSONOnce`/`waitDead`/progress-tracker builders collapse ~20 hand-synced boilerplate blocks; `hypervisor.IsDirectBoot`, `COWRawFileName`, and the `--force` stop sentinel (`BaseConfig.ForceStop/StopTimeout`) get single owners; `images.LookupOne` unifies the boot-path resolver with Inspect's (digest prefixes now resolve in `Config()` too); `network.AddSpec.Queues` replaces the `vmCfg.CPU` mutation hack and `AddRecover` now restores the persisted per-NIC queue count (fixes FC network recovery rebuilding TAPs from the VM's CPU count); `Backend.List` parallelizes ToVM's per-running-VM file IO on the status/watch polling path. Earlier review folds unchanged: `Backend.UpdateRecord`, `cmdcore.ParseDirectIO`, disk verbs on `attachWith`/`detachWith`, SnapshotFileKind iota.
- Skipped with reasons (recorded in review): `validFileSize`→`utils.ValidFile` would double-stat and lose error detail; FC restore's COW-rename branch is reachable under `--run-dir` drift; merging the two compute-interval closers needs a bool-fork; clone-time storage validation stays in the backends because it must run before launch, which the shared skeleton is after.

## Dual-channel review round (post-E2E): 5 fixed, 1 skipped

- **A (HIGH)** `vm start` now runs under the per-VM ops lock — a concurrent `rm --force` can no longer delete the record/dirs mid-launch and orphan the VMM.
- **B (HIGH)** `AddRecover` nil-guards persisted `network_configs` entries (simplify-round regression — a null NIC crashed network recovery).
- **E (HIGH)** `vm disk/fs/device detach` now **blocks until the guest acks the ACPI eject** (`waitDeviceEjected`, 30s budget): on return the slot, name, and backing file are free — verified on `.79` with 5 zero-wait attach/detach cycles (~105ms each incl. eject; the old `id not unique`/`file already locked` races are gone). README updated.
- **D (MED)** `images.LookupOne` refuses a digest prefix spanning distinct images (map-iteration-order resolution); tag aliases of one digest still resolve. Unit-tested.
- **C (MED)** restore preflight now compares disk **serials** (tampered sidecar can't swap them), and both backends' staged restores run the same `cleanSnapshotFiles` sweep as DirectRestore so stale `data-*.raw`/memory files can't survive the merge. Unit-tested.
- **F (LOW, skipped)** TOCTOU between `resolveExternalVolume` and CH's open: an attacker who can swap host symlinks already owns the data dirs; re-checking under the ops lock closes nothing (the race is against the filesystem, not the lock). Recorded as out of threat model.

Gates re-run after the fixes: build+lint 0 issues both platforms, 28 packages `-race` on macOS, **29 packages `-race` in a Linux container**, `.79` re-drill green.

## Round 3 (state-write serialization): 2 P1s fixed

- **start/stop state flips now land inside the ops lock.** Previously the launch/shutdown ran locked but `BatchMarkStarted`/`UpdateStates(Stopped)` fired from the batch tail after unlock — a start could launch, unlock, lose to a queued stop that killed the VMM, then write Running over the corpse. `StartSequence` flips Running before releasing the lock, `StopOneLocked` flips Stopped after a successful shutdown, `StartAll`/`StopAll` are pure fan-outs. Lock-coverage matrix re-audited: every verb's state persistence (start/stop/delete/snapshot/hibernate/restore/netresize) is now inside its lock window; the create/clone placeholder window is pre-existing and fails typed (`disappeared from index`) rather than reviving records.
- **nil NIC entries are rejected at the start boundary.** The `AddRecover` nil guard only saved spec construction; both backends' arg builders still dereferenced null `network_configs` entries at launch. `types.ValidateNetworkConfigs` (same pattern as `ValidateStorageConfigs`) now refuses them in `StartSequence` — VM marked error, typed failure, `Launch` never runs — and `recoverNetwork` skips corrupt records instead of growing fresh plumbing for them. Deref matrix re-audited: all remaining `NetworkConfigs` consumers are nil-safe or fed freshly-built configs. Unit-tested (`TestStartSequenceRejectsNilNIC`, `TestStartSequenceFlipsRunningUnderLock`, `TestValidateNetworkConfigs`).

## Verification

- Unit: `TestBuildSnapshotMetaRefusesUnrecordedDisk`; `TestResolveExternalVolume` (symlink-into-managed-dir refused, `/var` symlink canonicalization); `TestDeleteAllStoppedVM` / `TestDeleteAllForceStopsUnderLock` (full force path against a live stub VMM — deadlocks if the stop variant re-takes the ops lock) / `TestDeleteAllRefusesLiveAPISocket`; extend/disk tables; ParseDirectIO via the `--data-disk` table.
- Gates: build + golangci-lint 0 issues on GOOS=linux+darwin, full suite 26 packages with `-race`.
- Hardware evidence still standing from earlier rounds: attach → guest write → detach → re-attach reads the marker back; concurrent same-path attach race — loser refuses typed; FC typed refusals; lifecycle green under the locks.
- **Hardware re-pass: DONE** — bare-metal `.79` (AMD 16c, CH v52/FC v1.16), cocoon rev `4c93d71`, full run report in `cocoon-specs/tests/2026-07-08-pr101-e2e-79.md` (**23/23 PASS, 0 FAIL**): attach → guest write → detach (file kept) → re-attach reads marker back; `snapshot save`/`hibernate` refused with the new message while attached, VM stays running, nothing registered; detach → snapshot + clone + in-place restore + hibernate/wake (uptime-continuous) all green; attach → stop → start → volume absent (runtime-only); managed-dir and symlink-smuggled paths refused, legit symlink resolves; three-way duplicate precheck typed; FC attach typed-unsupported; `vm rm --force` racing `vm restore` ×3 — serialized, consistent outcome, zero orphan VMM / leftover run dir; CH TAP multi-queue and FC TAP single-queue both survive netns-destroy recovery (AddRecover restores persisted queue counts); pkill-9 recovery, double-rm, mixed FC+CH list, gc (1ms, no deadlock, only a genuinely-unreferenced blob collected) all green. Two non-blocking guest-side findings recorded in the run doc: the hot-added block device (`/dev/vdX` + serial) is immediately usable but the udev `by-id` symlink is timing-unreliable on the minimal image (`udevadm trigger` materializes it 100%; README updated); the detach→re-attach B0EJ eject window measured at 111ms with typed refusals until the guest acks.
