### PR TITLE
clone: hot-plug cidata by role, not slice position

### DIFF
--- a/hypervisor/cloudhypervisor/clone.go
+++ b/hypervisor/cloudhypervisor/clone.go
@@ -173,10 +173,13 @@ func (ch *CloudHypervisor) restoreAndResumeClone(
 	}
 
 	if !opts.directBoot && !opts.vmCfg.Windows && !opts.hadCidataInSnapshot {
-		if len(opts.storageConfigs) == 0 {
+		// Select by role, not position: new --data-disk configs are appended after
+		// the cidata entry, so the last element is not necessarily cidata.
+		i := slices.IndexFunc(opts.storageConfigs, hasCidataRole)
+		if i < 0 {
 			return fmt.Errorf("vm.add-disk (cidata): missing storage config")
 		}
-		cidataDisk := storageConfigToDisk(opts.storageConfigs[len(opts.storageConfigs)-1], opts.vmCfg.CPU, opts.vmCfg.DiskQueueSize, opts.vmCfg.NoDirectIO)
+		cidataDisk := storageConfigToDisk(opts.storageConfigs[i], opts.vmCfg.CPU, opts.vmCfg.DiskQueueSize, opts.vmCfg.NoDirectIO)
 		if err = addDiskVM(ctx, hc, cidataDisk); err != nil {
 			return fmt.Errorf("vm.add-disk (cidata): %w", err)
 		}

--- a/hypervisor/cloudhypervisor/clone_test.go
+++ b/hypervisor/cloudhypervisor/clone_test.go
@@ -2,9 +2,13 @@ package cloudhypervisor
 
 import (
 	"encoding/json"
+	"net"
+	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/cocoonstack/cocoon/hypervisor"
@@ -620,5 +624,64 @@ func basePatchOpts() *patchOptions {
 		},
 		consoleSock: "/new/console.sock",
 		directBoot:  true,
+	}
+}
+
+func TestRestoreAndResumeCloneHotplugsCidataByRole(t *testing.T) {
+	// Short dir: t.TempDir embeds the test name and busts the unix sockaddr limit.
+	sockDir, err := os.MkdirTemp("", "ch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sockDir) })
+	sock := filepath.Join(sockDir, "a.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	var (
+		mu    sync.Mutex
+		added []string
+	)
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "vm.add-disk") {
+			var d chDisk
+			if err := json.NewDecoder(r.Body).Decode(&d); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			added = append(added, d.Path)
+			mu.Unlock()
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})}
+	go srv.Serve(ln) //nolint:errcheck
+	t.Cleanup(func() { _ = srv.Close() })
+
+	// Snapshot lacked cidata, so ensureCloneCidata appended one — and the clone's
+	// new --data-disk config landed after it. The hot-plug must pick the Role
+	// match, not the last element (which double-attached the data disk and never
+	// attached cidata).
+	storageConfigs := []*types.StorageConfig{
+		{Path: "/store/cow.raw", Role: types.StorageRoleCOW, Serial: "cocoon-cow"},
+		{Path: "/run/cidata.img", RO: true, Role: types.StorageRoleCidata},
+		{Path: "/run/extra.raw", Role: types.StorageRoleData, Serial: "extra"},
+	}
+	ch := &CloudHypervisor{}
+	if err := ch.restoreAndResumeClone(t.Context(), 0, sock, t.TempDir(), &cloneResumeOpts{
+		vmCfg:          &types.VMConfig{Config: types.Config{CPU: 2}},
+		storageConfigs: storageConfigs,
+		dataDisks:      storageConfigs[2:],
+		snapshotCfg:    &chVMConfig{},
+	}); err != nil {
+		t.Fatalf("restoreAndResumeClone: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	want := []string{"/run/cidata.img", "/run/extra.raw"}
+	if !slices.Equal(added, want) {
+		t.Fatalf("vm.add-disk paths = %v, want %v", added, want)
 	}
 }


### PR DESCRIPTION
## Problem

`vm clone <snapshot> --data-disk ...` on a snapshot that lacks a cidata disk (any non-Windows, non-direct-boot cloudimg VM snapshotted after its first restart) hot-adds the wrong disk:

- `restoreAndResumeClone` assumed the **last** storage config is the cidata disk, but `cloneAfterExtract` appends the new `--data-disk` configs **after** the cidata entry that `ensureCloneCidata` adds.
- Result: the new data disk is attached **twice** (once mislabeled as cidata, once by the data-disk loop) and the real cidata image is **never** attached, so the guest boots without its NoCloud datasource.

## Fix

Select the hot-plug candidate by `StorageRoleCidata` (`slices.IndexFunc`) instead of by slice position.

## Test

`TestRestoreAndResumeCloneHotplugsCidataByRole` drives `restoreAndResumeClone` against a fake CH API server on a unix socket and asserts the exact `vm.add-disk` sequence: with configs `[cow, cidata, data]` it must be `[cidata, data]`; the old code produced `[data, data]`.
