### PR TITLE
android: default redroid display refresh to 60fps

### DIFF
--- a/os-image/android/init-wrapper.sh
+++ b/os-image/android/init-wrapper.sh
@@ -87,6 +87,15 @@ for f in $($BB find /vendor/etc/vintf -name '*bluetooth*' 2>/dev/null); do
     $BB mv "$f" "${f}.disabled" 2>/dev/null
 done
 
+# Refresh rate: redroid guest mode leaves the display HAL at its 15fps default,
+# which feels laggy even though the software renderer draws a frame in ~1ms and
+# host CPU stays under 10%. Default to 60fps (measured ~4x smoother scroll);
+# override via kernel cmdline redroid.fps=N (e.g. cocoon COCOON_REDROID_FPS).
+REDROID_FPS=60
+for _x in $($BB cat /proc/cmdline); do
+    case "$_x" in redroid.fps=*) REDROID_FPS="${_x#redroid.fps=}" ;; esac
+done
+
 exec /init \
     qemu=1 \
     androidboot.hardware=redroid \
@@ -98,4 +107,5 @@ exec /init \
     androidboot.redroid_gpu_mode=guest \
     androidboot.redroid_width=720 \
     androidboot.redroid_height=1280 \
-    androidboot.redroid_dpi=240
+    androidboot.redroid_dpi=240 \
+    androidboot.redroid_fps=$REDROID_FPS


### PR DESCRIPTION
## Problem

redroid 15.0 under cocoon feels laggy at 4C4G even though a Windows VM on the same host is smooth. Root cause: redroid guest mode leaves the display HAL at its default **15fps**. The CPU software renderer (GLES→ANGLE→`pastel`) draws a frame in ~1ms, but at 15Hz each frame idles ~61ms and input is sampled at 15Hz (~66ms latency) — so it feels laggy while the CPU sits nearly idle. Windows uses a normal refresh rate, which is why only Android felt slow at the same specs.

## Fix

Refresh rate is a redroid-image concern, so the change lives entirely in the image's `init-wrapper.sh`: default to **60fps** and honor kernel cmdline `redroid.fps=N` for override. cocoon stays image-agnostic (no image-specific logic in the hypervisor).

## Measured (4C4G, fixed Settings scroll, host-computed fps)

| metric | 15fps (default) | 60fps |
|---|---|---|
| scroll fps | 14.5 | **58.7 (~4x)** |
| jank | 0% | 0.24% |
| per-frame GPU time | 1ms | 1ms |
| host 16-core CPU during 60fps scroll | — | **92.9% idle** |

60 is the sweet spot — the display HAL halves 90 → 45. Verified on a Ryzen 9700X + CH v52 host: default → display 60fps; `redroid.fps=30` on the kernel cmdline → 30fps. A GLES 2D game (Shattered Pixel Dungeon) installs and runs full-screen at 60fps.

Honest ceiling: 2D/UI/desktop/light games become smooth; heavy 3D remains bounded by CPU software rendering (no GPU) — but that was never the cause of the lag; the 15fps lock was.
