### PR TITLE
review: fold the shared create protocol into beginCreate/finalizeCreate

### DIFF
--- a/snapshot/localfile/localfile.go
+++ b/snapshot/localfile/localfile.go
@@ -87,29 +87,14 @@ func (lf *LocalFile) DataDir(ctx context.Context, ref string) (string, types.Sna
 
 // Create stores a snapshot via placeholder→extract→finalize; a mid-flight crash leaves a pending record for GC.
 func (lf *LocalFile) Create(ctx context.Context, cfg *types.SnapshotConfig, stream io.Reader) (_ string, err error) {
-	id := cfg.ID
-	if id == "" {
-		return "", fmt.Errorf("snapshot ID is required (must be set by caller)")
-	}
-	if err = cfg.Validate(); err != nil {
+	dataDir, err := lf.beginCreate(ctx, cfg)
+	if err != nil {
 		return "", err
 	}
-
-	dataDir := lf.conf.SnapshotDataDir(id)
-	now := time.Now()
-
-	if err = lf.insertRecord(ctx, id, cfg.Name, &snapshot.SnapshotRecord{
-		Snapshot: types.Snapshot{SnapshotConfig: *cfg, CreatedAt: now},
-		Pending:  true,
-		DataDir:  dataDir,
-	}); err != nil {
-		return "", err
-	}
-
 	defer func() {
 		if err != nil {
 			os.RemoveAll(dataDir) //nolint:errcheck,gosec
-			lf.rollbackCreate(ctx, id, cfg.Name)
+			lf.rollbackCreate(ctx, cfg.ID, cfg.Name)
 		}
 	}()
 
@@ -119,39 +104,14 @@ func (lf *LocalFile) Create(ctx context.Context, cfg *types.SnapshotConfig, stre
 	if err = utils.ExtractTar(dataDir, stream); err != nil {
 		return "", fmt.Errorf("extract snapshot data: %w", err)
 	}
-
-	size, sizeErr := utils.DirSize(dataDir)
-	if sizeErr != nil {
-		return "", fmt.Errorf("compute data dir size: %w", sizeErr)
+	if err = lf.finalizeCreate(ctx, cfg, dataDir); err != nil {
+		return "", err
 	}
-	finalizedAt := time.Now()
-	if err = lf.store.Update(ctx, func(idx *snapshot.SnapshotIndex) error {
-		rec := idx.Snapshots[id]
-		if rec == nil {
-			return fmt.Errorf("snapshot %q disappeared from index", id)
-		}
-		rec.Pending = false
-		rec.SizeBytes = size
-		rec.LastAccessedAt = finalizedAt
-		return nil
-	}); err != nil {
-		return "", fmt.Errorf("finalize snapshot: %w", err)
-	}
-
-	emitSnapStart(ctx, lf.metering, id, cfg.Hypervisor, size, finalizedAt)
-	return id, nil
+	return cfg.ID, nil
 }
 
 // CreateFromDir persists a snapshot by renaming srcDir into the store data dir — one atomic move, no tar read+extract — when they share a filesystem. It reports ok=false (srcDir untouched) across filesystems so the caller streams instead. The placeholder→move→finalize protocol matches Create, so a mid-flight crash leaves a GC-collectable pending record and the layout is byte-for-byte what Create produces.
 func (lf *LocalFile) CreateFromDir(ctx context.Context, cfg *types.SnapshotConfig, srcDir string) (_ string, _ bool, err error) {
-	id := cfg.ID
-	if id == "" {
-		return "", false, fmt.Errorf("snapshot ID is required (must be set by caller)")
-	}
-	if err = cfg.Validate(); err != nil {
-		return "", false, err
-	}
-
 	sameFS, err := utils.SameFilesystem(srcDir, lf.conf.DataDir())
 	if err != nil {
 		return "", false, fmt.Errorf("check filesystem: %w", err)
@@ -160,27 +120,21 @@ func (lf *LocalFile) CreateFromDir(ctx context.Context, cfg *types.SnapshotConfi
 		return "", false, nil
 	}
 
-	dataDir := lf.conf.SnapshotDataDir(id)
-	now := time.Now()
-	if err = lf.insertRecord(ctx, id, cfg.Name, &snapshot.SnapshotRecord{
-		Snapshot: types.Snapshot{SnapshotConfig: *cfg, CreatedAt: now},
-		Pending:  true,
-		DataDir:  dataDir,
-	}); err != nil {
+	dataDir, err := lf.beginCreate(ctx, cfg)
+	if err != nil {
 		return "", false, err
 	}
-
 	defer func() {
 		if err != nil {
 			os.RemoveAll(dataDir) //nolint:errcheck,gosec
-			lf.rollbackCreate(ctx, id, cfg.Name)
+			lf.rollbackCreate(ctx, cfg.ID, cfg.Name)
 		}
 	}()
 
 	// A st_dev match can't rule out EXDEV (bind mounts): roll back and report ok=false so the caller streams via tar.
 	if err = osRename(srcDir, dataDir); err != nil {
 		if errors.Is(err, syscall.EXDEV) {
-			lf.rollbackCreate(ctx, id, cfg.Name)
+			lf.rollbackCreate(ctx, cfg.ID, cfg.Name)
 			return "", false, nil
 		}
 		return "", false, fmt.Errorf("move capture into store: %w", err)
@@ -192,27 +146,10 @@ func (lf *LocalFile) CreateFromDir(ctx context.Context, cfg *types.SnapshotConfi
 	if err = utils.SyncTree(dataDir); err != nil {
 		return "", false, fmt.Errorf("sync snapshot to disk: %w", err)
 	}
-
-	size, sizeErr := utils.DirSize(dataDir)
-	if sizeErr != nil {
-		return "", false, fmt.Errorf("compute data dir size: %w", sizeErr)
+	if err = lf.finalizeCreate(ctx, cfg, dataDir); err != nil {
+		return "", false, err
 	}
-	finalizedAt := time.Now()
-	if err = lf.store.Update(ctx, func(idx *snapshot.SnapshotIndex) error {
-		rec := idx.Snapshots[id]
-		if rec == nil {
-			return fmt.Errorf("snapshot %q disappeared from index", id)
-		}
-		rec.Pending = false
-		rec.SizeBytes = size
-		rec.LastAccessedAt = finalizedAt
-		return nil
-	}); err != nil {
-		return "", false, fmt.Errorf("finalize snapshot: %w", err)
-	}
-
-	emitSnapStart(ctx, lf.metering, id, cfg.Hypervisor, size, finalizedAt)
-	return id, true, nil
+	return cfg.ID, true, nil
 }
 
 // List returns all snapshots (excluding pending ones).
@@ -299,6 +236,48 @@ func (lf *LocalFile) deleteOne(ctx context.Context, id string) error {
 	if deletedRecord {
 		emitSnapStop(ctx, lf.metering, id, hypType)
 	}
+	return nil
+}
+
+// beginCreate validates cfg and inserts the pending placeholder record, returning the data dir.
+func (lf *LocalFile) beginCreate(ctx context.Context, cfg *types.SnapshotConfig) (string, error) {
+	if cfg.ID == "" {
+		return "", fmt.Errorf("snapshot ID is required (must be set by caller)")
+	}
+	if err := cfg.Validate(); err != nil {
+		return "", err
+	}
+	dataDir := lf.conf.SnapshotDataDir(cfg.ID)
+	if err := lf.insertRecord(ctx, cfg.ID, cfg.Name, &snapshot.SnapshotRecord{
+		Snapshot: types.Snapshot{SnapshotConfig: *cfg, CreatedAt: time.Now()},
+		Pending:  true,
+		DataDir:  dataDir,
+	}); err != nil {
+		return "", err
+	}
+	return dataDir, nil
+}
+
+// finalizeCreate measures dataDir, flips the pending record durable, and emits metering.
+func (lf *LocalFile) finalizeCreate(ctx context.Context, cfg *types.SnapshotConfig, dataDir string) error {
+	size, err := utils.DirSize(dataDir)
+	if err != nil {
+		return fmt.Errorf("compute data dir size: %w", err)
+	}
+	finalizedAt := time.Now()
+	if err := lf.store.Update(ctx, func(idx *snapshot.SnapshotIndex) error {
+		rec := idx.Snapshots[cfg.ID]
+		if rec == nil {
+			return fmt.Errorf("snapshot %q disappeared from index", cfg.ID)
+		}
+		rec.Pending = false
+		rec.SizeBytes = size
+		rec.LastAccessedAt = finalizedAt
+		return nil
+	}); err != nil {
+		return fmt.Errorf("finalize snapshot: %w", err)
+	}
+	emitSnapStart(ctx, lf.metering, cfg.ID, cfg.Hypervisor, size, finalizedAt)
 	return nil
 }
 


### PR DESCRIPTION
`Create` and `CreateFromDir` (from #109) carried byte-identical placeholder-insert and finalize-record blocks (~25 duplicated lines). Extract `beginCreate` (validate + pending placeholder) and `finalizeCreate` (size + flip durable + metering) so the protocol lives in one place and cannot drift.

No behavior change, with one edge relocation: `CreateFromDir` now checks `SameFilesystem` before validating, so an invalid config with a cross-filesystem srcDir reports ok=false and surfaces the same validation error from the tar fallback's `Create` instead of directly.

Covered by the existing localfile suite (direct-vs-tar layout parity, EXDEV fallback, metering).