### PR TITLE
fix(clone): emit vsock_socket in `vm clone -o json`

### DIFF
--- a/hypervisor/cloudhypervisor/clone.go
+++ b/hypervisor/cloudhypervisor/clone.go
@@ -140,6 +140,7 @@ func (ch *CloudHypervisor) cloneAfterExtract(ctx context.Context, vmID string, v
 		NetSetup:  net,
 		CreatedAt: now, UpdatedAt: now, StartedAt: &now,
 	}
+	hypervisor.SetRunningSockets(info, runDir)
 	if err := ch.FinalizeClone(ctx, vmID, info, bootCfg, nil, sourceSnapshotID); err != nil {
 		ch.AbortLaunch(ctx, pid, sockPath, runDir, runtimeFiles)
 		return nil, fmt.Errorf("finalize VM record: %w", err)

--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -106,6 +106,7 @@ func (fc *Firecracker) cloneAfterExtract(ctx context.Context, vmID string, vmCfg
 		NetSetup:  net,
 		CreatedAt: now, UpdatedAt: now, StartedAt: &now,
 	}
+	hypervisor.SetRunningSockets(info, runDir)
 	if err := fc.FinalizeClone(ctx, vmID, info, bootCfg, blobIDs, sourceSnapshotID); err != nil {
 		fc.AbortLaunch(ctx, pid, sockPath, runDir, runtimeFiles)
 		return nil, fmt.Errorf("finalize VM record: %w", err)

--- a/hypervisor/inspect.go
+++ b/hypervisor/inspect.go
@@ -107,13 +107,10 @@ func (b *Backend) UpdateRecord(ctx context.Context, vmID string, mutate func(*VM
 	})
 }
 
-// SetRunningSockets fills a running VM's live host-side sockets — the CH API
-// socket, and the hybrid-vsock UDS when it is bound — from runDir. Records
-// built in-process by clone and restore skip ToVM, so they call this to make
-// `-o json` carry the sockets the way inspect and list do.
+// SetRunningSockets fills a running VM's live sockets (CH API socket, vsock UDS
+// when bound) from runDir — for clone/restore records that skip ToVM.
 func SetRunningSockets(info *types.VM, runDir string) {
 	info.SocketPath = SocketPath(runDir)
-	// Empty for legacy VMs whose UDS isn't bound.
 	if p := VsockSockPath(runDir); isVsockBound(p) {
 		info.VsockSocket = p
 	}

--- a/hypervisor/inspect.go
+++ b/hypervisor/inspect.go
@@ -43,12 +43,8 @@ func (b *Backend) ToVM(rec *VMRecord) *types.VM {
 	info := rec.VM
 	info.Hypervisor = b.Typ
 	if info.State == types.VMStateRunning {
-		info.SocketPath = SocketPath(rec.RunDir)
+		SetRunningSockets(&info, rec.RunDir)
 		info.PID, _ = utils.ReadPIDFile(b.PIDFilePath(rec.RunDir))
-		// Empty for legacy VMs whose UDS isn't bound.
-		if p := VsockSockPath(rec.RunDir); isVsockBound(p) {
-			info.VsockSocket = p
-		}
 	}
 	info.SnapshotIDs = maps.Clone(info.SnapshotIDs)
 	return &info
@@ -109,6 +105,18 @@ func (b *Backend) UpdateRecord(ctx context.Context, vmID string, mutate func(*VM
 		}
 		return mutate(r)
 	})
+}
+
+// SetRunningSockets fills a running VM's live host-side sockets — the CH API
+// socket, and the hybrid-vsock UDS when it is bound — from runDir. Records
+// built in-process by clone and restore skip ToVM, so they call this to make
+// `-o json` carry the sockets the way inspect and list do.
+func SetRunningSockets(info *types.VM, runDir string) {
+	info.SocketPath = SocketPath(runDir)
+	// Empty for legacy VMs whose UDS isn't bound.
+	if p := VsockSockPath(runDir); isVsockBound(p) {
+		info.VsockSocket = p
+	}
 }
 
 func isVsockBound(path string) bool {

--- a/hypervisor/restore.go
+++ b/hypervisor/restore.go
@@ -67,10 +67,7 @@ func (b *Backend) FinalizeRestore(ctx context.Context, vmID string, vmCfg *types
 	info.Config = *vmCfg
 	info.State = types.VMStateRunning
 	info.PID = pid
-	info.SocketPath = SocketPath(rec.RunDir)
-	if p := VsockSockPath(rec.RunDir); isVsockBound(p) {
-		info.VsockSocket = p // let `vm restore -o json` carry the vsock UDS, as ToVM does
-	}
+	SetRunningSockets(&info, rec.RunDir)
 	info.StartedAt = &now
 	info.UpdatedAt = now
 	return &info, nil


### PR DESCRIPTION
## Problem

`vm clone --from-dir -o json` reported an empty `vsock_socket` (and `socket_path`), unlike `vm run`/`vm restore`/`vm inspect`. `cloneAfterExtract` (both Cloud Hypervisor and Firecracker) builds the returned `*types.VM` record in-process and never routes it through `ToVM`, so the live host-side sockets stayed zero. `reseedAfterResume`'s internal `refreshVM` does re-`Inspect`, but that record is used only to fire the reseed signal — it is never written back into the record that gets JSON-encoded.

Downstream, sandboxd's pool has to resolve the clone's vsock by polling `vm list` (a second cocoon subprocess) on the claim/refill hot path. `#107` fixed the same class of gap for `vm restore`; clone was missed.

## Fix

Extract `SetRunningSockets(info, runDir)` — the running-socket enrichment `ToVM` and `FinalizeRestore` already did inline (CH API socket unconditionally; hybrid-vsock UDS when bound) — and call it from both clone backends before `FinalizeClone`. `ToVM` and `FinalizeRestore` now call the shared helper too, so there is one definition and clone joins run/restore/inspect in carrying the sockets. The VMM is already resumed (running) when `cloneAfterExtract` builds the record, so the UDS is bound and reported.

## Verification (bare-metal .79, CH backend)

A/B against the same exported golden:

| cocoon | `vm clone --from-dir -o json` → `vsock_socket` |
|---|---|
| system `v0.4.8-master.5beb36a` (no clone fix) | `<empty/absent>` |
| this branch | `/var/lib/cocoon/run/cloudhypervisor/<id>/vsock.uds` |

`socket_path` is likewise populated. Firecracker takes the identical `SetRunningSockets` call. Logs stay on stderr, JSON on stdout (clean parse).

## Gates

- `go build ./...` ✓, `go vet ./hypervisor/...` ✓
- `go test ./hypervisor/...` ✓ (hypervisor + cloudhypervisor + firecracker)
- `golangci-lint run` (pinned v2.9.0) on `GOOS=linux` and `GOOS=darwin` ✓ (0 issues), `golangci-lint fmt --diff` ✓