### PR TITLE
fix(snapshot): complete ingestion durability; move capture fsyncs off the pause window

### DIFF
--- a/hypervisor/cloudhypervisor/snapshot.go
+++ b/hypervisor/cloudhypervisor/snapshot.go
@@ -55,7 +55,7 @@ func (ch *CloudHypervisor) snapshotSpec(ctx context.Context) hypervisor.Snapshot
 			if _, statErr := os.Stat(cidataSrc); statErr != nil {
 				return nil
 			}
-			if cpErr := utils.SparseCopy(filepath.Join(tmpDir, cidataFile), cidataSrc); cpErr != nil {
+			if cpErr := utils.SparseCopy(filepath.Join(tmpDir, cidataFile), cidataSrc, utils.NoSync); cpErr != nil {
 				return fmt.Errorf("copy cidata: %w", cpErr)
 			}
 			return nil

--- a/hypervisor/disks.go
+++ b/hypervisor/disks.go
@@ -46,7 +46,7 @@ func DiskPathByRole(configs []*types.StorageConfig, role types.StorageRole) stri
 	return ""
 }
 
-// CopyWritableDisks reflinks the COW disk and every Role==Data disk into dstDir concurrently: inside the snapshot pause window, wall time is the longest single copy instead of the sum.
+// CopyWritableDisks reflinks the COW disk and every Role==Data disk into dstDir concurrently: inside the snapshot pause window, wall time is the longest single copy instead of the sum. Durability is paid at persist (SyncTree / store ingestion), not here.
 func CopyWritableDisks(ctx context.Context, dstDir, cowPath string, configs []*types.StorageConfig) error {
 	pairs := [][2]string{{filepath.Join(dstDir, filepath.Base(cowPath)), cowPath}}
 	for _, sc := range configs {
@@ -54,7 +54,7 @@ func CopyWritableDisks(ctx context.Context, dstDir, cowPath string, configs []*t
 			pairs = append(pairs, [2]string{filepath.Join(dstDir, DataDiskBaseName(sc.Serial)), sc.Path})
 		}
 	}
-	return copyPairs(ctx, pairs)
+	return copyPairs(ctx, pairs, utils.NoSync)
 }
 
 // PrepareDataDisks creates sparse files for each spec under baseDir, optionally formats (ext4 default), returns StorageConfigs; names must be unique and ValidDataDiskName-passing.
@@ -133,9 +133,9 @@ func ExpandRawImage(path string, targetSize int64) error {
 	return nil
 }
 
