### PR TITLE
perf(hibernate): direct capture — rename the tmp dir into the local store

### DIFF
--- a/cmd/core/utils.go
+++ b/cmd/core/utils.go
@@ -267,7 +267,7 @@ func PersistSnapshotDir(ctx context.Context, snapBackend snapshot.Snapshot, cfg 
 			return "", fmt.Errorf("save snapshot: %w", err)
 		}
 		if done {
-			log.WithFunc("cmdcore.PersistSnapshotDir").Info(ctx, "saved snapshot data (direct)")
+			log.WithFunc("core.PersistSnapshotDir").Info(ctx, "saved snapshot data (direct)")
 			return id, nil
 		}
 	}
@@ -280,7 +280,7 @@ func PersistSnapshotStream(ctx context.Context, snapBackend snapshot.Snapshot, c
 	defer CloseOnCancel(ctx, stream)()
 	cfg.Name = name
 	cfg.Description = description
-	log.WithFunc("cmdcore.PersistSnapshotStream").Info(ctx, "saving snapshot data ...")
+	log.WithFunc("core.PersistSnapshotStream").Info(ctx, "saving snapshot data ...")
 	snapID, err := snapBackend.Create(ctx, cfg, stream)
 	if err != nil {
 		return "", fmt.Errorf("save snapshot: %w", err)

--- a/cmd/core/utils.go
+++ b/cmd/core/utils.go
@@ -257,6 +257,23 @@ func CaptureSnapshot(ctx context.Context, cmd *cobra.Command, snapBackend snapsh
 	return PersistSnapshotStream(ctx, snapBackend, cfg, stream, name, description)
 }
 
+// PersistSnapshotDir stores a finalized capture dir, preferring a direct in-place move (DirectCreator) when srcDir shares a filesystem with the backend's data dir, and falling back to a tar stream otherwise (cross-filesystem, or a backend without DirectCreator such as a remote store). srcDir is consumed on every path.
+func PersistSnapshotDir(ctx context.Context, snapBackend snapshot.Snapshot, cfg *types.SnapshotConfig, srcDir, name, description string) (string, error) {
+	cfg.Name = name
+	cfg.Description = description
+	if dc, ok := snapBackend.(snapshot.DirectCreator); ok {
+		id, done, err := dc.CreateFromDir(ctx, cfg, srcDir)
+		if err != nil {
+			return "", fmt.Errorf("save snapshot: %w", err)
+		}
+		if done {
+			log.WithFunc("cmdcore.PersistSnapshotDir").Info(ctx, "saved snapshot data (direct)")
+			return id, nil
+		}
+	}
+	return PersistSnapshotStream(ctx, snapBackend, cfg, utils.TarDirStreamWithRemove(srcDir), name, description)
+}
+
 // PersistSnapshotStream labels cfg and stores the stream, closing it either way.
 func PersistSnapshotStream(ctx context.Context, snapBackend snapshot.Snapshot, cfg *types.SnapshotConfig, stream io.ReadCloser, name, description string) (string, error) {
 	defer stream.Close() //nolint:errcheck

--- a/cmd/vm/hibernate.go
+++ b/cmd/vm/hibernate.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"cmp"
 	"fmt"
-	"io"
 
 	"github.com/projecteru2/core/log"
 	"github.com/spf13/cobra"
@@ -45,8 +44,8 @@ func (h Handler) Hibernate(cmd *cobra.Command, args []string) error {
 	logger.Infof(ctx, "hibernating VM %s ...", vmRef)
 	// persist runs inside the pause window; the VMM dies only after it succeeds.
 	var snapID string
-	err = hib.Hibernate(ctx, vmRef, func(cfg *types.SnapshotConfig, stream io.ReadCloser) error {
-		id, pErr := cmdcore.PersistSnapshotStream(ctx, snapBackend, cfg, stream, name, description)
+	err = hib.Hibernate(ctx, vmRef, func(cfg *types.SnapshotConfig, srcDir string) error {
+		id, pErr := cmdcore.PersistSnapshotDir(ctx, snapBackend, cfg, srcDir, name, description)
 		snapID = id
 		return pErr
 	})

--- a/hypervisor/cloudhypervisor/snapshot.go
+++ b/hypervisor/cloudhypervisor/snapshot.go
@@ -20,7 +20,7 @@ func (ch *CloudHypervisor) Snapshot(ctx context.Context, ref string) (*types.Sna
 }
 
 // Hibernate captures like Snapshot but persists and then terminates the VMM inside the pause window instead of resuming.
-func (ch *CloudHypervisor) Hibernate(ctx context.Context, ref string, persist func(cfg *types.SnapshotConfig, stream io.ReadCloser) error) error {
+func (ch *CloudHypervisor) Hibernate(ctx context.Context, ref string, persist func(cfg *types.SnapshotConfig, srcDir string) error) error {
 	return ch.HibernateSequence(ctx, ref, hypervisor.HibernateSpec{
 		SnapshotSpec: ch.snapshotSpec(ctx),
 		Terminate: func(rec *hypervisor.VMRecord, hc *http.Client, pid int) error {

--- a/hypervisor/firecracker/snapshot.go
+++ b/hypervisor/firecracker/snapshot.go
@@ -23,7 +23,7 @@ func (fc *Firecracker) Snapshot(ctx context.Context, ref string) (*types.Snapsho
 }
 
 // Hibernate captures like Snapshot but persists and then terminates the VMM inside the pause window instead of resuming.
-func (fc *Firecracker) Hibernate(ctx context.Context, ref string, persist func(cfg *types.SnapshotConfig, stream io.ReadCloser) error) error {
+func (fc *Firecracker) Hibernate(ctx context.Context, ref string, persist func(cfg *types.SnapshotConfig, srcDir string) error) error {
 	return fc.HibernateSequence(ctx, ref, hypervisor.HibernateSpec{
 		SnapshotSpec: fc.snapshotSpec(ctx),
 		Terminate: func(rec *hypervisor.VMRecord, _ *http.Client, pid int) error {

--- a/hypervisor/hibernate_test.go
+++ b/hypervisor/hibernate_test.go
@@ -3,7 +3,6 @@ package hypervisor
 import (
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -26,9 +25,7 @@ func TestHibernateSequencePersistFailureResumesAndRollsBack(t *testing.T) {
 	b, id := newHibernateTestVM(t)
 	calls := &hibernateCalls{}
 
-	err := b.HibernateSequence(t.Context(), id, hibernateStubSpec(calls), func(_ *types.SnapshotConfig, stream io.ReadCloser) error {
-		_, _ = io.Copy(io.Discard, stream)
-		_ = stream.Close()
+	err := b.HibernateSequence(t.Context(), id, hibernateStubSpec(calls), func(_ *types.SnapshotConfig, _ string) error {
 		return errors.New("store full")
 	})
 	if err == nil || !strings.Contains(err.Error(), "persist snapshot") {
@@ -58,10 +55,12 @@ func TestHibernateSequenceSuccess(t *testing.T) {
 	calls := &hibernateCalls{}
 
 	var gotCfg *types.SnapshotConfig
-	err := b.HibernateSequence(t.Context(), id, hibernateStubSpec(calls), func(cfg *types.SnapshotConfig, stream io.ReadCloser) error {
+	err := b.HibernateSequence(t.Context(), id, hibernateStubSpec(calls), func(cfg *types.SnapshotConfig, srcDir string) error {
 		gotCfg = cfg
-		_, _ = io.Copy(io.Discard, stream)
-		return stream.Close()
+		if _, statErr := os.Stat(srcDir); statErr != nil {
+			return statErr
+		}
+		return os.RemoveAll(srcDir)
 	})
 	if err != nil {
 		t.Fatalf("HibernateSequence: %v", err)
@@ -94,9 +93,8 @@ func TestHibernateSequenceTerminateFailureMarksError(t *testing.T) {
 
 	spec := hibernateStubSpec(calls)
 	spec.Terminate = func(*VMRecord, *http.Client, int) error { return errors.New("kill refused") }
-	err := b.HibernateSequence(t.Context(), id, spec, func(_ *types.SnapshotConfig, stream io.ReadCloser) error {
-		_, _ = io.Copy(io.Discard, stream)
-		return stream.Close()
+	err := b.HibernateSequence(t.Context(), id, spec, func(_ *types.SnapshotConfig, srcDir string) error {
+		return os.RemoveAll(srcDir)
 	})
 	if err == nil || !strings.Contains(err.Error(), "terminate") {
 		t.Fatalf("HibernateSequence: %v, want terminate error", err)

--- a/hypervisor/hypervisor.go
+++ b/hypervisor/hypervisor.go
@@ -45,7 +45,7 @@ type Direct interface {
 	DirectRestore(ctx context.Context, vmRef string, vmCfg *types.VMConfig, srcDir, sourceSnapshotID string) (*types.VM, error)
 }
 
-// Hibernator snapshots and stops atomically: capture, persist, and termination share one pause window, and the VMM dies only after persist succeeds — a failed persist leaves the VM running.
+// Hibernator snapshots and stops atomically: capture, persist, and termination share one pause window, and the VMM dies only after persist succeeds — a failed persist leaves the VM running. persist consumes srcDir (the finalized capture dir) — moving it into a local store or streaming it out — and must return only once the snapshot is durable.
 type Hibernator interface {
-	Hibernate(ctx context.Context, ref string, persist func(cfg *types.SnapshotConfig, stream io.ReadCloser) error) error
+	Hibernate(ctx context.Context, ref string, persist func(cfg *types.SnapshotConfig, srcDir string) error) error
 }

--- a/hypervisor/snapshot.go
+++ b/hypervisor/snapshot.go
@@ -95,7 +95,7 @@ func (b *Backend) SnapshotSequence(ctx context.Context, ref string, spec Snapsho
 }
 
 // HibernateSequence is SnapshotSequence with persist inside the pause window and terminate instead of resume: the snapshot point and the stop coincide, any failure before terminate resumes the VM, and a failed terminate marks it error.
-func (b *Backend) HibernateSequence(ctx context.Context, ref string, spec HibernateSpec, persist func(cfg *types.SnapshotConfig, stream io.ReadCloser) error) (err error) {
+func (b *Backend) HibernateSequence(ctx context.Context, ref string, spec HibernateSpec, persist func(cfg *types.SnapshotConfig, srcDir string) error) (err error) {
 	vmID, rec, tmpDir, unlock, err := b.prepareSnapshot(ctx, ref)
 	if err != nil {
 		return err
@@ -128,7 +128,7 @@ func (b *Backend) HibernateSequence(ctx context.Context, ref string, spec Hibern
 			if sErr != nil {
 				return failResume(sErr)
 			}
-			if pErr := persist(cfg, utils.TarDirStreamWithRemove(tmpDir)); pErr != nil {
+			if pErr := persist(cfg, tmpDir); pErr != nil {
 				b.UnrecordSnapshot(ctx, vmID, cfg.ID)
 				return failResume(fmt.Errorf("persist snapshot: %w", pErr))
 			}

--- a/snapshot/localfile/localfile.go
+++ b/snapshot/localfile/localfile.go
@@ -2,10 +2,12 @@ package localfile
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
 	"os"
+	"syscall"
 	"time"
 
 	"github.com/projecteru2/core/log"
@@ -23,6 +25,8 @@ import (
 )
 
 const typ = "localfile"
+
+var osRename = os.Rename // seam for EXDEV fallback tests
 
 var (
 	_ snapshot.Snapshot           = (*LocalFile)(nil)
@@ -173,13 +177,20 @@ func (lf *LocalFile) CreateFromDir(ctx context.Context, cfg *types.SnapshotConfi
 		}
 	}()
 
-	// Atomic move: the snapshot is complete and durable before we return, so
-	// hibernate may terminate the VMM. SameFilesystem ruled out EXDEV.
-	if err = os.Rename(srcDir, dataDir); err != nil {
+	// A st_dev match can't rule out EXDEV (bind mounts): roll back and report ok=false so the caller streams via tar.
+	if err = osRename(srcDir, dataDir); err != nil {
+		if errors.Is(err, syscall.EXDEV) {
+			lf.rollbackCreate(ctx, id, cfg.Name)
+			return "", false, nil
+		}
 		return "", false, fmt.Errorf("move capture into store: %w", err)
 	}
 	if err = os.Chmod(dataDir, 0o750); err != nil { //nolint:gosec // match the store's 0o750 data dirs (MkdirAll in Create)
 		return "", false, fmt.Errorf("chmod data dir: %w", err)
+	}
+	// Durable before kill: the VMM dies once we return and a bare rename fsyncs nothing, so sync files and dir entries before finalize (the tar path fsyncs per file in ExtractTar).
+	if err = utils.SyncTree(dataDir); err != nil {
+		return "", false, fmt.Errorf("sync snapshot to disk: %w", err)
 	}
 
 	size, sizeErr := utils.DirSize(dataDir)

--- a/snapshot/localfile/localfile.go
+++ b/snapshot/localfile/localfile.go
@@ -27,6 +27,7 @@ const typ = "localfile"
 var (
 	_ snapshot.Snapshot           = (*LocalFile)(nil)
 	_ snapshot.Direct             = (*LocalFile)(nil)
+	_ snapshot.DirectCreator      = (*LocalFile)(nil)
 	_ snapshot.CompressedExporter = (*LocalFile)(nil)
 	_ snapshot.DirectoryExporter  = (*LocalFile)(nil)
 )
@@ -135,6 +136,72 @@ func (lf *LocalFile) Create(ctx context.Context, cfg *types.SnapshotConfig, stre
 
 	emitSnapStart(ctx, lf.metering, id, cfg.Hypervisor, size, finalizedAt)
 	return id, nil
+}
+
+// CreateFromDir persists a snapshot by renaming srcDir into the store data dir — one atomic move, no tar read+extract — when they share a filesystem. It reports ok=false (srcDir untouched) across filesystems so the caller streams instead. The placeholder→move→finalize protocol matches Create, so a mid-flight crash leaves a GC-collectable pending record and the layout is byte-for-byte what Create produces.
+func (lf *LocalFile) CreateFromDir(ctx context.Context, cfg *types.SnapshotConfig, srcDir string) (_ string, _ bool, err error) {
+	id := cfg.ID
+	if id == "" {
+		return "", false, fmt.Errorf("snapshot ID is required (must be set by caller)")
+	}
+	if err = cfg.Validate(); err != nil {
+		return "", false, err
+	}
+
+	sameFS, err := utils.SameFilesystem(srcDir, lf.conf.DataDir())
+	if err != nil {
+		return "", false, fmt.Errorf("check filesystem: %w", err)
+	}
+	if !sameFS {
+		return "", false, nil
+	}
+
+	dataDir := lf.conf.SnapshotDataDir(id)
+	now := time.Now()
+	if err = lf.insertRecord(ctx, id, cfg.Name, &snapshot.SnapshotRecord{
+		Snapshot: types.Snapshot{SnapshotConfig: *cfg, CreatedAt: now},
+		Pending:  true,
+		DataDir:  dataDir,
+	}); err != nil {
+		return "", false, err
+	}
+
+	defer func() {
+		if err != nil {
+			os.RemoveAll(dataDir) //nolint:errcheck,gosec
+			lf.rollbackCreate(ctx, id, cfg.Name)
+		}
+	}()
+
+	// Atomic move: the snapshot is complete and durable before we return, so
+	// hibernate may terminate the VMM. SameFilesystem ruled out EXDEV.
+	if err = os.Rename(srcDir, dataDir); err != nil {
+		return "", false, fmt.Errorf("move capture into store: %w", err)
+	}
+	if err = os.Chmod(dataDir, 0o750); err != nil { //nolint:gosec // match the store's 0o750 data dirs (MkdirAll in Create)
+		return "", false, fmt.Errorf("chmod data dir: %w", err)
+	}
+
+	size, sizeErr := utils.DirSize(dataDir)
+	if sizeErr != nil {
+		return "", false, fmt.Errorf("compute data dir size: %w", sizeErr)
+	}
+	finalizedAt := time.Now()
+	if err = lf.store.Update(ctx, func(idx *snapshot.SnapshotIndex) error {
+		rec := idx.Snapshots[id]
+		if rec == nil {
+			return fmt.Errorf("snapshot %q disappeared from index", id)
+		}
+		rec.Pending = false
+		rec.SizeBytes = size
+		rec.LastAccessedAt = finalizedAt
+		return nil
+	}); err != nil {
+		return "", false, fmt.Errorf("finalize snapshot: %w", err)
+	}
+
+	emitSnapStart(ctx, lf.metering, id, cfg.Hypervisor, size, finalizedAt)
+	return id, true, nil
 }
 
 // List returns all snapshots (excluding pending ones).

--- a/snapshot/localfile/localfile.go
+++ b/snapshot/localfile/localfile.go
@@ -26,14 +26,14 @@ import (
 
 const typ = "localfile"
 
-var osRename = os.Rename // seam for EXDEV fallback tests
-
 var (
 	_ snapshot.Snapshot           = (*LocalFile)(nil)
 	_ snapshot.Direct             = (*LocalFile)(nil)
 	_ snapshot.DirectCreator      = (*LocalFile)(nil)
 	_ snapshot.CompressedExporter = (*LocalFile)(nil)
 	_ snapshot.DirectoryExporter  = (*LocalFile)(nil)
+
+	osRename = os.Rename // seam for EXDEV fallback tests
 )
 
 // Option configures a LocalFile constructed via New.

--- a/snapshot/localfile/localfile_test.go
+++ b/snapshot/localfile/localfile_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"io"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -113,6 +114,53 @@ func TestDeleteOneIdempotentDoesNotEmitTwice(t *testing.T) {
 	}
 	if entries[1].Hypervisor != "cloud-hypervisor" {
 		t.Errorf("stop entry has Hypervisor=%q; phantom emits leak as empty", entries[1].Hypervisor)
+	}
+}
+
+func TestCreateFromDirDirectMatchesCreateLayout(t *testing.T) {
+	rec := meteringcapture.New()
+	lf := newTestLFWithRecorder(t, rec)
+	ctx := t.Context()
+
+	files := map[string][]byte{
+		"memory-range-0": []byte("guest-ram"),
+		"config.json":    []byte(`{"disks":[]}`),
+		"cocoon.json":    []byte(`{"storage_configs":[]}`),
+	}
+
+	// A capture dir under the store root shares its filesystem, so the direct
+	// (rename) path is taken rather than the cross-fs streaming fallback.
+	srcDir := writeCaptureDir(t, filepath.Join(lf.conf.RootDir, "capture-src"), files)
+	id, ok, err := lf.CreateFromDir(ctx, &types.SnapshotConfig{
+		ID: testID(t), Name: "direct-snap", Hypervisor: "cloud-hypervisor",
+	}, srcDir)
+	if err != nil {
+		t.Fatalf("CreateFromDir: %v", err)
+	}
+	if !ok {
+		t.Fatal("CreateFromDir took the fallback path; expected direct (same filesystem)")
+	}
+	if _, statErr := os.Stat(srcDir); !errors.Is(statErr, fs.ErrNotExist) {
+		t.Errorf("srcDir survived the move: stat err = %v", statErr)
+	}
+	if _, err := lf.Inspect(ctx, id); err != nil {
+		t.Fatalf("Inspect after CreateFromDir: %v", err)
+	}
+	if entries := rec.Entries(); len(entries) != 1 || entries[0].Kind != metering.KindSnapStorageStart {
+		t.Fatalf("metering = %v, want one snap.storage.start", kinds(rec.Entries()))
+	}
+
+	// The on-disk layout is byte-for-byte what the tar path (Create) produces.
+	id2, err := lf.Create(ctx, &types.SnapshotConfig{
+		ID: testID(t), Name: "streamed-snap", Hypervisor: "cloud-hypervisor",
+	}, makeTar(t, files))
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	direct := readDirFiles(t, lf.conf.SnapshotDataDir(id))
+	streamed := readDirFiles(t, lf.conf.SnapshotDataDir(id2))
+	if !maps.Equal(direct, streamed) {
+		t.Errorf("direct layout %v differs from tar layout %v", direct, streamed)
 	}
 }
 
@@ -1222,6 +1270,41 @@ func newTestLFWithRecorder(t *testing.T, rec metering.Recorder) *LocalFile {
 		t.Fatalf("New: %v", err)
 	}
 	return lf
+}
+
+// writeCaptureDir stages a capture directory (like a hypervisor's snapshot tmp dir) for CreateFromDir.
+func writeCaptureDir(t *testing.T, dir string, files map[string][]byte) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for name, data := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// readDirFiles reads a directory's regular files into a name→content map.
+func readDirFiles(t *testing.T, dir string) map[string]string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	out := make(map[string]string, len(entries))
+	for _, e := range entries {
+		if !e.Type().IsRegular() {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		out[e.Name()] = string(data)
+	}
+	return out
 }
 
 // makeTar builds a tar archive in memory from a map of name→content.

--- a/snapshot/localfile/localfile_test.go
+++ b/snapshot/localfile/localfile_test.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"maps"
@@ -191,8 +192,19 @@ func TestCreateFromDirEXDEVFallsBack(t *testing.T) {
 	if _, statErr := os.Stat(srcDir); statErr != nil {
 		t.Errorf("srcDir removed on EXDEV fallback: %v", statErr)
 	}
-	if _, inspectErr := lf.Inspect(ctx, id); inspectErr == nil {
-		t.Errorf("snapshot %s still indexed after EXDEV fallback; pending record not rolled back", id)
+	// Check the index directly: Inspect hides pending records, so it cannot
+	// distinguish "rolled back" from "stale pending left behind" — and a stale
+	// name reservation would fail the tar-fallback Create with "already in use".
+	if err := lf.store.With(ctx, func(idx *snapshot.SnapshotIndex) error {
+		if _, stale := idx.Snapshots[id]; stale {
+			return fmt.Errorf("pending record %s still in index", id)
+		}
+		if _, stale := idx.Names["exdev-snap"]; stale {
+			return fmt.Errorf("name %q still reserved", "exdev-snap")
+		}
+		return nil
+	}); err != nil {
+		t.Errorf("EXDEV rollback incomplete: %v", err)
 	}
 	if n := len(rec.Entries()); n != 0 {
 		t.Errorf("metering emitted %d entries on fallback, want 0", n)

--- a/snapshot/localfile/localfile_test.go
+++ b/snapshot/localfile/localfile_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/cocoonstack/cocoon/config"
@@ -161,6 +162,40 @@ func TestCreateFromDirDirectMatchesCreateLayout(t *testing.T) {
 	streamed := readDirFiles(t, lf.conf.SnapshotDataDir(id2))
 	if !maps.Equal(direct, streamed) {
 		t.Errorf("direct layout %v differs from tar layout %v", direct, streamed)
+	}
+}
+
+func TestCreateFromDirEXDEVFallsBack(t *testing.T) {
+	rec := meteringcapture.New()
+	lf := newTestLFWithRecorder(t, rec)
+	ctx := t.Context()
+
+	// st_dev matches but rename EXDEVs (as on a bind mount): must roll back the pending record, leave srcDir intact, and report ok=false.
+	orig := osRename
+	osRename = func(string, string) error { return syscall.EXDEV }
+	t.Cleanup(func() { osRename = orig })
+
+	id := testID(t)
+	srcDir := writeCaptureDir(t, filepath.Join(lf.conf.RootDir, "capture-exdev"), map[string][]byte{
+		"memory-range-0": []byte("ram"),
+	})
+	gotID, ok, err := lf.CreateFromDir(ctx, &types.SnapshotConfig{
+		ID: id, Name: "exdev-snap", Hypervisor: "cloud-hypervisor",
+	}, srcDir)
+	if err != nil {
+		t.Fatalf("CreateFromDir on EXDEV: unexpected err = %v", err)
+	}
+	if ok || gotID != "" {
+		t.Fatalf("CreateFromDir = (%q, %v), want fallback (\"\", false)", gotID, ok)
+	}
+	if _, statErr := os.Stat(srcDir); statErr != nil {
+		t.Errorf("srcDir removed on EXDEV fallback: %v", statErr)
+	}
+	if _, inspectErr := lf.Inspect(ctx, id); inspectErr == nil {
+		t.Errorf("snapshot %s still indexed after EXDEV fallback; pending record not rolled back", id)
+	}
+	if n := len(rec.Entries()); n != 0 {
+		t.Errorf("metering emitted %d entries on fallback, want 0", n)
 	}
 }
 

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -13,6 +13,11 @@ type Direct interface {
 	DataDir(ctx context.Context, ref string) (string, types.SnapshotConfig, error)
 }
 
+// DirectCreator is an optional interface for snapshot backends that can ingest a capture directory in place — moving it into the store instead of a tar round-trip — when srcDir shares a filesystem with the store's data dir. ok is false (srcDir left intact) when the direct path is unavailable, so the caller falls back to Create with a stream.
+type DirectCreator interface {
+	CreateFromDir(ctx context.Context, cfg *types.SnapshotConfig, srcDir string) (id string, ok bool, err error)
+}
+
 // CompressedExporter is an optional interface for backends that support exporting with compression (e.g. gzip). The default Export produces raw tar.
 type CompressedExporter interface {
 	ExportCompressed(ctx context.Context, ref string) (io.ReadCloser, error)

--- a/utils/atomic.go
+++ b/utils/atomic.go
@@ -82,3 +82,32 @@ func SyncParentDir(dir string) error {
 	}
 	return nil
 }
+
+// SyncTree fsyncs every regular file directly under dir (snapshot dirs are flat), then dir and its parent — the durable-before-kill barrier hibernate needs, since a bare rename fsyncs nothing.
+func SyncTree(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if !e.Type().IsRegular() {
+			continue
+		}
+		if err := syncFile(filepath.Join(dir, e.Name())); err != nil {
+			return err
+		}
+	}
+	if err := SyncParentDir(dir); err != nil {
+		return err
+	}
+	return SyncParentDir(filepath.Dir(dir))
+}
+
+func syncFile(path string) (err error) {
+	f, err := os.Open(path) //nolint:gosec // path is a cocoon-managed snapshot file
+	if err != nil {
+		return err
+	}
+	defer func() { err = errors.Join(err, f.Close()) }()
+	return f.Sync()
+}

--- a/utils/atomic_test.go
+++ b/utils/atomic_test.go
@@ -58,6 +58,25 @@ func TestAtomicWriteFile_Overwrite(t *testing.T) {
 	}
 }
 
+func TestSyncTree(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "snap")
+	if err := os.MkdirAll(sub, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"memory-range-0", "config.json"} {
+		if err := os.WriteFile(filepath.Join(sub, name), []byte("data"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := SyncTree(sub); err != nil {
+		t.Fatalf("SyncTree: %v", err)
+	}
+	if err := SyncTree(filepath.Join(dir, "nonexistent")); err == nil {
+		t.Error("SyncTree on missing dir: want error, got nil")
+	}
+}
+
 func TestAtomicWriteFile_EmptyData(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "empty.dat")

--- a/utils/file.go
+++ b/utils/file.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/projecteru2/core/log"
@@ -16,6 +17,27 @@ import (
 
 // StaleTempAge is the age threshold for removing stale temp files during GC.
 const StaleTempAge = time.Hour
+
+// SameFilesystem reports whether a and b live on the same filesystem (matching st_dev), so a rename or hardlink between them can succeed rather than failing with EXDEV.
+func SameFilesystem(a, b string) (bool, error) {
+	sa, err := os.Stat(a)
+	if err != nil {
+		return false, err
+	}
+	sb, err := os.Stat(b)
+	if err != nil {
+		return false, err
+	}
+	da, ok := sa.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false, nil
+	}
+	db, ok := sb.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false, nil
+	}
+	return da.Dev == db.Dev, nil
+}
 
 // EnsureDirs creates all directories with 0o750 permissions.
 func EnsureDirs(dirs ...string) error {


### PR DESCRIPTION
## Problem

Hibernate (memory snapshot → disk) costs ~330–460 ms bare metal, ~10× the
~30 ms restore. The whole cost lands **inside the single VM-pause window**,
and the reason is that the memory image is written, read back, and written
again — three full-image I/O passes, serialized before the VMM is killed:

1. Cloud Hypervisor's `vm.snapshot` writes guest memory + state into the
   capture tmp dir (`hypervisor/cloudhypervisor/snapshot.go` → `snapshotVM`).
2. The COW disk is reflinked in (cheap).
3. The whole tmp dir is re-read and tar-streamed out
   (`utils/stream.go` `TarDirStream`).
4. The tar is extracted into a fresh store data dir
   (`snapshot/localfile` `Create` → `utils.ExtractTar`).

So the memory image is **written (CH) → read (tar) → written (extract)**.

Restore is fast because it already has a **Direct** path: it hardlink-merges
the durable snapshot dir straight into the run dir with no tar round-trip
(`hypervisor/restore.go` `DirectRestoreSequence`, chosen in `cmd/vm/run.go`
when the backend is the local `localfile.LocalFile`). The asymmetry: Direct
existed for the **read** side (restore/clone) but not the **write** side
(hibernate/capture). `cmd/vm/hibernate.go` always called the streaming
`PersistSnapshotStream`, even when the backend is the same same-filesystem
`LocalFile`.

## Change

Add a Direct **capture** path mirroring restore. When the snapshot store is a
local `LocalFile` on the **same filesystem** as the CH capture tmp dir, move
the finalized tmp dir straight into the store's data dir with a single atomic
`os.Rename` instead of `TarDirStream` + `ExtractTar`. CH's own `vm.snapshot`
memory write is unavoidable and stays; this removes one of the two remaining
full-image passes — the tar read + the extract write collapse into one
metadata operation (rename, no bytes copied).

- `snapshot.DirectCreator` — new optional interface: `CreateFromDir(ctx, cfg, srcDir) (id, ok, err)`. `ok=false` (srcDir untouched) means "direct path unavailable, caller should stream".
- `localfile.LocalFile.CreateFromDir` — same-fs gate, then insert-pending → `os.Rename` → finalize, reusing the exact placeholder→finalize protocol as `Create`.
- `utils.SameFilesystem` — `st_dev` comparison so we only attempt rename when it can succeed (else EXDEV).
- The hibernate persist callback now receives the finalized capture **dir** instead of a pre-built stream, so the `cmd` layer (which knows the backend) picks direct vs. stream in `cmdcore.PersistSnapshotDir`. `Hibernator` / `HibernateSequence` / CH + FC `Hibernate` signatures updated accordingly.

The hot-path cost on the **claim/restore** path is zero — this only touches
the capture/persist side of hibernate.

## Correctness argument

**Atomic persist-before-kill.** Hibernate's contract is that the snapshot is
durably persisted before the VMM is terminated. `CreateFromDir` moves the
whole dir with one `os.Rename` (atomic, all-or-nothing) and flips the record
`Pending=false` via the same flock-serialized `store.Update` as `Create`,
*before* returning. `HibernateSequence` only calls `Terminate` after `persist`
returns nil — unchanged. A crash between rename and finalize leaves a pending
record for GC plus complete data in place (identical to `Create`'s crash
window); a crash before rename leaves the tmp dir (cleaned by the error defer)
and no finalized snapshot — the VM resumes. Durability is no weaker than the
existing streaming `Create` (same `store.Update`, no extra fsync claimed).

**Same-filesystem fallback.** `SameFilesystem(srcDir, DataDir())` gates the
direct path up front (before any record is inserted), mirroring how restore's
`CloneSnapshotFiles` handles cross-device by falling back. Cross-fs (or a
non-`LocalFile`, e.g. a remote store) → `ok=false` → `PersistSnapshotDir`
falls through to the unchanged `TarDirStream`/`ExtractTar` `Create`. srcDir is
consumed on every path.

**Identical on-disk layout.** The rename moves the same file set CH/finalize
already wrote (memory-range-*, config.json, state.json, reflinked COW +
data-*.raw, and the `cocoon.json` sidecar). File names and logical contents
are byte-for-byte what `ExtractTar` produces, so `preflightRestore`
(`validateSnapshotIntegrity`), `List`, and GC are unaffected. `SizeBytes` uses
the same `utils.DirSize` (logical `info.Size()`), so accounting matches too.
`TestCreateFromDirDirectMatchesCreateLayout` asserts the direct and streamed
data dirs are equal. The one non-bit-identical aspect is *physical* block
allocation: `ExtractTar` zero-punches sparse holes, whereas rename preserves
CH's exact allocation — transparent to every reader (holes and explicit zero
blocks both read as zeros) and never larger in logical size.

**Streaming path preserved.** The generic `Snapshot` streaming and any
cross-node send still use `TarDirStream`; only the local same-fs hibernate
persist takes the new path. FC hibernate shares the store layer, so it also
benefits when its capture dir is same-fs.

## Gates (ran locally; commands + real output)

- `go build ./...` → exit 0
- `GOOS=linux GOARCH=amd64 go vet ./...` → exit 0; `GOOS=darwin GOARCH=amd64 go vet ./...` → exit 0
- `go test -race -count=1 ./...` → all packages `ok` (full suite), incl. `./hypervisor/...`, `./snapshot/...`, `./cmd/core/...`, `./utils/...`
- `make lint` (pinned golangci-lint **v2.9.0**, linux + darwin) → **0 issues** both platforms
- goimports clean on all touched files

`make fmt-check` reports pre-existing gofumpt drift on files this PR does not
touch (the Makefile installs `gofumpt@latest`, now v0.9.2, which reformats
code already on `master`); every file this PR touches is gofumpt- and
goimports-clean.

## Acceptance gate before merge

No KVM in the dev environment, so this is verified by build/vet/test/lint + the
correctness argument above. **A bare-metal hibernate A/B on the .79 testbed is
the acceptance gate before merge** — measure hibernate wall-time (expect the
tar read + extract passes to disappear) and confirm a Direct-captured snapshot
restores cleanly.
