### PR TITLE
android: fix eth0 DHCP crash-loop on VM restart

### DIFF
--- a/os-image/android/network.sh
+++ b/os-image/android/network.sh
@@ -14,9 +14,12 @@
 IFACE=eth0
 TABLES="legacy_system legacy_network local_network"
 
-# Guard against repeated invocations.
-GUARD="/data/local/tmp/.cocoon-network-done"
-[ -f "$GUARD" ] && exit 0
+# Guard against repeated invocations WITHIN a boot only. Must NOT persist across
+# reboots: /data survives stop/start, and a stale guard would skip the eth0
+# re-bounce below, so the guest never re-triggers DHCP -> eth0 stays IP-less ->
+# EthernetService/IpClient NPE -> system_server crash-loop. A property resets
+# every boot; a /data file does not.
+[ "$(getprop cocoon.network.configured)" = "1" ] && exit 0
 
 cmdline_ip() {
     local cmdline
@@ -88,4 +91,4 @@ else
     log -t cocoon-network "dhcp: deleted ipconfig.txt, bounced $IFACE for EthernetService DHCP"
 fi
 
-touch "$GUARD"
+setprop cocoon.network.configured 1


### PR DESCRIPTION
## Problem

On a redroid VM that has a NIC, a `stop`/`start` (VM restart) drops the guest into a `system_server` crash-loop that never completes boot. The first boot is fine.

## Root cause

`cocoon-network.sh` guards against repeated invocations with a file at `/data/local/tmp/.cocoon-network-done`. `/data` **persists across stop/start**, so on the second boot the stale guard makes the script `exit 0` *before* it re-bounces `eth0`. The guest therefore never re-triggers DHCP: `eth0` stays IP-less, EthernetService/IpClient dereferences a null `LinkAddress` (NPE), the network stack dies, and `system_server` crash-loops (boot never completes).

## Fix

Use a boot-scoped Android property (`cocoon.network.configured`) instead of a persistent `/data` file. It still prevents duplicate runs within a single boot (the `init.svc.netd=running` trigger can fire more than once), but resets every boot so a restart re-runs the network setup and re-triggers DHCP.

## Reproduced & verified (isolated bridge + local dnsmasq, no LAN)

| after stop/start | before fix | after fix |
|---|---|---|
| DHCP packets from guest | **0** (never asks) | `DISCOVER → REQUEST → ACK`, gets a lease |
| eth0 IP | none | lease acquired |
| boot | crash-loop (140 IpClient/networkstack crashes) | completes |
