### PR TITLE
cni: attempt every NIC teardown before the DB sweep

### DIFF
--- a/network/cni/cni.go
+++ b/network/cni/cni.go
@@ -26,7 +26,11 @@ import (
 
 const typ = "cni"
 
-var _ network.Network = (*CNI)(nil)
+var (
+	_ network.Network = (*CNI)(nil)
+
+	deleteTAPFn = deleteTAPInNetns // seam for cross-platform teardown tests
+)
 
 // CNI implements network.Network using CNI plugins with per-VM netns + bridge + tap.
 type CNI struct {
@@ -130,7 +134,7 @@ func (c *CNI) deleteVM(ctx context.Context, vmID string) error {
 	}
 	// Run even when records is empty: a VM resized to 0 NICs still owns its netns.
 	nsPath := netnsPath(vmID)
-	_ = c.tearDownNICs(ctx, vmID, nsPath, records, false)
+	_, _ = c.tearDownNICs(ctx, vmID, nsPath, records, false)
 	nsName := netnsName(vmID)
 	if err := deleteNetns(ctx, nsName); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("remove netns %s: %w", nsPath, err)
@@ -142,13 +146,16 @@ func (c *CNI) deleteVM(ctx context.Context, vmID string) error {
 	return c.deleteRecords(ctx, allIDs)
 }
 
-// tearDownNICs runs CNI DEL (+ optional TAP delete) on every record, joining per-record
-// failures — the caller sweeps the DB afterwards, so a skipped record never gets another attempt.
-func (c *CNI) tearDownNICs(ctx context.Context, vmID, nsPath string, records []networkRecord, deleteTAP bool) error {
+// tearDownNICs runs CNI DEL (+ optional TAP delete) on every record, returning the IDs of
+// fully-torn-down records and the joined per-record failures. Callers sweep only the
+// returned IDs: a failed NIC keeps its record so retry / vm rm / GC — which all walk the
+// DB — can still release its CNI resources (the IPAM lease foremost).
+func (c *CNI) tearDownNICs(ctx context.Context, vmID, nsPath string, records []networkRecord, deleteTAP bool) ([]string, error) {
 	logger := log.WithFunc("cni.tearDownNICs")
 	if c.cniConf == nil {
-		return c.errNoConflist()
+		return nil, c.errNoConflist()
 	}
+	downIDs := make([]string, 0, len(records))
 	var errs []error
 	for _, rec := range records {
 		var recErr error
@@ -169,7 +176,7 @@ func (c *CNI) tearDownNICs(ctx context.Context, vmID, nsPath string, records []n
 			var idx int
 			if _, scanErr := fmt.Sscanf(rec.IfName, "eth%d", &idx); scanErr != nil {
 				logger.Warnf(ctx, "parse ifname %q for %s: %v (skip tap delete)", rec.IfName, vmID, scanErr)
-			} else if delErr := deleteTAPInNetns(nsPath, tapNameForVM(vmID, idx)); delErr != nil {
+			} else if delErr := deleteTAPFn(nsPath, tapNameForVM(vmID, idx)); delErr != nil {
 				if recErr == nil {
 					recErr = fmt.Errorf("delete tap %s: %w", tapNameForVM(vmID, idx), delErr)
 				}
@@ -178,9 +185,11 @@ func (c *CNI) tearDownNICs(ctx context.Context, vmID, nsPath string, records []n
 		}
 		if recErr != nil {
 			errs = append(errs, recErr)
+			continue
 		}
+		downIDs = append(downIDs, rec.ID)
 	}
-	return errors.Join(errs...)
+	return downIDs, errors.Join(errs...)
 }
 
 func (c *CNI) deleteRecords(ctx context.Context, ids []string) error {

--- a/network/cni/cni.go
+++ b/network/cni/cni.go
@@ -29,7 +29,9 @@ const typ = "cni"
 var (
 	_ network.Network = (*CNI)(nil)
 
-	deleteTAPFn = deleteTAPInNetns // seam for cross-platform teardown tests
+	// Seams for cross-platform teardown tests (netns/TAP ops are linux-only).
+	deleteTAPFn   = deleteTAPInNetns
+	deleteNetnsFn = deleteNetns
 )
 
 // CNI implements network.Network using CNI plugins with per-VM netns + bridge + tap.
@@ -134,16 +136,13 @@ func (c *CNI) deleteVM(ctx context.Context, vmID string) error {
 	}
 	// Run even when records is empty: a VM resized to 0 NICs still owns its netns.
 	nsPath := netnsPath(vmID)
-	_, _ = c.tearDownNICs(ctx, vmID, nsPath, records, false)
+	// Sweep only released records: a failed DEL keeps its record so GC retries the release.
+	downIDs, _ := c.tearDownNICs(ctx, vmID, nsPath, records, false)
 	nsName := netnsName(vmID)
-	if err := deleteNetns(ctx, nsName); err != nil && !errors.Is(err, fs.ErrNotExist) {
+	if err := deleteNetnsFn(ctx, nsName); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("remove netns %s: %w", nsPath, err)
 	}
-	allIDs := make([]string, 0, len(records))
-	for _, rec := range records {
-		allIDs = append(allIDs, rec.ID)
-	}
-	return c.deleteRecords(ctx, allIDs)
+	return c.deleteRecords(ctx, downIDs)
 }
 
 // tearDownNICs runs CNI DEL (+ optional TAP delete) on every record, returning the fully-torn-down record IDs (the caller's sweep set) and the joined failures.

--- a/network/cni/cni.go
+++ b/network/cni/cni.go
@@ -29,9 +29,11 @@ const typ = "cni"
 var (
 	_ network.Network = (*CNI)(nil)
 
-	// Seams for cross-platform teardown tests (netns/TAP ops are linux-only).
-	deleteTAPFn   = deleteTAPInNetns
-	deleteNetnsFn = deleteNetns
+	// Seams for cross-platform lifecycle tests (netns/TAP ops are linux-only).
+	deleteTAPFn       = deleteTAPInNetns
+	deleteNetnsFn     = deleteNetns
+	ensureNetnsFn     = ensureNetns
+	setupTCRedirectFn = setupTCRedirect
 )
 
 // CNI implements network.Network using CNI plugins with per-VM netns + bridge + tap.

--- a/network/cni/cni.go
+++ b/network/cni/cni.go
@@ -146,10 +146,7 @@ func (c *CNI) deleteVM(ctx context.Context, vmID string) error {
 	return c.deleteRecords(ctx, allIDs)
 }
 
-// tearDownNICs runs CNI DEL (+ optional TAP delete) on every record, returning the IDs of
-// fully-torn-down records and the joined per-record failures. Callers sweep only the
-// returned IDs: a failed NIC keeps its record so retry / vm rm / GC — which all walk the
-// DB — can still release its CNI resources (the IPAM lease foremost).
+// tearDownNICs runs CNI DEL (+ optional TAP delete) on every record, returning the fully-torn-down record IDs (the caller's sweep set) and the joined failures.
 func (c *CNI) tearDownNICs(ctx context.Context, vmID, nsPath string, records []networkRecord, deleteTAP bool) ([]string, error) {
 	logger := log.WithFunc("cni.tearDownNICs")
 	if c.cniConf == nil {

--- a/network/cni/cni.go
+++ b/network/cni/cni.go
@@ -130,7 +130,7 @@ func (c *CNI) deleteVM(ctx context.Context, vmID string) error {
 	}
 	// Run even when records is empty: a VM resized to 0 NICs still owns its netns.
 	nsPath := netnsPath(vmID)
-	_ = c.tearDownNICs(ctx, vmID, nsPath, records, false, true)
+	_ = c.tearDownNICs(ctx, vmID, nsPath, records, false)
 	nsName := netnsName(vmID)
 	if err := deleteNetns(ctx, nsName); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("remove netns %s: %w", nsPath, err)
@@ -142,15 +142,14 @@ func (c *CNI) deleteVM(ctx context.Context, vmID string) error {
 	return c.deleteRecords(ctx, allIDs)
 }
 
-// tearDownNICs runs CNI DEL (+ optional TAP delete) per record; bestEffort=false stops at first failure. Caller sweeps DB.
-func (c *CNI) tearDownNICs(ctx context.Context, vmID, nsPath string, records []networkRecord, deleteTAP, bestEffort bool) error {
+// tearDownNICs runs CNI DEL (+ optional TAP delete) on every record, joining per-record
+// failures — the caller sweeps the DB afterwards, so a skipped record never gets another attempt.
+func (c *CNI) tearDownNICs(ctx context.Context, vmID, nsPath string, records []networkRecord, deleteTAP bool) error {
 	logger := log.WithFunc("cni.tearDownNICs")
 	if c.cniConf == nil {
-		if !bestEffort {
-			return c.errNoConflist()
-		}
-		return nil
+		return c.errNoConflist()
 	}
+	var errs []error
 	for _, rec := range records {
 		var recErr error
 		cl, err := c.confListByName(rec.Type)
@@ -177,11 +176,11 @@ func (c *CNI) tearDownNICs(ctx context.Context, vmID, nsPath string, records []n
 				logger.Warnf(ctx, "delete tap %s in netns %s: %v", tapNameForVM(vmID, idx), nsPath, delErr)
 			}
 		}
-		if recErr != nil && !bestEffort {
-			return recErr
+		if recErr != nil {
+			errs = append(errs, recErr)
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (c *CNI) deleteRecords(ctx context.Context, ids []string) error {

--- a/network/cni/cni_test.go
+++ b/network/cni/cni_test.go
@@ -167,6 +167,29 @@ func TestRemoveKeepsFailedNICRecords(t *testing.T) {
 	assertRecordIDs(t, c, nil)
 }
 
+func TestRemoveSweepsDuplicateIfNameRecords(t *testing.T) {
+	c, _ := newTestCNIWithStore(t)
+	origTAP := deleteTAPFn
+	deleteTAPFn = func(string, string) error { return nil }
+	t.Cleanup(func() { deleteTAPFn = origTAP })
+
+	ctx := t.Context()
+	// A failed reclaim can leave two records for one ifname; Remove must tear down
+	// and sweep both (DEL is idempotent), not strand one as a phantom.
+	seedRecords(t, c, "vm1", "eth1")
+	if err := c.store.Update(ctx, func(idx *networkIndex) error {
+		idx.Networks["n-eth1-dup"] = &networkRecord{ID: "n-eth1-dup", Type: "cni-bridge", VMID: "vm1", IfName: "eth1"}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.Remove(ctx, "vm1", 1); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	assertRecordIDs(t, c, nil)
+}
+
 func TestDeleteVMKeepsFailedNICRecords(t *testing.T) {
 	c, exec := newTestCNIWithStore(t)
 	exec.failIf = "eth1"

--- a/network/cni/cni_test.go
+++ b/network/cni/cni_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/containernetworking/cni/pkg/version"
 
 	"github.com/cocoonstack/cocoon/lock/flock"
+	"github.com/cocoonstack/cocoon/network"
 	storejson "github.com/cocoonstack/cocoon/storage/json"
+	"github.com/cocoonstack/cocoon/types"
 )
 
 const (
@@ -145,9 +147,7 @@ func TestTearDownNICsAttemptsAllRecords(t *testing.T) {
 func TestRemoveKeepsFailedNICRecords(t *testing.T) {
 	c, exec := newTestCNIWithStore(t)
 	exec.failIf = "eth1"
-	origTAP := deleteTAPFn
-	deleteTAPFn = func(string, string) error { return nil }
-	t.Cleanup(func() { deleteTAPFn = origTAP })
+	stubLifecycleSeams(t)
 
 	ctx := t.Context()
 	seedRecords(t, c, "vm1", "eth0", "eth1")
@@ -169,9 +169,7 @@ func TestRemoveKeepsFailedNICRecords(t *testing.T) {
 
 func TestRemoveSweepsDuplicateIfNameRecords(t *testing.T) {
 	c, _ := newTestCNIWithStore(t)
-	origTAP := deleteTAPFn
-	deleteTAPFn = func(string, string) error { return nil }
-	t.Cleanup(func() { deleteTAPFn = origTAP })
+	stubLifecycleSeams(t)
 
 	ctx := t.Context()
 	// A failed reclaim can leave two records for one ifname; Remove must tear down
@@ -193,9 +191,7 @@ func TestRemoveSweepsDuplicateIfNameRecords(t *testing.T) {
 func TestDeleteVMKeepsFailedNICRecords(t *testing.T) {
 	c, exec := newTestCNIWithStore(t)
 	exec.failIf = "eth1"
-	origNetns := deleteNetnsFn
-	deleteNetnsFn = func(context.Context, string) error { return nil }
-	t.Cleanup(func() { deleteNetnsFn = origNetns })
+	stubLifecycleSeams(t)
 
 	ctx := t.Context()
 	seedRecords(t, c, "vm1", "eth0", "eth1")
@@ -209,9 +205,7 @@ func TestDeleteVMKeepsFailedNICRecords(t *testing.T) {
 
 func TestReclaimStaleNIC(t *testing.T) {
 	c, exec := newTestCNIWithStore(t)
-	origTAP := deleteTAPFn
-	deleteTAPFn = func(string, string) error { return nil }
-	t.Cleanup(func() { deleteTAPFn = origTAP })
+	stubLifecycleSeams(t)
 
 	ctx := t.Context()
 	seedRecords(t, c, "vm1", "eth1")
@@ -219,7 +213,7 @@ func TestReclaimStaleNIC(t *testing.T) {
 
 	// DEL failure keeps the record (nothing was released).
 	exec.failIf = "eth1"
-	if err := c.reclaimStaleNIC(ctx, "vm1", "/run/netns/vm1", "tapvm1-1", rec); err == nil {
+	if err := c.reclaimStaleNIC(ctx, "vm1", "/run/netns/vm1", rec); err == nil {
 		t.Fatal("reclaimStaleNIC: want error on failed DEL")
 	}
 	assertRecordIDs(t, c, []string{"n-eth1"})
@@ -228,17 +222,53 @@ func TestReclaimStaleNIC(t *testing.T) {
 	// that collides with the re-add's CreateTAP, with nothing left to retry it.
 	exec.failIf = ""
 	deleteTAPFn = func(string, string) error { return fmt.Errorf("device busy") }
-	if err := c.reclaimStaleNIC(ctx, "vm1", "/run/netns/vm1", "tapvm1-1", rec); err == nil {
+	if err := c.reclaimStaleNIC(ctx, "vm1", "/run/netns/vm1", rec); err == nil {
 		t.Fatal("reclaimStaleNIC: want error on failed TAP delete")
 	}
 	assertRecordIDs(t, c, []string{"n-eth1"})
 
 	// Both succeed: the record is released and swept, freeing the index for re-add.
 	deleteTAPFn = func(string, string) error { return nil }
-	if err := c.reclaimStaleNIC(ctx, "vm1", "/run/netns/vm1", "tapvm1-1", rec); err != nil {
+	if err := c.reclaimStaleNIC(ctx, "vm1", "/run/netns/vm1", rec); err != nil {
 		t.Fatalf("reclaimStaleNIC: %v", err)
 	}
 	assertRecordIDs(t, c, nil)
+}
+
+func TestAddFailsClosedOnStaleReclaim(t *testing.T) {
+	c, exec := newTestCNIWithStore(t)
+	stubLifecycleSeams(t)
+
+	ctx := t.Context()
+	seedRecords(t, c, "vm1", "eth0")
+
+	// The stale record's DEL fails: Add must fail instead of double-allocating (lenient
+	// IPAM) or burying the root cause under the ADD failure (strict IPAM).
+	exec.failIf = "eth0"
+	if _, err := c.Add(ctx, "vm1", testVMCfg(), network.AddSpec{Index: 0}); err == nil || !strings.Contains(err.Error(), "reclaim stale NIC") {
+		t.Fatalf("Add err = %v, want reclaim failure", err)
+	}
+	assertRecordIDs(t, c, []string{"n-eth0"})
+
+	// Retry after the fault clears: reclaim succeeds, the fresh add replaces the record.
+	exec.failIf = ""
+	configs, err := c.Add(ctx, "vm1", testVMCfg(), network.AddSpec{Index: 0})
+	if err != nil {
+		t.Fatalf("retry Add: %v", err)
+	}
+	if len(configs) != 1 {
+		t.Fatalf("got %d configs, want 1", len(configs))
+	}
+	var got []networkRecord
+	if err := c.store.With(ctx, func(idx *networkIndex) error {
+		got = idx.byVMID("vm1")
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].ID == "n-eth0" || got[0].IfName != "eth0" {
+		t.Fatalf("records = %+v, want one fresh eth0 record", got)
+	}
 }
 
 // newTestCNIWithStore builds a CNI over a real JSON store and a recordingExec-backed libcni.
@@ -254,8 +284,25 @@ func newTestCNIWithStore(t *testing.T) (*CNI, *recordingExec) {
 		store:       storejson.New[networkIndex](filepath.Join(dir, "net.json"), flock.New(filepath.Join(dir, "net.lock"))),
 		confLists:   map[string]*libcni.NetworkConfigList{"cni-bridge": cl},
 		defaultName: "cni-bridge",
-		cniConf:     libcni.NewCNIConfig([]string{"/nonexistent"}, exec),
+		cniConf:     libcni.NewCNIConfigWithCacheDir([]string{"/nonexistent"}, filepath.Join(dir, "cache"), exec),
 	}, exec
+}
+
+// stubLifecycleSeams replaces the linux-only netns/TAP seams with success stubs, matching the real absent-is-success semantics; t.Cleanup restores them.
+func stubLifecycleSeams(t *testing.T) {
+	t.Helper()
+	origTAP, origNetns, origEnsure, origTC := deleteTAPFn, deleteNetnsFn, ensureNetnsFn, setupTCRedirectFn
+	deleteTAPFn = func(string, string) error { return nil }
+	deleteNetnsFn = func(context.Context, string) error { return nil }
+	ensureNetnsFn = func(string, string) (bool, error) { return false, nil }
+	setupTCRedirectFn = func(_, _, _ string, _ int, _ string) (string, error) { return "aa:bb:cc:dd:ee:01", nil }
+	t.Cleanup(func() {
+		deleteTAPFn, deleteNetnsFn, ensureNetnsFn, setupTCRedirectFn = origTAP, origNetns, origEnsure, origTC
+	})
+}
+
+func testVMCfg() *types.VMConfig {
+	return &types.VMConfig{Config: types.Config{CPU: 2, Network: "cni-bridge"}}
 }
 
 // seedRecords inserts one record per ifName, with ID "n-<ifName>".
@@ -301,9 +348,9 @@ func (e *recordingExec) ExecPlugin(_ context.Context, _ string, _ []byte, enviro
 	}
 	e.attempted = append(e.attempted, ifName)
 	if ifName == e.failIf {
-		return nil, fmt.Errorf("simulated DEL failure on %s", ifName)
+		return nil, fmt.Errorf("simulated plugin failure on %s", ifName)
 	}
-	return []byte(`{}`), nil
+	return []byte(`{"cniVersion":"1.0.0"}`), nil
 }
 
 func (e *recordingExec) FindInPath(plugin string, _ []string) (string, error) {

--- a/network/cni/cni_test.go
+++ b/network/cni/cni_test.go
@@ -3,6 +3,7 @@ package cni
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -11,6 +12,9 @@ import (
 
 	"github.com/containernetworking/cni/libcni"
 	"github.com/containernetworking/cni/pkg/version"
+
+	"github.com/cocoonstack/cocoon/lock/flock"
+	storejson "github.com/cocoonstack/cocoon/storage/json"
 )
 
 const (
@@ -125,13 +129,71 @@ func TestTearDownNICsAttemptsAllRecords(t *testing.T) {
 		{ID: "n2", Type: "cni-bridge", VMID: "vm1", IfName: "eth2"},
 	}
 
-	err = c.tearDownNICs(t.Context(), "vm1", "/run/netns/vm1", records, false)
+	downIDs, err := c.tearDownNICs(t.Context(), "vm1", "/run/netns/vm1", records, false)
 	if err == nil || !strings.Contains(err.Error(), "eth1") {
 		t.Fatalf("tearDownNICs err = %v, want eth1 failure", err)
 	}
 	want := []string{"eth0", "eth1", "eth2"}
 	if !slices.Equal(exec.attempted, want) {
 		t.Fatalf("DEL attempted on %v, want %v (a mid-list failure must not skip later records)", exec.attempted, want)
+	}
+	if wantDown := []string{"n0", "n2"}; !slices.Equal(downIDs, wantDown) {
+		t.Fatalf("downIDs = %v, want %v (only fully-torn-down records are sweepable)", downIDs, wantDown)
+	}
+}
+
+func TestRemoveKeepsFailedNICRecords(t *testing.T) {
+	cl, err := libcni.ConfListFromBytes([]byte(bridgeConflist))
+	if err != nil {
+		t.Fatal(err)
+	}
+	exec := &recordingExec{failIf: "eth1"}
+	dir := t.TempDir()
+	c := &CNI{
+		store:       storejson.New[networkIndex](filepath.Join(dir, "net.json"), flock.New(filepath.Join(dir, "net.lock"))),
+		confLists:   map[string]*libcni.NetworkConfigList{"cni-bridge": cl},
+		defaultName: "cni-bridge",
+		cniConf:     libcni.NewCNIConfig([]string{"/nonexistent"}, exec),
+	}
+	origTAP := deleteTAPFn
+	deleteTAPFn = func(string, string) error { return nil }
+	t.Cleanup(func() { deleteTAPFn = origTAP })
+
+	ctx := t.Context()
+	if err := c.store.Update(ctx, func(idx *networkIndex) error {
+		idx.Networks["n0"] = &networkRecord{ID: "n0", Type: "cni-bridge", VMID: "vm1", IfName: "eth0"}
+		idx.Networks["n1"] = &networkRecord{ID: "n1", Type: "cni-bridge", VMID: "vm1", IfName: "eth1"}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// eth1's CNI DEL fails: its record must survive the sweep so vm rm/GC/retry can
+	// still release the IPAM lease; eth0's record must be swept.
+	if err := c.Remove(ctx, "vm1", 0, 1); err == nil || !strings.Contains(err.Error(), "eth1") {
+		t.Fatalf("Remove err = %v, want eth1 failure", err)
+	}
+	assertRecordIDs(t, c, []string{"n1"})
+
+	// Retry after the fault clears: the kept record lets Remove finish the release.
+	exec.failIf = ""
+	if err := c.Remove(ctx, "vm1", 1); err != nil {
+		t.Fatalf("retry Remove: %v", err)
+	}
+	assertRecordIDs(t, c, nil)
+}
+
+func assertRecordIDs(t *testing.T, c *CNI, want []string) {
+	t.Helper()
+	var got []string
+	if err := c.store.With(t.Context(), func(idx *networkIndex) error {
+		got = slices.Sorted(maps.Keys(idx.Networks))
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("records = %v, want %v", got, want)
 	}
 }
 

--- a/network/cni/cni_test.go
+++ b/network/cni/cni_test.go
@@ -143,37 +143,21 @@ func TestTearDownNICsAttemptsAllRecords(t *testing.T) {
 }
 
 func TestRemoveKeepsFailedNICRecords(t *testing.T) {
-	cl, err := libcni.ConfListFromBytes([]byte(bridgeConflist))
-	if err != nil {
-		t.Fatal(err)
-	}
-	exec := &recordingExec{failIf: "eth1"}
-	dir := t.TempDir()
-	c := &CNI{
-		store:       storejson.New[networkIndex](filepath.Join(dir, "net.json"), flock.New(filepath.Join(dir, "net.lock"))),
-		confLists:   map[string]*libcni.NetworkConfigList{"cni-bridge": cl},
-		defaultName: "cni-bridge",
-		cniConf:     libcni.NewCNIConfig([]string{"/nonexistent"}, exec),
-	}
+	c, exec := newTestCNIWithStore(t)
+	exec.failIf = "eth1"
 	origTAP := deleteTAPFn
 	deleteTAPFn = func(string, string) error { return nil }
 	t.Cleanup(func() { deleteTAPFn = origTAP })
 
 	ctx := t.Context()
-	if err := c.store.Update(ctx, func(idx *networkIndex) error {
-		idx.Networks["n0"] = &networkRecord{ID: "n0", Type: "cni-bridge", VMID: "vm1", IfName: "eth0"}
-		idx.Networks["n1"] = &networkRecord{ID: "n1", Type: "cni-bridge", VMID: "vm1", IfName: "eth1"}
-		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+	seedRecords(t, c, "vm1", "eth0", "eth1")
 
 	// eth1's CNI DEL fails: its record must survive the sweep so vm rm/GC/retry can
 	// still release the IPAM lease; eth0's record must be swept.
 	if err := c.Remove(ctx, "vm1", 0, 1); err == nil || !strings.Contains(err.Error(), "eth1") {
 		t.Fatalf("Remove err = %v, want eth1 failure", err)
 	}
-	assertRecordIDs(t, c, []string{"n1"})
+	assertRecordIDs(t, c, []string{"n-eth1"})
 
 	// Retry after the fault clears: the kept record lets Remove finish the release.
 	exec.failIf = ""
@@ -181,6 +165,79 @@ func TestRemoveKeepsFailedNICRecords(t *testing.T) {
 		t.Fatalf("retry Remove: %v", err)
 	}
 	assertRecordIDs(t, c, nil)
+}
+
+func TestDeleteVMKeepsFailedNICRecords(t *testing.T) {
+	c, exec := newTestCNIWithStore(t)
+	exec.failIf = "eth1"
+	origNetns := deleteNetnsFn
+	deleteNetnsFn = func(context.Context, string) error { return nil }
+	t.Cleanup(func() { deleteNetnsFn = origNetns })
+
+	ctx := t.Context()
+	seedRecords(t, c, "vm1", "eth0", "eth1")
+
+	// vm rm stays best-effort, but the failed NIC's record must survive for GC to retry.
+	if err := c.deleteVM(ctx, "vm1"); err != nil {
+		t.Fatalf("deleteVM: %v", err)
+	}
+	assertRecordIDs(t, c, []string{"n-eth1"})
+}
+
+func TestReclaimStaleNIC(t *testing.T) {
+	c, exec := newTestCNIWithStore(t)
+	origTAP := deleteTAPFn
+	deleteTAPFn = func(string, string) error { return nil }
+	t.Cleanup(func() { deleteTAPFn = origTAP })
+
+	ctx := t.Context()
+	seedRecords(t, c, "vm1", "eth1")
+	rec := networkRecord{ID: "n-eth1", Type: "cni-bridge", VMID: "vm1", IfName: "eth1"}
+
+	// DEL failure keeps the record (nothing was released).
+	exec.failIf = "eth1"
+	if err := c.reclaimStaleNIC(ctx, "vm1", "/run/netns/vm1", "tapvm1-1", rec); err == nil {
+		t.Fatal("reclaimStaleNIC: want error on failed DEL")
+	}
+	assertRecordIDs(t, c, []string{"n-eth1"})
+
+	// DEL success releases and sweeps the record, freeing the index for re-add.
+	exec.failIf = ""
+	if err := c.reclaimStaleNIC(ctx, "vm1", "/run/netns/vm1", "tapvm1-1", rec); err != nil {
+		t.Fatalf("reclaimStaleNIC: %v", err)
+	}
+	assertRecordIDs(t, c, nil)
+}
+
+// newTestCNIWithStore builds a CNI over a real JSON store and a recordingExec-backed libcni.
+func newTestCNIWithStore(t *testing.T) (*CNI, *recordingExec) {
+	t.Helper()
+	cl, err := libcni.ConfListFromBytes([]byte(bridgeConflist))
+	if err != nil {
+		t.Fatal(err)
+	}
+	exec := &recordingExec{}
+	dir := t.TempDir()
+	return &CNI{
+		store:       storejson.New[networkIndex](filepath.Join(dir, "net.json"), flock.New(filepath.Join(dir, "net.lock"))),
+		confLists:   map[string]*libcni.NetworkConfigList{"cni-bridge": cl},
+		defaultName: "cni-bridge",
+		cniConf:     libcni.NewCNIConfig([]string{"/nonexistent"}, exec),
+	}, exec
+}
+
+// seedRecords inserts one record per ifName, with ID "n-<ifName>".
+func seedRecords(t *testing.T, c *CNI, vmID string, ifNames ...string) {
+	t.Helper()
+	if err := c.store.Update(t.Context(), func(idx *networkIndex) error {
+		for _, ifName := range ifNames {
+			id := "n-" + ifName
+			idx.Networks[id] = &networkRecord{ID: id, Type: "cni-bridge", VMID: vmID, IfName: ifName}
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func assertRecordIDs(t *testing.T, c *CNI, want []string) {

--- a/network/cni/cni_test.go
+++ b/network/cni/cni_test.go
@@ -224,8 +224,17 @@ func TestReclaimStaleNIC(t *testing.T) {
 	}
 	assertRecordIDs(t, c, []string{"n-eth1"})
 
-	// DEL success releases and sweeps the record, freeing the index for re-add.
+	// TAP-delete failure also keeps the record: sweeping would leave a live TAP
+	// that collides with the re-add's CreateTAP, with nothing left to retry it.
 	exec.failIf = ""
+	deleteTAPFn = func(string, string) error { return fmt.Errorf("device busy") }
+	if err := c.reclaimStaleNIC(ctx, "vm1", "/run/netns/vm1", "tapvm1-1", rec); err == nil {
+		t.Fatal("reclaimStaleNIC: want error on failed TAP delete")
+	}
+	assertRecordIDs(t, c, []string{"n-eth1"})
+
+	// Both succeed: the record is released and swept, freeing the index for re-add.
+	deleteTAPFn = func(string, string) error { return nil }
 	if err := c.reclaimStaleNIC(ctx, "vm1", "/run/netns/vm1", "tapvm1-1", rec); err != nil {
 		t.Fatalf("reclaimStaleNIC: %v", err)
 	}

--- a/network/cni/cni_test.go
+++ b/network/cni/cni_test.go
@@ -1,10 +1,16 @@
 package cni
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
+
+	"github.com/containernetworking/cni/libcni"
+	"github.com/containernetworking/cni/pkg/version"
 )
 
 const (
@@ -100,6 +106,61 @@ func TestLoadConfLists(t *testing.T) {
 			t.Fatalf("expected parse error, got nil")
 		}
 	})
+}
+
+func TestTearDownNICsAttemptsAllRecords(t *testing.T) {
+	cl, err := libcni.ConfListFromBytes([]byte(bridgeConflist))
+	if err != nil {
+		t.Fatal(err)
+	}
+	exec := &recordingExec{failIf: "eth1"}
+	c := &CNI{
+		confLists:   map[string]*libcni.NetworkConfigList{"cni-bridge": cl},
+		defaultName: "cni-bridge",
+		cniConf:     libcni.NewCNIConfig([]string{"/nonexistent"}, exec),
+	}
+	records := []networkRecord{
+		{ID: "n0", Type: "cni-bridge", VMID: "vm1", IfName: "eth0"},
+		{ID: "n1", Type: "cni-bridge", VMID: "vm1", IfName: "eth1"},
+		{ID: "n2", Type: "cni-bridge", VMID: "vm1", IfName: "eth2"},
+	}
+
+	err = c.tearDownNICs(t.Context(), "vm1", "/run/netns/vm1", records, false)
+	if err == nil || !strings.Contains(err.Error(), "eth1") {
+		t.Fatalf("tearDownNICs err = %v, want eth1 failure", err)
+	}
+	want := []string{"eth0", "eth1", "eth2"}
+	if !slices.Equal(exec.attempted, want) {
+		t.Fatalf("DEL attempted on %v, want %v (a mid-list failure must not skip later records)", exec.attempted, want)
+	}
+}
+
+// recordingExec fakes CNI plugin execution, recording each DEL's CNI_IFNAME and failing one.
+type recordingExec struct {
+	attempted []string
+	failIf    string
+}
+
+func (e *recordingExec) ExecPlugin(_ context.Context, _ string, _ []byte, environ []string) ([]byte, error) {
+	var ifName string
+	for _, kv := range environ {
+		if v, ok := strings.CutPrefix(kv, "CNI_IFNAME="); ok {
+			ifName = v
+		}
+	}
+	e.attempted = append(e.attempted, ifName)
+	if ifName == e.failIf {
+		return nil, fmt.Errorf("simulated DEL failure on %s", ifName)
+	}
+	return []byte(`{}`), nil
+}
+
+func (e *recordingExec) FindInPath(plugin string, _ []string) (string, error) {
+	return "/fake/" + plugin, nil
+}
+
+func (e *recordingExec) Decode([]byte) (version.PluginInfo, error) {
+	return version.PluginSupports("0.3.1", "0.4.0", "1.0.0"), nil
 }
 
 func writeFile(t *testing.T, path, content string) {

--- a/network/cni/gc.go
+++ b/network/cni/gc.go
@@ -76,22 +76,20 @@ func (c *CNI) GCModule() gc.Module[cniSnapshot] {
 					continue
 				}
 
-				// CNI DEL per NIC — best-effort IPAM release.
-				_, _ = c.tearDownNICs(ctx, vmID, netnsPath(vmID), records, false)
+				// CNI DEL per NIC — a failed release keeps its record for the next GC cycle.
+				downIDs, _ := c.tearDownNICs(ctx, vmID, netnsPath(vmID), records, false)
 
 				nsName := netnsName(vmID)
-				if err := deleteNetns(ctx, nsName); err != nil && !errors.Is(err, fs.ErrNotExist) {
+				if err := deleteNetnsFn(ctx, nsName); err != nil && !errors.Is(err, fs.ErrNotExist) {
 					errs = append(errs, fmt.Errorf("remove netns %s: %w", nsName, err))
 					continue
 				}
 
 				// Lockless write.
-				if len(records) > 0 {
+				if len(downIDs) > 0 {
 					if err := c.store.WriteRaw(func(idx *networkIndex) error {
-						for id, rec := range idx.Networks {
-							if rec != nil && rec.VMID == vmID {
-								delete(idx.Networks, id)
-							}
+						for _, id := range downIDs {
+							delete(idx.Networks, id)
 						}
 						return nil
 					}); err != nil {
@@ -99,8 +97,8 @@ func (c *CNI) GCModule() gc.Module[cniSnapshot] {
 						continue
 					}
 				}
-				logger.Infof(ctx, "collected id=%s netns=%s nics=%d reason=orphan",
-					vmID, nsName, len(records))
+				logger.Infof(ctx, "collected id=%s netns=%s nics=%d/%d reason=orphan",
+					vmID, nsName, len(downIDs), len(records))
 			}
 			return errors.Join(errs...)
 		},

--- a/network/cni/gc.go
+++ b/network/cni/gc.go
@@ -77,7 +77,7 @@ func (c *CNI) GCModule() gc.Module[cniSnapshot] {
 				}
 
 				// CNI DEL per NIC — best-effort IPAM release.
-				_ = c.tearDownNICs(ctx, vmID, netnsPath(vmID), records, false)
+				_, _ = c.tearDownNICs(ctx, vmID, netnsPath(vmID), records, false)
 
 				nsName := netnsName(vmID)
 				if err := deleteNetns(ctx, nsName); err != nil && !errors.Is(err, fs.ErrNotExist) {

--- a/network/cni/gc.go
+++ b/network/cni/gc.go
@@ -77,7 +77,7 @@ func (c *CNI) GCModule() gc.Module[cniSnapshot] {
 				}
 
 				// CNI DEL per NIC — best-effort IPAM release.
-				_ = c.tearDownNICs(ctx, vmID, netnsPath(vmID), records, false, true)
+				_ = c.tearDownNICs(ctx, vmID, netnsPath(vmID), records, false)
 
 				nsName := netnsName(vmID)
 				if err := deleteNetns(ctx, nsName); err != nil && !errors.Is(err, fs.ErrNotExist) {

--- a/network/cni/lifecycle.go
+++ b/network/cni/lifecycle.go
@@ -158,9 +158,7 @@ func (c *CNI) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs
 	})
 }
 
-// Remove tears down NIC plumbing for the given indices; preserves the netns.
-// Only fully-torn-down NICs lose their DB records: a failed teardown keeps its record so
-// retry / vm rm / GC can still release the CNI resources — sweeping it would orphan them.
+// Remove tears down NIC plumbing for the given indices; preserves the netns. A failed NIC keeps its DB record so retry / vm rm / GC can still release its CNI resources.
 func (c *CNI) Remove(ctx context.Context, vmID string, indices ...int) error {
 	if len(indices) == 0 {
 		return nil

--- a/network/cni/lifecycle.go
+++ b/network/cni/lifecycle.go
@@ -188,18 +188,24 @@ func (c *CNI) Remove(ctx context.Context, vmID string, indices ...int) error {
 	}); err != nil {
 		return fmt.Errorf("read network index: %w", err)
 	}
-	byIfName := make(map[string]networkRecord, len(records))
-	for _, r := range records {
-		byIfName[r.IfName] = r
-	}
-	picked := make([]networkRecord, 0, len(indices))
+	wanted := make(map[string]bool, len(indices))
 	for _, i := range indices {
-		ifName := fmt.Sprintf("eth%d", i)
-		rec, ok := byIfName[ifName]
-		if !ok {
+		wanted[fmt.Sprintf("eth%d", i)] = true
+	}
+	// Pick every matching record, not one per ifname: a failed reclaim can leave
+	// duplicates, and DEL is idempotent — skipping one would strand it as a phantom.
+	picked := make([]networkRecord, 0, len(indices))
+	found := make(map[string]bool, len(indices))
+	for _, r := range records {
+		if wanted[r.IfName] {
+			picked = append(picked, r)
+			found[r.IfName] = true
+		}
+	}
+	for _, i := range indices {
+		if ifName := fmt.Sprintf("eth%d", i); !found[ifName] {
 			return fmt.Errorf("nic %d (%s): no record", i, ifName)
 		}
-		picked = append(picked, rec)
 	}
 	downIDs, err := c.tearDownNICs(ctx, vmID, netnsPath(vmID), picked, true)
 	return errors.Join(err, c.deleteRecords(ctx, downIDs))

--- a/network/cni/lifecycle.go
+++ b/network/cni/lifecycle.go
@@ -216,7 +216,7 @@ func (c *CNI) cniDel(ctx context.Context, confList *libcni.NetworkConfigList, vm
 	return c.cniConf.DelNetworkList(ctx, confList, rt)
 }
 
-// reclaimStaleNIC releases a record left by a failed detach before its index is reused: CNI DEL (by the record's own conflist), best-effort TAP delete, then the record sweep.
+// reclaimStaleNIC releases a record left by a failed detach before its index is reused: CNI DEL (by the record's own conflist), TAP delete, then the record sweep — any failure keeps the record so the next re-add retries (both ops are idempotent).
 func (c *CNI) reclaimStaleNIC(ctx context.Context, vmID, nsPath, tapName string, rec networkRecord) error {
 	cl, err := c.confListByName(rec.Type)
 	if err != nil {
@@ -225,7 +225,9 @@ func (c *CNI) reclaimStaleNIC(ctx context.Context, vmID, nsPath, tapName string,
 	if err := c.cniDel(ctx, cl, vmID, nsPath, rec.IfName); err != nil {
 		return fmt.Errorf("cni del %s/%s: %w", vmID, rec.IfName, err)
 	}
-	_ = deleteTAPFn(nsPath, tapName)
+	if err := deleteTAPFn(nsPath, tapName); err != nil {
+		return fmt.Errorf("delete tap %s: %w", tapName, err)
+	}
 	return c.deleteRecords(ctx, []string{rec.ID})
 }
 

--- a/network/cni/lifecycle.go
+++ b/network/cni/lifecycle.go
@@ -106,10 +106,11 @@ func (c *CNI) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs
 				rt.Args = [][2]string{{"IgnoreUnknown", "1"}, {"IP", spec.Existing.Network.IP}}
 			}
 		} else if rec, ok := stale[ifName]; ok {
-			// A failed detach left this index's record: release it first, or the IPAM
-			// plugin refuses the duplicate container+ifname allocation.
+			// A failed detach left this index's record: the index is reusable only after a
+			// full reclaim — proceeding would double-allocate on lenient IPAM plugins, or
+			// bury the root cause under the ADD failure on strict ones.
 			if rcErr := c.reclaimStaleNIC(ctx, vmID, nsPath, tapName, rec); rcErr != nil {
-				logger.Warnf(ctx, "reclaim stale NIC %s/%s: %v (continuing)", vmID, ifName, rcErr)
+				return nil, fmt.Errorf("reclaim stale NIC %s/%s: %w", vmID, ifName, rcErr)
 			}
 		}
 

--- a/network/cni/lifecycle.go
+++ b/network/cni/lifecycle.go
@@ -60,7 +60,7 @@ func (c *CNI) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs
 		return nil, fmt.Errorf("read network index: %w", err)
 	}
 
-	createdNetns, err := ensureNetns(nsName, nsPath)
+	createdNetns, err := ensureNetnsFn(nsName, nsPath)
 	if err != nil {
 		return nil, fmt.Errorf("ensure netns %s: %w", nsName, err)
 	}
@@ -106,10 +106,9 @@ func (c *CNI) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs
 				rt.Args = [][2]string{{"IgnoreUnknown", "1"}, {"IP", spec.Existing.Network.IP}}
 			}
 		} else if rec, ok := stale[ifName]; ok {
-			// A failed detach left this index's record: the index is reusable only after a
-			// full reclaim — proceeding would double-allocate on lenient IPAM plugins, or
-			// bury the root cause under the ADD failure on strict ones.
-			if rcErr := c.reclaimStaleNIC(ctx, vmID, nsPath, tapName, rec); rcErr != nil {
+			// The index is reusable only after a full reclaim: proceeding would double-allocate
+			// on lenient IPAM plugins or bury the root cause under the ADD failure on strict ones.
+			if rcErr := c.reclaimStaleNIC(ctx, vmID, nsPath, rec); rcErr != nil {
 				return nil, fmt.Errorf("reclaim stale NIC %s/%s: %w", vmID, ifName, rcErr)
 			}
 		}
@@ -130,7 +129,7 @@ func (c *CNI) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs
 			overrideMAC = spec.Existing.MAC
 		}
 		queues := network.ResolveQueues(spec.Queues, vmCfg.CPU)
-		mac, setupErr := setupTCRedirect(nsPath, ifName, tapName, queues, overrideMAC)
+		mac, setupErr := setupTCRedirectFn(nsPath, ifName, tapName, queues, overrideMAC)
 		if setupErr != nil {
 			return nil, fmt.Errorf("setup tc-redirect %s: %w", vmID, setupErr)
 		}
@@ -217,19 +216,13 @@ func (c *CNI) cniDel(ctx context.Context, confList *libcni.NetworkConfigList, vm
 	return c.cniConf.DelNetworkList(ctx, confList, rt)
 }
 
-// reclaimStaleNIC releases a record left by a failed detach before its index is reused: CNI DEL (by the record's own conflist), TAP delete, then the record sweep — any failure keeps the record so the next re-add retries (both ops are idempotent).
-func (c *CNI) reclaimStaleNIC(ctx context.Context, vmID, nsPath, tapName string, rec networkRecord) error {
-	cl, err := c.confListByName(rec.Type)
+// reclaimStaleNIC releases a record left by a failed detach before its index is reused; any failure keeps the record so the next re-add retries (the teardown is idempotent).
+func (c *CNI) reclaimStaleNIC(ctx context.Context, vmID, nsPath string, rec networkRecord) error {
+	downIDs, err := c.tearDownNICs(ctx, vmID, nsPath, []networkRecord{rec}, true)
 	if err != nil {
 		return err
 	}
-	if err := c.cniDel(ctx, cl, vmID, nsPath, rec.IfName); err != nil {
-		return fmt.Errorf("cni del %s/%s: %w", vmID, rec.IfName, err)
-	}
-	if err := deleteTAPFn(nsPath, tapName); err != nil {
-		return fmt.Errorf("delete tap %s: %w", tapName, err)
-	}
-	return c.deleteRecords(ctx, []string{rec.ID})
+	return c.deleteRecords(ctx, downIDs)
 }
 
 func tapNameForVM(vmID string, nic int) string {

--- a/network/cni/lifecycle.go
+++ b/network/cni/lifecycle.go
@@ -159,7 +159,8 @@ func (c *CNI) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs
 }
 
 // Remove tears down NIC plumbing for the given indices; preserves the netns.
-// Always sweeps DB records for picked indices so resize-up to the same index isn't stale; CNI/TAP errors still propagate.
+// Only fully-torn-down NICs lose their DB records: a failed teardown keeps its record so
+// retry / vm rm / GC can still release the CNI resources — sweeping it would orphan them.
 func (c *CNI) Remove(ctx context.Context, vmID string, indices ...int) error {
 	if len(indices) == 0 {
 		return nil
@@ -176,7 +177,6 @@ func (c *CNI) Remove(ctx context.Context, vmID string, indices ...int) error {
 		byIfName[r.IfName] = r
 	}
 	picked := make([]networkRecord, 0, len(indices))
-	pickedIDs := make([]string, 0, len(indices))
 	for _, i := range indices {
 		ifName := fmt.Sprintf("eth%d", i)
 		rec, ok := byIfName[ifName]
@@ -184,10 +184,9 @@ func (c *CNI) Remove(ctx context.Context, vmID string, indices ...int) error {
 			return fmt.Errorf("nic %d (%s): no record", i, ifName)
 		}
 		picked = append(picked, rec)
-		pickedIDs = append(pickedIDs, rec.ID)
 	}
-	err := c.tearDownNICs(ctx, vmID, netnsPath(vmID), picked, true)
-	return errors.Join(err, c.deleteRecords(ctx, pickedIDs))
+	downIDs, err := c.tearDownNICs(ctx, vmID, netnsPath(vmID), picked, true)
+	return errors.Join(err, c.deleteRecords(ctx, downIDs))
 }
 
 func (c *CNI) cniDel(ctx context.Context, confList *libcni.NetworkConfigList, vmID, nsPath, ifName string) error {

--- a/network/cni/lifecycle.go
+++ b/network/cni/lifecycle.go
@@ -186,7 +186,7 @@ func (c *CNI) Remove(ctx context.Context, vmID string, indices ...int) error {
 		picked = append(picked, rec)
 		pickedIDs = append(pickedIDs, rec.ID)
 	}
-	err := c.tearDownNICs(ctx, vmID, netnsPath(vmID), picked, true, false)
+	err := c.tearDownNICs(ctx, vmID, netnsPath(vmID), picked, true)
 	return errors.Join(err, c.deleteRecords(ctx, pickedIDs))
 }
 

--- a/network/cni/lifecycle.go
+++ b/network/cni/lifecycle.go
@@ -48,6 +48,18 @@ func (c *CNI) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs
 	nsName := netnsName(vmID)
 	nsPath := netnsPath(vmID)
 
+	var stale map[string]networkRecord
+	if err = c.store.With(ctx, func(idx *networkIndex) error {
+		records := idx.byVMID(vmID)
+		stale = make(map[string]networkRecord, len(records))
+		for _, r := range records {
+			stale[r.IfName] = r
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("read network index: %w", err)
+	}
+
 	createdNetns, err := ensureNetns(nsName, nsPath)
 	if err != nil {
 		return nil, fmt.Errorf("ensure netns %s: %w", nsName, err)
@@ -92,6 +104,12 @@ func (c *CNI) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs
 			}
 			if spec.Existing.Network != nil && spec.Existing.Network.IP != "" {
 				rt.Args = [][2]string{{"IgnoreUnknown", "1"}, {"IP", spec.Existing.Network.IP}}
+			}
+		} else if rec, ok := stale[ifName]; ok {
+			// A failed detach left this index's record: release it first, or the IPAM
+			// plugin refuses the duplicate container+ifname allocation.
+			if rcErr := c.reclaimStaleNIC(ctx, vmID, nsPath, tapName, rec); rcErr != nil {
+				logger.Warnf(ctx, "reclaim stale NIC %s/%s: %v (continuing)", vmID, ifName, rcErr)
 			}
 		}
 
@@ -190,6 +208,19 @@ func (c *CNI) Remove(ctx context.Context, vmID string, indices ...int) error {
 func (c *CNI) cniDel(ctx context.Context, confList *libcni.NetworkConfigList, vmID, nsPath, ifName string) error {
 	rt := &libcni.RuntimeConf{ContainerID: vmID, NetNS: nsPath, IfName: ifName}
 	return c.cniConf.DelNetworkList(ctx, confList, rt)
+}
+
+// reclaimStaleNIC releases a record left by a failed detach before its index is reused: CNI DEL (by the record's own conflist), best-effort TAP delete, then the record sweep.
+func (c *CNI) reclaimStaleNIC(ctx context.Context, vmID, nsPath, tapName string, rec networkRecord) error {
+	cl, err := c.confListByName(rec.Type)
+	if err != nil {
+		return err
+	}
+	if err := c.cniDel(ctx, cl, vmID, nsPath, rec.IfName); err != nil {
+		return fmt.Errorf("cni del %s/%s: %w", vmID, rec.IfName, err)
+	}
+	_ = deleteTAPFn(nsPath, tapName)
+	return c.deleteRecords(ctx, []string{rec.ID})
 }
 
 func tapNameForVM(vmID string, nic int) string {

--- a/network/cni/lifecycle_linux.go
+++ b/network/cni/lifecycle_linux.go
@@ -52,15 +52,22 @@ func deleteNetns(ctx context.Context, name string) error {
 	})
 }
 
-// deleteTAPInNetns deletes a named TAP device inside target netns.
+// deleteTAPInNetns is idempotent: an absent TAP or an already-deleted netns is success, or every teardown retry after a partial failure would wedge on the missing device.
 func deleteTAPInNetns(nsPath, tapName string) error {
-	return cns.WithNetNSPath(nsPath, func(_ cns.NetNS) error {
+	err := cns.WithNetNSPath(nsPath, func(_ cns.NetNS) error {
 		link, err := netlink.LinkByName(tapName)
 		if err != nil {
+			if _, ok := errors.AsType[netlink.LinkNotFoundError](err); ok {
+				return nil
+			}
 			return fmt.Errorf("find %s: %w", tapName, err)
 		}
 		return netlink.LinkDel(link)
 	})
+	if _, ok := errors.AsType[cns.NSPathNotExistErr](err); ok {
+		return nil
+	}
+	return err
 }
 
 // setupTCRedirect wires ifName <-> tapName inside target netns, returns MAC.


### PR DESCRIPTION
## Problem

A NIC teardown failure anywhere in the CNI lifecycle permanently leaked the NIC's resources (the IPAM lease foremost — host-local keys it by container+ifname, and only CNI DEL releases it):

1. **Detach (`Remove`)**: swept the DB records for all picked indices even when teardown failed — and `vm rm`/GC release resources only by walking the DB, so a swept record meant no retry path, ever. netresize's "vm rm or gc will reclaim" warning was a false promise. (Also: `tearDownNICs` stopped at the first failing record, never attempting later ones — latent, since production passes one index per call.)
2. **vm rm (`deleteVM`) and GC**: same always-sweep, so even a record kept by (1)'s fix would be lost one layer later if the plugin was still failing.
3. **Re-add (`Add`)**: no reconcile entry — a fresh CNI ADD against an index with a stale record hits host-local's duplicate-allocation refusal (this collision pre-existed even under always-sweep, because the lease outlives the DB record).
4. **TAP state machine**: `deleteTAPInNetns` treated an absent TAP (or an already-deleted netns) as failure, so every retry after a partial failure wedged on the missing device and kept records could never converge.

## Fix

- `tearDownNICs` attempts every record and returns the fully-torn-down record IDs; `Remove`, `deleteVM`, and GC sweep **only** those. A failed NIC keeps its record: GC retries it every cycle once the VM is gone, and netresize's reclaim promise becomes true.
- `Remove` picks **every** record matching the wanted ifnames (a failed reclaim can leave duplicates; DEL is idempotent), so no phantom record survives.
- `Add` reclaims a stale same-index record before re-adding (`reclaimStaleNIC`: DEL by the record's own conflist → TAP delete → sweep, strictly in that order and only on success). A failed reclaim **fails the resize-up** — proceeding would double-allocate on lenient IPAM plugins or bury the root cause on strict ones; the index is reusable only after a full reclaim, and the error is retryable since the whole chain is idempotent.
- `deleteTAPInNetns` is idempotent: `LinkNotFoundError` and `NSPathNotExistErr` are success (absent = deletion's goal met).
- `bestEffort` param dropped — best-effort callers already ignored the error.

## Tests (all drive real libcni via a fake `invoke.Exec`; netns/TAP ops behind seams whose nil-return matches the fixed absent-is-success semantics)

- `TestTearDownNICsAttemptsAllRecords` — mid-list DEL failure doesn't skip later records; only released IDs reported sweepable.
- `TestRemoveKeepsFailedNICRecords` — Remove → sweep → retry against a real store: failed record survives, retry releases it.
- `TestRemoveSweepsDuplicateIfNameRecords` — duplicate same-ifname records are all torn down and swept.
- `TestDeleteVMKeepsFailedNICRecords` — vm rm stays best-effort but keeps the failed record for GC.
- `TestReclaimStaleNIC` — DEL failure and TAP-delete failure each keep the record; full success sweeps it.
- `TestAddFailsClosedOnStaleReclaim` — Add fails with the reclaim as the named cause (not a buried ADD error) and keeps the record; a retry after the fault clears replaces it with a fresh one.

Known limitation: the linux-only idempotency branches (`LinkNotFoundError`/`NSPathNotExistErr`) compile-verify on linux but can't execute on darwin or unprivileged CI (setns needs CAP_SYS_ADMIN); real-plugin behavior belongs to the testbed fault-injection round.
