### PR TITLE
perf(snapshot): drop fsyncs on transient extract/copy paths; fold NoSync variants into SyncMode

### DIFF
--- a/hypervisor/clone.go
+++ b/hypervisor/clone.go
@@ -59,7 +59,7 @@ func (b *Backend) CloneFromStream(
 		}
 	}()
 
-	if err = utils.ExtractTar(runDir, snapshot, isLockFile); err != nil {
+	if err = utils.ExtractTar(runDir, snapshot, utils.NoSync, isLockFile); err != nil {
 		return nil, fmt.Errorf("extract snapshot: %w", err)
 	}
 

--- a/hypervisor/cloudhypervisor/patch.go
+++ b/hypervisor/cloudhypervisor/patch.go
@@ -60,7 +60,7 @@ func patchCHConfig(path string, opts *patchOptions) error {
 		}
 	}
 
-	return utils.AtomicWriteJSONNoSync(path, raw)
+	return utils.AtomicWriteJSON(path, raw, utils.NoSync)
 }
 
 func patchDisks(diskRaw json.RawMessage, opts *patchOptions) (json.RawMessage, error) {

--- a/hypervisor/cloudhypervisor/utils.go
+++ b/hypervisor/cloudhypervisor/utils.go
@@ -46,7 +46,7 @@ type chRestoreConfig struct {
 
 func (ch *CloudHypervisor) saveCmdline(ctx context.Context, rec *hypervisor.VMRecord, args []string) {
 	line := ch.conf.CHBinary + " " + strings.Join(args, " ")
-	if err := utils.AtomicWriteFileNoSync(filepath.Join(rec.RunDir, cmdlineFileName), []byte(line), 0o600); err != nil {
+	if err := utils.AtomicWriteFile(filepath.Join(rec.RunDir, cmdlineFileName), []byte(line), 0o600, utils.NoSync); err != nil {
 		log.WithFunc("cloudhypervisor.saveCmdline").Warnf(ctx, "save cmdline: %v", err)
 	}
 }

--- a/hypervisor/firecracker/create.go
+++ b/hypervisor/firecracker/create.go
@@ -126,7 +126,7 @@ func EnsureVmlinux(kernelPath string) (string, error) {
 		return "", fmt.Errorf("decompress kernel from %s: %w (FC requires uncompressed ELF kernel)", kernelPath, decompErr)
 	}
 
-	if err := utils.AtomicWriteFile(vmlinuxPath, decompressed, 0o600); err != nil {
+	if err := utils.AtomicWriteFile(vmlinuxPath, decompressed, 0o600, utils.Sync); err != nil {
 		return "", fmt.Errorf("write vmlinux: %w", err)
 	}
 	return vmlinuxPath, nil

--- a/hypervisor/restore.go
+++ b/hypervisor/restore.go
@@ -247,7 +247,7 @@ func PrepareStagingDir(runDir string, snapshot io.Reader) (stagingDir string, cl
 		return "", nil, fmt.Errorf("create staging dir: %w", err)
 	}
 	cleanup = func() { os.RemoveAll(stagingDir) } //nolint:errcheck,gosec
-	if err = utils.ExtractTar(stagingDir, snapshot, isLockFile); err != nil {
+	if err = utils.ExtractTar(stagingDir, snapshot, utils.NoSync, isLockFile); err != nil {
 		cleanup()
 		return "", nil, fmt.Errorf("extract snapshot: %w", err)
 	}

--- a/hypervisor/snapshot.go
+++ b/hypervisor/snapshot.go
@@ -203,7 +203,7 @@ func (b *Backend) finalizeSnapshot(ctx context.Context, vmID string, rec *VMReco
 }
 
 func SaveSnapshotMeta(dir string, meta *SnapshotMeta) error {
-	return utils.AtomicWriteJSON(filepath.Join(dir, SnapshotMetaFile), meta)
+	return utils.AtomicWriteJSON(filepath.Join(dir, SnapshotMetaFile), meta, utils.Sync)
 }
 
 func LoadSnapshotMeta(dir string) (*SnapshotMeta, error) {

--- a/hypervisor/utils.go
+++ b/hypervisor/utils.go
@@ -364,7 +364,7 @@ func CloneSnapshotFiles(ctx context.Context, dstDir, srcDir string, classify fun
 		case SnapshotFileSkip:
 		}
 	}
-	return copyPairs(ctx, cowPairs, utils.Sync)
+	return copyPairs(ctx, cowPairs, utils.NoSync)
 }
 
 // CleanSnapshotFiles removes snapshot-specific files from runDir.

--- a/snapshot/envelope.go
+++ b/snapshot/envelope.go
@@ -50,5 +50,5 @@ func WriteSnapshotEnvelope(dir string, cfg types.SnapshotConfig) error {
 	if err != nil {
 		return err
 	}
-	return utils.AtomicWriteFile(filepath.Join(dir, SnapshotJSONName), data, 0o644)
+	return utils.AtomicWriteFile(filepath.Join(dir, SnapshotJSONName), data, 0o644, utils.Sync)
 }

--- a/snapshot/localfile/import.go
+++ b/snapshot/localfile/import.go
@@ -43,7 +43,7 @@ func (lf *LocalFile) Import(ctx context.Context, r io.Reader, name, description 
 		}
 	}()
 
-	if err = utils.ExtractTar(dataDir, tarReader); err != nil {
+	if err = utils.ExtractTar(dataDir, tarReader, utils.Sync); err != nil {
 		return "", fmt.Errorf("extract archive: %w", err)
 	}
 	// Verify gzip checksum (CRC32 + size) when the input was gzip-wrapped.

--- a/snapshot/localfile/localfile.go
+++ b/snapshot/localfile/localfile.go
@@ -156,7 +156,7 @@ func (lf *LocalFile) Create(ctx context.Context, cfg *types.SnapshotConfig, stre
 	if err = os.MkdirAll(dataDir, 0o750); err != nil {
 		return "", fmt.Errorf("create data dir: %w", err)
 	}
-	if err = utils.ExtractTar(dataDir, stream); err != nil {
+	if err = utils.ExtractTar(dataDir, stream, utils.NoSync); err != nil {
 		return "", fmt.Errorf("extract snapshot data: %w", err)
 	}
 	if err = utils.SyncTree(dataDir); err != nil {

--- a/storage/json/json.go
+++ b/storage/json/json.go
@@ -43,7 +43,7 @@ func (s *Store[T]) WriteRaw(fn func(*T) error) error {
 	if err := fn(data); err != nil {
 		return err
 	}
-	return utils.AtomicWriteJSON(s.filePath, data)
+	return utils.AtomicWriteJSON(s.filePath, data, utils.Sync)
 }
 
 // With runs fn read-only under the store lock.

--- a/utils/atomic.go
+++ b/utils/atomic.go
@@ -18,26 +18,55 @@ const (
 // SyncMode selects whether a write helper fsyncs its output.
 type SyncMode bool
 
-// AtomicWriteFile writes data via temp + fsync + rename so readers never see a partial file.
-func AtomicWriteFile(path string, data []byte, perm os.FileMode) error {
-	return atomicWriteFile(path, data, perm, true)
-}
+// AtomicWriteFile writes data via temp + rename so readers never see a partial file; Sync adds the fsyncs that make it durable.
+func AtomicWriteFile(path string, data []byte, perm os.FileMode, sync SyncMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
 
-// AtomicWriteFileNoSync is AtomicWriteFile without the fsyncs, for transient
-// run-dir files regenerated on the next launch.
-func AtomicWriteFileNoSync(path string, data []byte, perm os.FileMode) error {
-	return atomicWriteFile(path, data, perm, false)
+	defer func() {
+		if err != nil {
+			_ = tmp.Close()
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err = tmp.Write(data); err != nil {
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if sync {
+		if err = tmp.Sync(); err != nil {
+			return fmt.Errorf("sync temp file: %w", err)
+		}
+	}
+	if err = tmp.Chmod(perm); err != nil {
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if err = tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err = os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("rename temp to target: %w", err)
+	}
+	if sync {
+		if err = SyncParentDir(dir); err != nil {
+			return fmt.Errorf("sync parent dir: %w", err)
+		}
+	}
+	return nil
 }
 
 // AtomicWriteJSON marshals v to JSON and writes it atomically.
-func AtomicWriteJSON(path string, v any) error {
-	return atomicWriteJSON(path, v, true)
-}
-
-// AtomicWriteJSONNoSync marshals v and writes it atomically without fsync
-// (see AtomicWriteFileNoSync).
-func AtomicWriteJSONNoSync(path string, v any) error {
-	return atomicWriteJSON(path, v, false)
+func AtomicWriteJSON(path string, v any, sync SyncMode) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("marshal JSON: %w", err)
+	}
+	data = append(data, '\n')
+	return AtomicWriteFile(path, data, 0o644, sync)
 }
 
 // ReadJSONFile loads path and unmarshals it into v.
@@ -85,55 +114,6 @@ func SyncTree(dir string) error {
 		return err
 	}
 	return SyncParentDir(filepath.Dir(dir))
-}
-
-func atomicWriteFile(path string, data []byte, perm os.FileMode, sync bool) error {
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, ".tmp-*")
-	if err != nil {
-		return fmt.Errorf("create temp file: %w", err)
-	}
-	tmpPath := tmp.Name()
-
-	defer func() {
-		if err != nil {
-			_ = tmp.Close()
-			_ = os.Remove(tmpPath)
-		}
-	}()
-
-	if _, err = tmp.Write(data); err != nil {
-		return fmt.Errorf("write temp file: %w", err)
-	}
-	if sync {
-		if err = tmp.Sync(); err != nil {
-			return fmt.Errorf("sync temp file: %w", err)
-		}
-	}
-	if err = tmp.Chmod(perm); err != nil {
-		return fmt.Errorf("chmod temp file: %w", err)
-	}
-	if err = tmp.Close(); err != nil {
-		return fmt.Errorf("close temp file: %w", err)
-	}
-	if err = os.Rename(tmpPath, path); err != nil {
-		return fmt.Errorf("rename temp to target: %w", err)
-	}
-	if sync {
-		if err = SyncParentDir(dir); err != nil {
-			return fmt.Errorf("sync parent dir: %w", err)
-		}
-	}
-	return nil
-}
-
-func atomicWriteJSON(path string, v any, sync bool) error {
-	data, err := json.Marshal(v)
-	if err != nil {
-		return fmt.Errorf("marshal JSON: %w", err)
-	}
-	data = append(data, '\n')
-	return atomicWriteFile(path, data, 0o644, sync)
 }
 
 func syncFile(path string) (err error) {

--- a/utils/atomic_test.go
+++ b/utils/atomic_test.go
@@ -12,7 +12,7 @@ func TestAtomicWriteFile_Basic(t *testing.T) {
 	path := filepath.Join(dir, "test.dat")
 	data := []byte("hello atomic")
 
-	if err := AtomicWriteFile(path, data, 0o644); err != nil {
+	if err := AtomicWriteFile(path, data, 0o644, Sync); err != nil {
 		t.Fatalf("AtomicWriteFile: %v", err)
 	}
 
@@ -37,10 +37,10 @@ func TestAtomicWriteFile_Overwrite(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "overwrite.dat")
 
-	if err := AtomicWriteFile(path, []byte("old"), 0o644); err != nil {
+	if err := AtomicWriteFile(path, []byte("old"), 0o644, Sync); err != nil {
 		t.Fatal(err)
 	}
-	if err := AtomicWriteFile(path, []byte("new"), 0o600); err != nil {
+	if err := AtomicWriteFile(path, []byte("new"), 0o600, Sync); err != nil {
 		t.Fatal(err)
 	}
 
@@ -81,7 +81,7 @@ func TestAtomicWriteFile_EmptyData(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "empty.dat")
 
-	if err := AtomicWriteFile(path, nil, 0o644); err != nil {
+	if err := AtomicWriteFile(path, nil, 0o644, Sync); err != nil {
 		t.Fatal(err)
 	}
 
@@ -95,7 +95,7 @@ func TestAtomicWriteFile_EmptyData(t *testing.T) {
 }
 
 func TestAtomicWriteFile_BadDir(t *testing.T) {
-	err := AtomicWriteFile("/nonexistent/dir/file.dat", []byte("x"), 0o644)
+	err := AtomicWriteFile("/nonexistent/dir/file.dat", []byte("x"), 0o644, Sync)
 	if err == nil {
 		t.Fatal("expected error for nonexistent directory")
 	}
@@ -105,7 +105,7 @@ func TestAtomicWriteFile_NoTempLeftBehind(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "clean.dat")
 
-	if err := AtomicWriteFile(path, []byte("data"), 0o644); err != nil {
+	if err := AtomicWriteFile(path, []byte("data"), 0o644, Sync); err != nil {
 		t.Fatal(err)
 	}
 
@@ -120,7 +120,7 @@ func TestAtomicWriteJSON_Basic(t *testing.T) {
 	path := filepath.Join(dir, "data.json")
 
 	input := map[string]string{"key": "value"}
-	if err := AtomicWriteJSON(path, input); err != nil {
+	if err := AtomicWriteJSON(path, input, Sync); err != nil {
 		t.Fatal(err)
 	}
 
@@ -150,7 +150,7 @@ func TestAtomicWriteJSON_Struct(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.json")
 
-	if err := AtomicWriteJSON(path, Config{Name: "test", Count: 42}); err != nil {
+	if err := AtomicWriteJSON(path, Config{Name: "test", Count: 42}, Sync); err != nil {
 		t.Fatal(err)
 	}
 
@@ -173,7 +173,7 @@ func TestAtomicWriteJSON_Unmarshalable(t *testing.T) {
 	path := filepath.Join(dir, "bad.json")
 
 	// Channels can't be marshaled.
-	err := AtomicWriteJSON(path, make(chan int))
+	err := AtomicWriteJSON(path, make(chan int), Sync)
 	if err == nil {
 		t.Fatal("expected error for unmarshalable value")
 	}
@@ -183,7 +183,7 @@ func TestAtomicWriteJSON_Permissions(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "perm.json")
 
-	if err := AtomicWriteJSON(path, "hello"); err != nil {
+	if err := AtomicWriteJSON(path, "hello", Sync); err != nil {
 		t.Fatal(err)
 	}
 

--- a/utils/tar.go
+++ b/utils/tar.go
@@ -55,7 +55,7 @@ func TarDir(tw *tar.Writer, dir string) error {
 }
 
 // ExtractTar extracts flat tar entries into dir; entries matching any skip predicate are dropped.
-func ExtractTar(dir string, r io.Reader, skip ...func(name string) bool) error {
+func ExtractTar(dir string, r io.Reader, sync SyncMode, skip ...func(name string) bool) error {
 	tr := tar.NewReader(r)
 	for {
 		hdr, err := tr.Next()
@@ -82,11 +82,11 @@ func ExtractTar(dir string, r io.Reader, skip ...func(name string) bool) error {
 			if parseErr != nil {
 				return fmt.Errorf("parse sparse size for %s: %w", name, parseErr)
 			}
-			if err := extractFileSparse(outPath, tr, hdr.FileInfo().Mode(), realSize, mapJSON); err != nil {
+			if err := extractFileSparse(outPath, tr, hdr.FileInfo().Mode(), realSize, mapJSON, sync); err != nil {
 				return fmt.Errorf("extract sparse %s: %w", name, err)
 			}
 		} else {
-			if err := extractFile(outPath, tr, hdr.FileInfo().Mode()); err != nil {
+			if err := extractFile(outPath, tr, hdr.FileInfo().Mode(), sync); err != nil {
 				return fmt.Errorf("extract %s: %w", name, err)
 			}
 		}
@@ -112,7 +112,7 @@ func tarFileFrom(tw *tar.Writer, f *os.File, fi os.FileInfo, nameInTar string) e
 }
 
 // extractFileSparse restores a sparse file from its segment map.
-func extractFileSparse(path string, r io.Reader, perm os.FileMode, realSize int64, mapJSON string) error {
+func extractFileSparse(path string, r io.Reader, perm os.FileMode, realSize int64, mapJSON string, sync SyncMode) error {
 	var segments []sparseSegment
 	if err := json.Unmarshal([]byte(mapJSON), &segments); err != nil {
 		return fmt.Errorf("decode sparse map: %w", err)
@@ -137,10 +137,13 @@ func extractFileSparse(path string, r io.Reader, perm os.FileMode, realSize int6
 		}
 	}
 
+	if !sync {
+		return nil
+	}
 	return f.Sync()
 }
 
-func extractFile(path string, r io.Reader, perm os.FileMode) error {
+func extractFile(path string, r io.Reader, perm os.FileMode, sync SyncMode) error {
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm) //nolint:gosec
 	if err != nil {
 		return err
@@ -178,6 +181,9 @@ func extractFile(path string, r io.Reader, perm os.FileMode) error {
 		}
 	}
 
+	if !sync {
+		return nil
+	}
 	return f.Sync()
 }
 

--- a/utils/tar_sparse_linux_test.go
+++ b/utils/tar_sparse_linux_test.go
@@ -65,7 +65,7 @@ func TestTarFileMaybeSparse_FallbackRoundTrip(t *testing.T) {
 	}
 
 	dst := t.TempDir()
-	if err := ExtractTar(dst, &buf); err != nil {
+	if err := ExtractTar(dst, &buf, Sync); err != nil {
 		t.Fatalf("ExtractTar: %v", err)
 	}
 

--- a/utils/tar_test.go
+++ b/utils/tar_test.go
@@ -177,7 +177,7 @@ func TestExtractTar(t *testing.T) {
 	buf := makeTar(t, files)
 
 	dir := t.TempDir()
-	if err := ExtractTar(dir, buf); err != nil {
+	if err := ExtractTar(dir, buf, Sync); err != nil {
 		t.Fatalf("ExtractTar: %v", err)
 	}
 
@@ -203,7 +203,7 @@ func TestExtractTar_SkipsDirectories(t *testing.T) {
 	tw.Close()                                                                                 //nolint:errcheck
 
 	dir := t.TempDir()
-	if err := ExtractTar(dir, &buf); err != nil {
+	if err := ExtractTar(dir, &buf, Sync); err != nil {
 		t.Fatalf("ExtractTar: %v", err)
 	}
 
@@ -225,7 +225,7 @@ func TestExtractTar_PathTraversal(t *testing.T) {
 	buf := makeTar(t, files)
 
 	dir := t.TempDir()
-	if err := ExtractTar(dir, buf); err != nil {
+	if err := ExtractTar(dir, buf, Sync); err != nil {
 		t.Fatalf("ExtractTar: %v", err)
 	}
 
@@ -251,7 +251,7 @@ func TestExtractTar_SkipsDotNames(t *testing.T) {
 	tw.Close()                                                                               //nolint:errcheck
 
 	dir := t.TempDir()
-	if err := ExtractTar(dir, &buf); err != nil {
+	if err := ExtractTar(dir, &buf, Sync); err != nil {
 		t.Fatal(err)
 	}
 	entries, _ := os.ReadDir(dir)
@@ -263,7 +263,7 @@ func TestExtractTar_SkipsDotNames(t *testing.T) {
 func TestExtractTar_Empty(t *testing.T) {
 	buf := makeTar(t, nil)
 	dir := t.TempDir()
-	if err := ExtractTar(dir, buf); err != nil {
+	if err := ExtractTar(dir, buf, Sync); err != nil {
 		t.Fatalf("ExtractTar: %v", err)
 	}
 	entries, _ := os.ReadDir(dir)
@@ -273,7 +273,7 @@ func TestExtractTar_Empty(t *testing.T) {
 }
 
 func TestExtractTar_InvalidData(t *testing.T) {
-	if err := ExtractTar(t.TempDir(), strings.NewReader("not a tar")); err == nil {
+	if err := ExtractTar(t.TempDir(), strings.NewReader("not a tar"), Sync); err == nil {
 		t.Fatal("expected error for invalid tar")
 	}
 }
@@ -299,7 +299,7 @@ func TestExtractTar_RoundTrip(t *testing.T) {
 	tw.Close() //nolint:errcheck
 
 	dstDir := t.TempDir()
-	if err := ExtractTar(dstDir, &buf); err != nil {
+	if err := ExtractTar(dstDir, &buf, NoSync); err != nil {
 		t.Fatalf("ExtractTar: %v", err)
 	}
 
@@ -323,7 +323,7 @@ func TestExtractTar_Sparse_SingleSegment(t *testing.T) {
 
 	buf := makeTarSparse(t, "sparse.bin", realSize, segments, dataContent)
 	dir := t.TempDir()
-	if err := ExtractTar(dir, buf); err != nil {
+	if err := ExtractTar(dir, buf, Sync); err != nil {
 		t.Fatal(err)
 	}
 
@@ -368,7 +368,7 @@ func TestExtractTar_Sparse_MultipleSegments(t *testing.T) {
 
 	buf := makeTarSparse(t, "multi.bin", realSize, segments, data)
 	dir := t.TempDir()
-	if err := ExtractTar(dir, buf); err != nil {
+	if err := ExtractTar(dir, buf, Sync); err != nil {
 		t.Fatal(err)
 	}
 
@@ -406,7 +406,7 @@ func TestExtractTar_Sparse_EntireFileIsHole(t *testing.T) {
 	const realSize = 32 * 1024
 	buf := makeTarSparse(t, "allhole.bin", realSize, nil, nil)
 	dir := t.TempDir()
-	if err := ExtractTar(dir, buf); err != nil {
+	if err := ExtractTar(dir, buf, Sync); err != nil {
 		t.Fatal(err)
 	}
 
@@ -437,7 +437,7 @@ func TestExtractTar_Sparse_InvalidMapJSON(t *testing.T) {
 	})
 	tw.Close() //nolint:errcheck
 
-	if err := ExtractTar(t.TempDir(), &buf); err == nil {
+	if err := ExtractTar(t.TempDir(), &buf, Sync); err == nil {
 		t.Fatal("expected error for invalid sparse map JSON")
 	}
 }
@@ -458,7 +458,7 @@ func TestExtractTar_Sparse_InvalidSizeString(t *testing.T) {
 	})
 	tw.Close() //nolint:errcheck
 
-	if err := ExtractTar(t.TempDir(), &buf); err == nil {
+	if err := ExtractTar(t.TempDir(), &buf, Sync); err == nil {
 		t.Fatal("expected error for invalid sparse size")
 	}
 }
@@ -490,7 +490,7 @@ func TestExtractTar_Sparse_MixedWithRegularEntries(t *testing.T) {
 	tw.Close()            //nolint:errcheck
 
 	dir := t.TempDir()
-	if err := ExtractTar(dir, &buf); err != nil {
+	if err := ExtractTar(dir, &buf, Sync); err != nil {
 		t.Fatal(err)
 	}
 
@@ -523,7 +523,7 @@ func TestExtractFile_AllZeroBlocks(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "zeros.bin")
 
-	if err := extractFile(path, bytes.NewReader(data), 0o644); err != nil {
+	if err := extractFile(path, bytes.NewReader(data), 0o644, NoSync); err != nil {
 		t.Fatal(err)
 	}
 
@@ -545,7 +545,7 @@ func TestExtractFile_NoZeroBlocks(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "dense.bin")
 
-	if err := extractFile(path, bytes.NewReader(data), 0o644); err != nil {
+	if err := extractFile(path, bytes.NewReader(data), 0o644, Sync); err != nil {
 		t.Fatal(err)
 	}
 
@@ -567,7 +567,7 @@ func TestExtractFile_MixedZeroAndData(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "mixed.bin")
 
-	if err := extractFile(path, bytes.NewReader(data), 0o644); err != nil {
+	if err := extractFile(path, bytes.NewReader(data), 0o644, Sync); err != nil {
 		t.Fatal(err)
 	}
 
@@ -589,7 +589,7 @@ func TestExtractFile_EndsWithHole(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "endhole.bin")
 
-	if err := extractFile(path, bytes.NewReader(data), 0o644); err != nil {
+	if err := extractFile(path, bytes.NewReader(data), 0o644, NoSync); err != nil {
 		t.Fatal(err)
 	}
 
@@ -608,7 +608,7 @@ func TestExtractFile_PartialBlock(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "partial.bin")
 
-	if err := extractFile(path, bytes.NewReader(data), 0o644); err != nil {
+	if err := extractFile(path, bytes.NewReader(data), 0o644, Sync); err != nil {
 		t.Fatal(err)
 	}
 
@@ -627,7 +627,7 @@ func TestExtractFile_PartialZeroBlock(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "pzero.bin")
 
-	if err := extractFile(path, bytes.NewReader(data), 0o644); err != nil {
+	if err := extractFile(path, bytes.NewReader(data), 0o644, Sync); err != nil {
 		t.Fatal(err)
 	}
 
@@ -647,7 +647,7 @@ func TestExtractFile_EmptyInput(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "empty.bin")
 
-	if err := extractFile(path, bytes.NewReader(nil), 0o644); err != nil {
+	if err := extractFile(path, bytes.NewReader(nil), 0o644, NoSync); err != nil {
 		t.Fatal(err)
 	}
 
@@ -664,7 +664,7 @@ func TestExtractFile_SingleByte(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "single.bin")
 
-	if err := extractFile(path, bytes.NewReader([]byte{0x42}), 0o644); err != nil {
+	if err := extractFile(path, bytes.NewReader([]byte{0x42}), 0o644, Sync); err != nil {
 		t.Fatal(err)
 	}
 
@@ -682,7 +682,7 @@ func TestExtractFile_SingleZeroByte(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "onezero.bin")
 
-	if err := extractFile(path, bytes.NewReader([]byte{0x00}), 0o644); err != nil {
+	if err := extractFile(path, bytes.NewReader([]byte{0x00}), 0o644, Sync); err != nil {
 		t.Fatal(err)
 	}
 
@@ -792,7 +792,7 @@ func TestExtractTar_RoundTrip_LargeFile(t *testing.T) {
 	tw.Close() //nolint:errcheck
 
 	dstDir := t.TempDir()
-	if err := ExtractTar(dstDir, &buf); err != nil {
+	if err := ExtractTar(dstDir, &buf, Sync); err != nil {
 		t.Fatal(err)
 	}
 

--- a/utils/watch_test.go
+++ b/utils/watch_test.go
@@ -21,7 +21,7 @@ func TestWatchFile(t *testing.T) {
 	}
 
 	// Write via atomic rename (same pattern as AtomicWriteFile).
-	if err := AtomicWriteFile(target, []byte(`{"v":1}`), 0o644); err != nil {
+	if err := AtomicWriteFile(target, []byte(`{"v":1}`), 0o644, Sync); err != nil {
 		t.Fatal(err)
 	}
 
@@ -46,7 +46,7 @@ func TestWatchFileDebounce(t *testing.T) {
 
 	// Rapid successive writes should coalesce into one signal.
 	for i := range 5 {
-		if err := AtomicWriteFile(target, []byte{byte('0' + i)}, 0o644); err != nil {
+		if err := AtomicWriteFile(target, []byte{byte('0' + i)}, 0o644, Sync); err != nil {
 			t.Fatal(err)
 		}
 	}


### PR DESCRIPTION
**Stacked on #120** (review/merge that first; after it lands, rebase this branch onto the updated master and confirm the diff shows only this one commit before merging).

## What

The counterpart to #120: paths whose product is rebuilt from a durable source on retry stop paying per-file fsyncs.

- restore staging (`PrepareStagingDir`) and stream-clone extraction (`CloneFromStream`): `ExtractTar` gains the `SyncMode` parameter from #120; these pass `NoSync`.
- direct clone/restore file clones (`CloneSnapshotFiles` → `copyPairs`): flip to `NoSync`.
- store ingestion stays durable, now in a single sync pass: `Import` keeps `Sync`; `Create` extracts with `NoSync` and relies on its existing `SyncTree` (files + dir entries) — removing the double fsync #120 left (each file was synced by ExtractTar, then re-synced by SyncTree), and letting extraction overlap background writeback instead of blocking per file.
- `AtomicWriteFileNoSync` / `AtomicWriteJSONNoSync` fold into the same parameter — one sync convention across utils, five exported write helpers instead of ten.

## Crash-semantics change (the part to review)

Interrupted operations converge exactly as before (restore tombstone, create placeholder + GC). What changes: after host power loss, an instance cloned/restored within the writeback window (~30s) may have holes in its COW base. That surfaces as loud guest fs errors on the next cold boot; recovery is recreate (`vm rm` + re-clone/re-restore) — sources stay durable in the snapshot store. Ops note: after a host power-loss reboot, recreate instances cloned/restored in the last minute instead of debugging them.

## Why

Same measurement as #120: fsync tax ≈ 0.155 s/GiB on the ext4/NVMe floor (host `ai`), seconds/GiB on PD-class disks — paid on the clone/restore latency path for zero durability benefit (the extracted/copied working set is consumed immediately from page cache and is replayable).

## Verification

- `go build ./...`, `go vet ./...`
- `make test` (full suite, `-race`): 28 packages ok
- `make lint` (GOOS=linux + darwin): 0 issues