-func copyPairs(ctx context.Context, pairs [][2]string) error {
+func copyPairs(ctx context.Context, pairs [][2]string, sync utils.SyncMode) error {
 	_, err := utils.Map(ctx, pairs, func(_ context.Context, _ int, p [2]string) (struct{}, error) {
-		if err := utils.ReflinkCopy(p[0], p[1]); err != nil {
+		if err := utils.ReflinkCopy(p[0], p[1], sync); err != nil {
 			return struct{}{}, fmt.Errorf("copy %s: %w", filepath.Base(p[1]), err)
 		}
 		return struct{}{}, nil

--- a/hypervisor/utils.go
+++ b/hypervisor/utils.go
@@ -364,7 +364,7 @@ func CloneSnapshotFiles(ctx context.Context, dstDir, srcDir string, classify fun
 		case SnapshotFileSkip:
 		}
 	}
-	return copyPairs(ctx, cowPairs)
+	return copyPairs(ctx, cowPairs, utils.Sync)
 }
 
 // CleanSnapshotFiles removes snapshot-specific files from runDir.

--- a/snapshot/localfile/export.go
+++ b/snapshot/localfile/export.go
@@ -54,7 +54,7 @@ func (lf *LocalFile) ExportToDir(ctx context.Context, ref, dir string) error {
 	}
 	// Fan out: snapshot dirs hold a few large files (memory, COW, data disks), so wall time is the longest copy, not the sum.
 	if _, err = utils.Map(ctx, names, func(_ context.Context, _ int, name string) (struct{}, error) {
-		if copyErr := utils.ReflinkCopy(filepath.Join(dir, name), filepath.Join(dataDir, name)); copyErr != nil {
+		if copyErr := utils.ReflinkCopy(filepath.Join(dir, name), filepath.Join(dataDir, name), utils.Sync); copyErr != nil {
 			return struct{}{}, fmt.Errorf("copy %s: %w", name, copyErr)
 		}
 		return struct{}{}, nil

--- a/snapshot/localfile/localfile.go
+++ b/snapshot/localfile/localfile.go
@@ -159,6 +159,9 @@ func (lf *LocalFile) Create(ctx context.Context, cfg *types.SnapshotConfig, stre
 	if err = utils.ExtractTar(dataDir, stream); err != nil {
 		return "", fmt.Errorf("extract snapshot data: %w", err)
 	}
+	if err = utils.SyncTree(dataDir); err != nil {
+		return "", fmt.Errorf("sync snapshot to disk: %w", err)
+	}
 	if err = lf.finalizeCreate(ctx, cfg, dataDir); err != nil {
 		return "", err
 	}
@@ -205,7 +208,7 @@ func (lf *LocalFile) CreateFromDir(ctx context.Context, cfg *types.SnapshotConfi
 	if err = os.Chmod(dataDir, 0o750); err != nil { //nolint:gosec // match the store's 0o750 data dirs (MkdirAll in Create)
 		return "", false, fmt.Errorf("chmod data dir: %w", err)
 	}
-	// Durable before kill: the VMM dies once we return and a bare rename fsyncs nothing, so sync files and dir entries before finalize (the tar path fsyncs per file in ExtractTar).
+	// Durable before kill: the VMM dies once we return and a bare rename fsyncs nothing, so sync files and dir entries before finalize.
 	if err = utils.SyncTree(dataDir); err != nil {
 		return "", false, fmt.Errorf("sync snapshot to disk: %w", err)
 	}

--- a/utils/atomic.go
+++ b/utils/atomic.go
@@ -9,6 +9,15 @@ import (
 	"syscall"
 )
 
+const (
+	// Sync fsyncs the written output; NoSync skips that for transient artifacts rebuilt from a durable source on retry.
+	Sync   SyncMode = true
+	NoSync SyncMode = false
+)
+
+// SyncMode selects whether a write helper fsyncs its output.
+type SyncMode bool
+
 // AtomicWriteFile writes data via temp + fsync + rename so readers never see a partial file.
 func AtomicWriteFile(path string, data []byte, perm os.FileMode) error {
 	return atomicWriteFile(path, data, perm, true)

--- a/utils/reflink_linux.go
+++ b/utils/reflink_linux.go
@@ -12,11 +12,11 @@ import (
 const ficlone = 0x40049409
 
 // ReflinkCopy copies a single file, preferring FICLONE (O(1) CoW on btrfs/xfs/bcachefs) and falling back to SparseCopy on any error.
-func ReflinkCopy(dst, src string) error {
+func ReflinkCopy(dst, src string, sync SyncMode) error {
 	if err := tryFiclone(dst, src); err == nil {
 		return nil
 	}
-	return SparseCopy(dst, src)
+	return SparseCopy(dst, src, sync)
 }
 
 func tryFiclone(dst, src string) error {

--- a/utils/reflink_other.go
+++ b/utils/reflink_other.go
@@ -3,6 +3,6 @@
 package utils
 
 // ReflinkCopy copies a single file. On non-Linux, falls back to SparseCopy.
-func ReflinkCopy(dst, src string) error {
-	return SparseCopy(dst, src)
+func ReflinkCopy(dst, src string, sync SyncMode) error {
+	return SparseCopy(dst, src, sync)
 }

--- a/utils/reflink_test.go
+++ b/utils/reflink_test.go
@@ -17,7 +17,7 @@ func TestReflinkCopy_BasicContent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ReflinkCopy(dst, src); err != nil {
+	if err := ReflinkCopy(dst, src, Sync); err != nil {
 		t.Fatalf("ReflinkCopy: %v", err)
 	}
 
@@ -39,7 +39,7 @@ func TestReflinkCopy_EmptyFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ReflinkCopy(dst, src); err != nil {
+	if err := ReflinkCopy(dst, src, Sync); err != nil {
 		t.Fatalf("ReflinkCopy: %v", err)
 	}
 
@@ -62,7 +62,7 @@ func TestReflinkCopy_LargeFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ReflinkCopy(dst, src); err != nil {
+	if err := ReflinkCopy(dst, src, Sync); err != nil {
 		t.Fatalf("ReflinkCopy: %v", err)
 	}
 
@@ -89,7 +89,7 @@ func TestReflinkCopy_OverwritesExisting(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ReflinkCopy(dst, src); err != nil {
+	if err := ReflinkCopy(dst, src, NoSync); err != nil {
 		t.Fatalf("ReflinkCopy: %v", err)
 	}
 
@@ -104,7 +104,7 @@ func TestReflinkCopy_OverwritesExisting(t *testing.T) {
 
 func TestReflinkCopy_SrcNotExist(t *testing.T) {
 	dir := t.TempDir()
-	err := ReflinkCopy(filepath.Join(dir, "dst"), filepath.Join(dir, "nonexistent"))
+	err := ReflinkCopy(filepath.Join(dir, "dst"), filepath.Join(dir, "nonexistent"), Sync)
 	if err == nil {
 		t.Fatal("expected error for nonexistent src")
 	}
@@ -117,7 +117,7 @@ func TestReflinkCopy_DstDirNotExist(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := ReflinkCopy(filepath.Join(dir, "nodir", "dst"), src)
+	err := ReflinkCopy(filepath.Join(dir, "nodir", "dst"), src, Sync)
 	if err == nil {
 		t.Fatal("expected error for nonexistent dst directory")
 	}
@@ -133,7 +133,7 @@ func TestReflinkCopy_PreservesSize(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ReflinkCopy(dst, src); err != nil {
+	if err := ReflinkCopy(dst, src, Sync); err != nil {
 		t.Fatal(err)
 	}
 

--- a/utils/sparse_linux.go
+++ b/utils/sparse_linux.go
@@ -17,7 +17,7 @@ const (
 
 // SparseCopy copies src to dst preserving sparsity via SEEK_HOLE/SEEK_DATA.
 // dst is created as a new file (truncated to src size, then only data segments written).
-func SparseCopy(dst, src string) error {
+func SparseCopy(dst, src string, sync SyncMode) error {
 	return copyWithCleanup(dst, src, func(srcFile, dstFile *os.File) error {
 		fi, err := srcFile.Stat()
 		if err != nil {
@@ -46,6 +46,9 @@ func SparseCopy(dst, src string) error {
 			}
 		}
 
+		if !sync {
+			return nil
+		}
 		if err := dstFile.Sync(); err != nil {
 			return fmt.Errorf("sync dst: %w", err)
 		}

--- a/utils/sparse_linux_test.go
+++ b/utils/sparse_linux_test.go
@@ -26,7 +26,7 @@ func TestSparseCopy_AllSparse(t *testing.T) {
 	}
 	f.Close()
 
-	if err := SparseCopy(dst, src); err != nil {
+	if err := SparseCopy(dst, src, Sync); err != nil {
 		t.Fatalf("SparseCopy: %v", err)
 	}
 
@@ -67,7 +67,7 @@ func TestSparseCopy_PartialData(t *testing.T) {
 	writeAt(t, f, 4096, data)
 	f.Close()
 
-	if err := SparseCopy(dst, src); err != nil {
+	if err := SparseCopy(dst, src, Sync); err != nil {
 		t.Fatalf("SparseCopy: %v", err)
 	}
 
@@ -94,7 +94,7 @@ func TestSparseCopy_NonSparse(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := SparseCopy(dst, src); err != nil {
+	if err := SparseCopy(dst, src, Sync); err != nil {
 		t.Fatalf("SparseCopy: %v", err)
 	}
 
@@ -113,7 +113,7 @@ func TestSparseCopy_EmptyFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := SparseCopy(dst, src); err != nil {
+	if err := SparseCopy(dst, src, Sync); err != nil {
 		t.Fatalf("SparseCopy: %v", err)
 	}
 
@@ -128,7 +128,7 @@ func TestSparseCopy_EmptyFile(t *testing.T) {
 
 func TestSparseCopy_SrcNotExist(t *testing.T) {
 	dir := t.TempDir()
-	err := SparseCopy(filepath.Join(dir, "dst"), filepath.Join(dir, "nonexistent"))
+	err := SparseCopy(filepath.Join(dir, "dst"), filepath.Join(dir, "nonexistent"), Sync)
 	if err == nil {
 		t.Fatal("expected error for nonexistent src")
 	}
@@ -156,7 +156,7 @@ func TestSparseCopy_MultiSegment(t *testing.T) {
 	writeAt(t, f, 128*1024, seg2)
 	f.Close()
 
-	if err := SparseCopy(dst, src); err != nil {
+	if err := SparseCopy(dst, src, Sync); err != nil {
 		t.Fatalf("SparseCopy: %v", err)
 	}
 

--- a/utils/sparse_other.go
+++ b/utils/sparse_other.go
@@ -8,9 +8,14 @@ import (
 )
 
 // SparseCopy copies src to dst. On non-Linux platforms, sparsity is not preserved.
-func SparseCopy(dst, src string) error {
+func SparseCopy(dst, src string, sync SyncMode) error {
 	return copyWithCleanup(dst, src, func(srcFile, dstFile *os.File) error {
-		_, err := io.Copy(dstFile, srcFile)
-		return err
+		if _, err := io.Copy(dstFile, srcFile); err != nil {
+			return err
+		}
+		if !sync {
+			return nil
+		}
+		return dstFile.Sync()
 	})
 }

--- a/utils/sparse_test.go
+++ b/utils/sparse_test.go
@@ -19,7 +19,7 @@ func TestSparseCopy_BasicContent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := SparseCopy(dst, src); err != nil {
+	if err := SparseCopy(dst, src, Sync); err != nil {
 		t.Fatalf("SparseCopy: %v", err)
 	}
 
@@ -41,7 +41,7 @@ func TestSparseCopy_EmptyFile_CrossPlatform(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := SparseCopy(dst, src); err != nil {
+	if err := SparseCopy(dst, src, Sync); err != nil {
 		t.Fatalf("SparseCopy: %v", err)
 	}
 
@@ -65,7 +65,7 @@ func TestSparseCopy_LargeFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := SparseCopy(dst, src); err != nil {
+	if err := SparseCopy(dst, src, Sync); err != nil {
 		t.Fatalf("SparseCopy: %v", err)
 	}
 
@@ -80,7 +80,7 @@ func TestSparseCopy_LargeFile(t *testing.T) {
 
 func TestSparseCopy_SrcNotExist_CrossPlatform(t *testing.T) {
 	dir := t.TempDir()
-	err := SparseCopy(filepath.Join(dir, "dst"), filepath.Join(dir, "nonexistent"))
+	err := SparseCopy(filepath.Join(dir, "dst"), filepath.Join(dir, "nonexistent"), Sync)
 	if err == nil {
 		t.Fatal("expected error for nonexistent src")
 	}
@@ -93,7 +93,7 @@ func TestSparseCopy_DstDirNotExist(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := SparseCopy(filepath.Join(dir, "nodir", "dst"), src)
+	err := SparseCopy(filepath.Join(dir, "nodir", "dst"), src, Sync)
 	if err == nil {
 		t.Fatal("expected error for nonexistent dst directory")
 	}
@@ -113,7 +113,7 @@ func TestSparseCopy_OverwritesExisting(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := SparseCopy(dst, src); err != nil {
+	if err := SparseCopy(dst, src, NoSync); err != nil {
 		t.Fatalf("SparseCopy: %v", err)
 	}
 
@@ -136,7 +136,7 @@ func TestSparseCopy_PreservesSize(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := SparseCopy(dst, src); err != nil {
+	if err := SparseCopy(dst, src, Sync); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Two changes with the same invariant: **snapshot durability is unchanged** — one path gains the fsync it owed, one path stops paying it at the worst possible moment.

## 1. Tar-fallback ingestion syncs directory entries

`hypervisor.Hibernator` terminates the VMM on the strength of persist's return. The same-filesystem path (`CreateFromDir`) already runs `SyncTree` before finalizing, but the cross-filesystem/EXDEV fallback (`LocalFile.Create`) only fsynced file contents via `ExtractTar` — per fsync(2), directory entries need an explicit directory fsync. Power loss right after a cross-filesystem hibernate could leave the DB record finalized while the data dir entries were lost: VM stopped, snapshot unrecoverable. Fix: `SyncTree(dataDir)` after extraction, before the record flips durable.

## 2. Capture copies stop fsyncing inside the guest pause window

The COW/data/cidata copies taken during capture (`CopyWritableDisks`, cidata `SparseCopy`) were fsynced inside the pause window — and then re-synced at persist (`SyncTree` on the direct path, per-file `ExtractTar` on the stream path). `SparseCopy`/`ReflinkCopy` gain a `SyncMode` parameter (`utils.Sync` / `utils.NoSync`); capture passes `NoSync`, every other caller keeps `Sync`. Same total I/O, the payment just leaves the pause: `snapshot save`'s guest stall shrinks by the writeback time; hibernate semantics unchanged (persist still completes before terminate).

Non-Linux `SparseCopy` also gains the final fsync it silently lacked, so both platforms honor the same contract.

## Measurements

Host `ai` (bare metal, ext4 on NVMe TiPlus7100 2TB, kernel 6.17), 4 GiB dense source in page cache, 4 alternating rounds, zero variance:

```
cp --reflink=always → Operation not supported   (ext4: SparseCopy full-copy path is what capture runs)
write only:      0.48 s
write + fsync:   1.10 s     → pause-window saving ≈ 0.155 s/GiB (NVMe floor; PD-class disks: seconds/GiB)
```

FICLONE filesystems (btrfs/xfs) never paid the copy, so the pause saving is ext4-specific.

## Verification

- `go build ./...`, `go vet ./...`
- `go test -race` (utils, hypervisor/..., snapshot/...): ok; full `make test` green on the superset branch
- `make lint` (GOOS=linux + darwin): 0 issues

Stacked below #119, which drops fsyncs on transient extract/copy paths (a crash-semantics change) and folds the remaining NoSync variants into `SyncMode`.