### PR TITLE
perf(snapshot): persist snapshot save through the direct-capture path

### DIFF
--- a/cmd/core/utils.go
+++ b/cmd/core/utils.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -264,6 +265,7 @@ func PersistSnapshotDir(ctx context.Context, snapBackend snapshot.Snapshot, cfg 
 	if dc, ok := snapBackend.(snapshot.DirectCreator); ok {
 		id, done, err := dc.CreateFromDir(ctx, cfg, srcDir)
 		if err != nil {
+			os.RemoveAll(srcDir) //nolint:errcheck,gosec // consume srcDir on every path: a failed direct save must not leave the GB capture dir behind
 			return "", fmt.Errorf("save snapshot: %w", err)
 		}
 		if done {

--- a/cmd/core/utils.go
+++ b/cmd/core/utils.go
@@ -243,18 +243,18 @@ func EnsureSnapshotNameFree(ctx context.Context, snapBackend snapshot.Snapshot, 
 	return nil
 }
 
-// CaptureSnapshot checks the --name preflight, runs capture, and persists the stream, returning the stored snapshot id.
-func CaptureSnapshot(ctx context.Context, cmd *cobra.Command, snapBackend snapshot.Snapshot, capture func() (*types.SnapshotConfig, io.ReadCloser, error)) (string, error) {
+// CaptureSnapshot checks the --name preflight, runs capture, and persists the capture dir, returning the stored snapshot id.
+func CaptureSnapshot(ctx context.Context, cmd *cobra.Command, snapBackend snapshot.Snapshot, capture func() (*types.SnapshotConfig, string, error)) (string, error) {
 	name, _ := cmd.Flags().GetString("name")
 	description, _ := cmd.Flags().GetString("description")
 	if err := EnsureSnapshotNameFree(ctx, snapBackend, name); err != nil {
 		return "", err
 	}
-	cfg, stream, err := capture()
+	cfg, srcDir, err := capture()
 	if err != nil {
 		return "", err
 	}
-	return PersistSnapshotStream(ctx, snapBackend, cfg, stream, name, description)
+	return PersistSnapshotDir(ctx, snapBackend, cfg, srcDir, name, description)
 }
 
 // PersistSnapshotDir stores a finalized capture dir, preferring a direct in-place move (DirectCreator) when srcDir shares a filesystem with the backend's data dir, and falling back to a tar stream otherwise (cross-filesystem, or a backend without DirectCreator such as a remote store). srcDir is consumed on every path.

--- a/cmd/core/utils_test.go
+++ b/cmd/core/utils_test.go
@@ -1,9 +1,13 @@
 package core
 
 import (
+	"context"
+	"errors"
+	"os"
 	"strings"
 	"testing"
 
+	"github.com/cocoonstack/cocoon/snapshot"
 	"github.com/cocoonstack/cocoon/types"
 )
 
@@ -181,4 +185,28 @@ func TestNormalizeDataDiskSpecs(t *testing.T) {
 			t.Error("expected duplicate-name error")
 		}
 	})
+}
+
+// directErrSnap is a DirectCreator whose CreateFromDir always fails; the
+// embedded interface panics on any other call, so the test proves the failure
+// path alone.
+type directErrSnap struct {
+	snapshot.Snapshot
+}
+
+func (directErrSnap) CreateFromDir(context.Context, *types.SnapshotConfig, string) (string, bool, error) {
+	return "", false, errors.New("disk full")
+}
+
+func TestPersistSnapshotDirCleansCaptureOnDirectError(t *testing.T) {
+	srcDir, err := os.MkdirTemp(t.TempDir(), "capture-*")
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	if _, err := PersistSnapshotDir(context.Background(), directErrSnap{}, &types.SnapshotConfig{}, srcDir, "s", ""); err == nil {
+		t.Fatal("want error from a failed direct save")
+	}
+	if _, err := os.Stat(srcDir); !os.IsNotExist(err) {
+		t.Errorf("capture dir survived a failed direct save: %v", err)
+	}
 }

--- a/cmd/snapshot/handler.go
+++ b/cmd/snapshot/handler.go
@@ -41,7 +41,7 @@ func (h Handler) Save(cmd *cobra.Command, args []string) error {
 	}
 
 	logger.Infof(ctx, "snapshotting VM %s ...", vmRef)
-	snapID, err := cmdcore.CaptureSnapshot(ctx, cmd, snapBackend, func() (*types.SnapshotConfig, io.ReadCloser, error) {
+	snapID, err := cmdcore.CaptureSnapshot(ctx, cmd, snapBackend, func() (*types.SnapshotConfig, string, error) {
 		return hyper.Snapshot(ctx, vmRef)
 	})
 	if err != nil {

--- a/hypervisor/cloudhypervisor/snapshot.go
+++ b/hypervisor/cloudhypervisor/snapshot.go
@@ -3,7 +3,6 @@ package cloudhypervisor
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -14,8 +13,8 @@ import (
 	"github.com/cocoonstack/cocoon/utils"
 )
 
-// Snapshot pauses, captures CH state+COW, resumes, and streams the result.
-func (ch *CloudHypervisor) Snapshot(ctx context.Context, ref string) (*types.SnapshotConfig, io.ReadCloser, error) {
+// Snapshot pauses, captures CH state+COW, resumes, and returns the capture dir.
+func (ch *CloudHypervisor) Snapshot(ctx context.Context, ref string) (*types.SnapshotConfig, string, error) {
 	return ch.SnapshotSequence(ctx, ref, ch.snapshotSpec(ctx))
 }
 

--- a/hypervisor/firecracker/snapshot.go
+++ b/hypervisor/firecracker/snapshot.go
@@ -3,7 +3,6 @@ package firecracker
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"path/filepath"
 
@@ -17,8 +16,8 @@ const (
 	snapshotMemFile     = "mem"
 )
 
-// Snapshot pauses, captures vmstate+mem+COW, resumes, and streams the result.
-func (fc *Firecracker) Snapshot(ctx context.Context, ref string) (*types.SnapshotConfig, io.ReadCloser, error) {
+// Snapshot pauses, captures vmstate+mem+COW, resumes, and returns the capture dir.
+func (fc *Firecracker) Snapshot(ctx context.Context, ref string) (*types.SnapshotConfig, string, error) {
 	return fc.SnapshotSequence(ctx, ref, fc.snapshotSpec(ctx))
 }
 

--- a/hypervisor/hypervisor.go
+++ b/hypervisor/hypervisor.go
@@ -27,7 +27,7 @@ type Hypervisor interface {
 	Delete(ctx context.Context, refs []string, force bool) ([]string, error)
 	Console(ctx context.Context, ref string) (io.ReadWriteCloser, error)
 	LogPath(ctx context.Context, ref string) (string, error)
-	Snapshot(ctx context.Context, ref string) (*types.SnapshotConfig, io.ReadCloser, error)
+	Snapshot(ctx context.Context, ref string) (*types.SnapshotConfig, string, error)
 	Clone(ctx context.Context, vmID string, vmCfg *types.VMConfig, net types.NetSetup, snapshotConfig *types.SnapshotConfig, snapshot io.Reader) (*types.VM, error)
 	Restore(ctx context.Context, vmRef string, vmCfg *types.VMConfig, snapshot io.Reader, sourceSnapshotID string) (*types.VM, error)
 

--- a/hypervisor/snapshot.go
+++ b/hypervisor/snapshot.go
@@ -3,7 +3,6 @@ package hypervisor
 import (
 	"context"
 	"fmt"
-	"io"
 	"maps"
 	"os"
 	"path/filepath"
@@ -63,11 +62,11 @@ func (b *Backend) BuildSnapshotConfig(snapID string, rec *VMRecord) *types.Snaps
 	return cfg
 }
 
-// SnapshotSequence is the shared capture skeleton; only capture runs in the pause window — AfterCapture (e.g. cidata copy) runs outside.
-func (b *Backend) SnapshotSequence(ctx context.Context, ref string, spec SnapshotSpec) (_ *types.SnapshotConfig, _ io.ReadCloser, err error) {
+// SnapshotSequence is the shared capture skeleton; only capture runs in the pause window — AfterCapture (e.g. cidata copy) runs outside. It returns the finalized capture dir, which the caller consumes (PersistSnapshotDir).
+func (b *Backend) SnapshotSequence(ctx context.Context, ref string, spec SnapshotSpec) (_ *types.SnapshotConfig, _ string, err error) {
 	vmID, rec, tmpDir, unlock, err := b.prepareSnapshot(ctx, ref)
 	if err != nil {
-		return nil, nil, err
+		return nil, "", err
 	}
 	defer unlock()
 	defer func() {
@@ -85,13 +84,13 @@ func (b *Backend) SnapshotSequence(ctx context.Context, ref string, spec Snapsho
 		})
 	}
 	if err = runWrapped(&rec, spec.Wrap, captureWindow); err != nil {
-		return nil, nil, fmt.Errorf("snapshot VM %s: %w", vmID, err)
+		return nil, "", fmt.Errorf("snapshot VM %s: %w", vmID, err)
 	}
 	cfg, err := b.finalizeSnapshot(ctx, vmID, &rec, spec, tmpDir)
 	if err != nil {
-		return nil, nil, err
+		return nil, "", err
 	}
-	return cfg, utils.TarDirStreamWithRemove(tmpDir), nil
+	return cfg, tmpDir, nil
 }
 
 // HibernateSequence is SnapshotSequence with persist inside the pause window and terminate instead of resume: the snapshot point and the stop coincide, any failure before terminate resumes the VM, and a failed terminate marks it error.


### PR DESCRIPTION
`snapshot save` still paid the tar round-trip #109 removed for hibernate: the hypervisor writes the capture dir, then `Create` re-read it, tar-framed it, and re-wrote every file into the snapshot store with per-file fsyncs — a full extra I/O pass over memory+COW on the same filesystem. This is the direct sibling of #109, using the machinery it landed.

## Change (16+/19−, no new code paths)
- `Hypervisor.Snapshot` returns the **finalized capture dir** instead of a tar stream (interface + CH + FC + `SnapshotSequence`).
- `CaptureSnapshot` persists it via the existing `PersistSnapshotDir`: `CreateFromDir` rename when the dir shares a filesystem with the store, tar-stream fallback otherwise — identical durability (`CreateFromDir` runs `SyncTree`; the tar path fsyncs per file).
- Pause window unchanged: capture still runs inside it, persist stays outside (unlike hibernate, the VM resumes first).

## Evidence (.79 bare metal, master base)
`snapshot save` on a running 1G rt VM, ×5:

| build | wall (median) | path |
|---|---|---|
| master | ~383 ms (383–524) | stream |
| this PR | **~253 ms** (253–258) | direct ×5 |

**1.5× (−34%)**, and the tail tightens. Correctness: a NEW-saved snapshot **exports** (same file set), **clones** (`vm clone --from-dir` boots + answers silkd), and **restores** (`vm stop` → `vm restore` → alive). Full sandbox `sandboxd-e2e.sh` against this binary: **E2E_EXIT=0, SMOKE 15/15**, checkpoint step 469 ms — the lowest of today's runs (prior 516–572 ms on master).

Gate: `go test -race ./...` ok, `make lint` (pinned v2.9.0) linux+darwin 0 issues. `snapshot save` CLI output/JSON unchanged; sandboxd's fork/promote/checkpoint (which call `snapshot save` + `export`) benefit directly.