### PR TITLE
fix(restore): emit vsock_socket in `vm restore -o json`

### DIFF
--- a/hypervisor/restore.go
+++ b/hypervisor/restore.go
@@ -68,6 +68,9 @@ func (b *Backend) FinalizeRestore(ctx context.Context, vmID string, vmCfg *types
 	info.State = types.VMStateRunning
 	info.PID = pid
 	info.SocketPath = SocketPath(rec.RunDir)
+	if p := VsockSockPath(rec.RunDir); isVsockBound(p) {
+		info.VsockSocket = p // let `vm restore -o json` carry the vsock UDS, as ToVM does
+	}
 	info.StartedAt = &now
 	info.UpdatedAt = now
 	return &info, nil


### PR DESCRIPTION
`FinalizeRestore` set `SocketPath` but not `VsockSocket`, so `vm restore -o json` (and the direct / `--from-dir` restore path via `runDirectRestore`) omitted the vsock UDS that `vm run` and `vm inspect` already carry via `ToVM`. Populate it the same way — `VsockSockPath(rec.RunDir)` guarded by `isVsockBound`, so a not-yet-bound restore stays empty (caller falls back).

Lets a caller (sandboxd's restore/wake path) read the socket from restore's own output instead of a second `cocoon vm list` — the cocoon half of the sandbox F3 perf item.

Gates: `go build ./...`, `go test ./hypervisor/... ./types/...`, `golangci-lint` all green. Acceptance to confirm on hardware: `cocoon vm restore <vm> --from-dir <dir> -o json | jq .vsock_socket` is non-empty for a running restore.