### PR TITLE
perf(lock): drop flock poll interval 100ms -> 2ms

### DIFF
--- a/lock/flock/flock.go
+++ b/lock/flock/flock.go
@@ -10,8 +10,6 @@ import (
 	"github.com/cocoonstack/cocoon/lock"
 )
 
-// retryDelay quantizes every contended acquire; at 100ms it stalled a ~40ms
-// clone for a full quantum. 2ms polling is noise even against a long holder.
 const retryDelay = 2 * time.Millisecond
 
 var _ lock.Locker = (*Lock)(nil)

--- a/lock/flock/flock.go
+++ b/lock/flock/flock.go
@@ -10,7 +10,9 @@ import (
 	"github.com/cocoonstack/cocoon/lock"
 )
 
-const retryDelay = 100 * time.Millisecond
+// retryDelay quantizes every contended acquire; at 100ms it stalled a ~40ms
+// clone for a full quantum. 2ms polling is noise even against a long holder.
+const retryDelay = 2 * time.Millisecond
 
 var _ lock.Locker = (*Lock)(nil)
 


### PR DESCRIPTION
`flock.Lock` acquires the cross-process lock via gofrs `TryLockContext(ctx, retryDelay)` — a **poll loop**, not a blocking `flock(2)`. `retryDelay` was 100 ms, so it quantized every *contended* acquire. The VM index and snapshot index each take an exclusive flock per mutation, so two concurrent claims (or a claim racing a sandboxd `vm list` poll) turned a sub-ms wait into a 100 ms sleep — a p99 cliff on the ~40 ms clone tier.

Drop it to 2 ms: negligible poll cost, and even a minutes-long holder (an image pull) only costs a waiter ~500 harmless syscalls/s.

## Evidence (.79 bare metal, master base)
8 concurrent `vm clone --from-dir` per round × 3 rounds, with a background `vm list --format json` poll loop adding index-lock contention (n=24):

| build | p50 | p90 | p99 | max |
|---|---|---|---|---|
| master (100 ms) | 436 ms | 736 ms | 738 ms | 839 ms |
| this PR (2 ms) | **111 ms** | 117 ms | 119 ms | 120 ms |

**~4× p50, ~6× p99** under concurrency. Single uncontended clone is unaffected. No format/API change.

> A blocking `syscall.Flock` + `LOCK_SH` for read-only `With()` (so list polls stop serializing against each other) is the fuller fix the audit flagged; this is the one-line, zero-risk first step.