### PR TITLE
fix(fc): clone from a snapshot must not require a live source VM

### DIFF
--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -254,9 +254,11 @@ func lockRecreatedDir(ctx context.Context, dir string) (*flock.Lock, error) {
 			return nil, fmt.Errorf("recreate source dir: %w", err)
 		}
 		l := flock.NewTransient(filepath.Join(dir, hypervisor.OpsLockName))
-		err := l.Lock(ctx)
-		if err == nil || !errors.Is(err, fs.ErrNotExist) {
-			return l, err
+		switch err := l.Lock(ctx); {
+		case err == nil:
+			return l, nil
+		case !errors.Is(err, fs.ErrNotExist):
+			return nil, err
 		}
 	}
 }

--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -261,12 +261,28 @@ func lockRecreatedDir(ctx context.Context, dir string) (*flock.Lock, error) {
 	}
 }
 
-// recoverStaleBackup clears a crashed clone's redirect symlink and restores its backup; caller must hold the COW lock. A symlink at a source drive path can only be a redirect leftover, and a dead source leaves no backup.
-func recoverStaleBackup(cowPath string) {
+// recoverStaleBackup clears a crashed clone's redirect symlink and restores its backup; caller must hold the COW lock. Imported metadata paths are untrusted, so only a symlink with a backup beside it or a target under the managed run root — the two shapes cocoon's own redirects take — is removed.
+func recoverStaleBackup(runRoot, cowPath string) {
+	backup := cowPath + cloneBackupSuffix
+	_, backupErr := os.Lstat(backup)
 	if fi, err := os.Lstat(cowPath); err == nil && fi.Mode()&os.ModeSymlink != 0 {
-		_ = os.Remove(cowPath)
+		if backupErr == nil || redirectsInto(runRoot, cowPath) {
+			_ = os.Remove(cowPath)
+		}
 	}
-	_ = os.Rename(cowPath+cloneBackupSuffix, cowPath)
+	_ = os.Rename(backup, cowPath)
+}
+
+// redirectsInto reports whether the symlink at path targets the managed run root.
+func redirectsInto(runRoot, path string) bool {
+	target, err := os.Readlink(path)
+	if err != nil {
+		return false
+	}
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(filepath.Dir(path), target)
+	}
+	return hypervisor.IsUnderDir(target, runRoot)
 }
 
 func buildNetworkOverrides(networkConfigs []*types.NetworkConfig) []fcNetworkOverride {

--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -261,28 +261,16 @@ func lockRecreatedDir(ctx context.Context, dir string) (*flock.Lock, error) {
 	}
 }
 
-// recoverStaleBackup clears a crashed clone's redirect symlink and restores its backup; caller must hold the COW lock. Imported metadata paths are untrusted, so only a symlink with a backup beside it or a target under the managed run root — the two shapes cocoon's own redirects take — is removed.
+// recoverStaleBackup clears a crashed clone's redirect symlink and restores its backup; caller must hold the COW lock. Imported metadata paths are untrusted: a symlink is removed only with a backup beside it or when it sits inside the managed run root, where every cocoon redirect lives and nothing foreign does.
 func recoverStaleBackup(runRoot, cowPath string) {
 	backup := cowPath + cloneBackupSuffix
 	_, backupErr := os.Lstat(backup)
 	if fi, err := os.Lstat(cowPath); err == nil && fi.Mode()&os.ModeSymlink != 0 {
-		if backupErr == nil || redirectsInto(runRoot, cowPath) {
+		if backupErr == nil || hypervisor.IsUnderDir(cowPath, runRoot) {
 			_ = os.Remove(cowPath)
 		}
 	}
 	_ = os.Rename(backup, cowPath)
-}
-
-// redirectsInto reports whether the symlink at path targets the managed run root.
-func redirectsInto(runRoot, path string) bool {
-	target, err := os.Readlink(path)
-	if err != nil {
-		return false
-	}
-	if !filepath.IsAbs(target) {
-		target = filepath.Join(filepath.Dir(path), target)
-	}
-	return hypervisor.IsUnderDir(target, runRoot)
 }
 
 func buildNetworkOverrides(networkConfigs []*types.NetworkConfig) []fcNetworkOverride {

--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -214,7 +214,7 @@ func cleanupDriveRedirects(redirects []driveRedirect) {
 	}
 }
 
-// holdRedirectDirs recreates missing parents of redirected source paths and holds their ops locks: the dirs are recordless, and the GC orphan scan reaps any unlocked recordless dir mid-clone. Release drops the locks and removes the dirs.
+// holdRedirectDirs recreates missing parents of redirected source paths and holds their ops locks: the dirs are recordless, and the GC orphan scan reaps any unlocked recordless dir mid-clone.
 func holdRedirectDirs(ctx context.Context, srcConfigs, dstConfigs []*types.StorageConfig) (func(), error) {
 	var dirs []string
 	seen := make(map[string]struct{})

--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"time"
 
 	"github.com/projecteru2/core/log"
@@ -70,9 +71,6 @@ func (fc *Firecracker) cloneAfterExtract(ctx context.Context, vmID string, vmCfg
 	sockPath := hypervisor.SocketPath(runDir)
 	var pid int
 	if cloneErr := fc.withSourceWritableDisksLocked(ctx, meta.StorageConfigs, func() error {
-		if aliveErr := fc.ensureSourceAlive(ctx, meta.StorageConfigs); aliveErr != nil {
-			return aliveErr
-		}
 		redirects, redirectErr := createDriveRedirects(meta.StorageConfigs, storageConfigs)
 		if redirectErr != nil {
 			return fmt.Errorf("drive redirect: %w", redirectErr)
@@ -138,21 +136,6 @@ func (fc *Firecracker) restoreAndResumeClone(
 		if err = patchDrivePath(ctx, hc, fmt.Sprintf(driveIDFmt, i), dstConfigs[i].Path); err != nil {
 			return fmt.Errorf("re-anchor drive %d: %w", i, err)
 		}
-	}
-	return nil
-}
-
-// ensureSourceAlive re-checks the source VM record under the writable-disk locks: rm deletes the record before unlinking any file, so a lock acquired on a fresh inode after a concurrent rm always observes the record gone and must abort instead of racing the deletion.
-func (fc *Firecracker) ensureSourceAlive(ctx context.Context, configs []*types.StorageConfig) error {
-	for _, sc := range configs {
-		if sc.Role != types.StorageRoleCOW && sc.Role != types.StorageRoleData {
-			continue
-		}
-		srcID := filepath.Base(filepath.Dir(sc.Path))
-		if _, err := fc.LoadRecord(ctx, srcID); err != nil {
-			return fmt.Errorf("clone source VM %s: %w", srcID, err)
-		}
-		return nil
 	}
 	return nil
 }
@@ -223,8 +206,9 @@ func createDriveRedirects(srcConfigs, dstConfigs []*types.StorageConfig) ([]driv
 	return redirects, nil
 }
 
+// cleanupDriveRedirects unwinds in reverse so a shared dir is removed only after its sibling symlinks are gone.
 func cleanupDriveRedirects(redirects []driveRedirect) {
-	for _, r := range redirects {
+	for _, r := range slices.Backward(redirects) {
 		_ = os.Remove(r.symlinkPath)
 		if r.backupPath != "" {
 			_ = os.Rename(r.backupPath, r.symlinkPath)

--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -2,8 +2,10 @@ package firecracker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
@@ -13,6 +15,7 @@ import (
 
 	"github.com/cocoonstack/cocoon/extend/disk"
 	"github.com/cocoonstack/cocoon/hypervisor"
+	"github.com/cocoonstack/cocoon/lock/flock"
 	"github.com/cocoonstack/cocoon/types"
 	"github.com/cocoonstack/cocoon/utils"
 )
@@ -22,7 +25,6 @@ const cloneBackupSuffix = ".cocoon-clone-backup"
 type driveRedirect struct {
 	symlinkPath string
 	backupPath  string
-	createdDir  bool
 }
 
 func (fc *Firecracker) Clone(ctx context.Context, vmID string, vmCfg *types.VMConfig, net types.NetSetup, snapshotConfig *types.SnapshotConfig, snapshot io.Reader) (*types.VM, error) {
@@ -71,6 +73,11 @@ func (fc *Firecracker) cloneAfterExtract(ctx context.Context, vmID string, vmCfg
 	sockPath := hypervisor.SocketPath(runDir)
 	var pid int
 	if cloneErr := fc.withSourceWritableDisksLocked(ctx, meta.StorageConfigs, func() error {
+		releaseDirs, holdErr := holdRedirectDirs(ctx, meta.StorageConfigs, storageConfigs)
+		if holdErr != nil {
+			return holdErr
+		}
+		defer releaseDirs()
 		redirects, redirectErr := createDriveRedirects(meta.StorageConfigs, storageConfigs)
 		if redirectErr != nil {
 			return fmt.Errorf("drive redirect: %w", redirectErr)
@@ -186,14 +193,6 @@ func createDriveRedirects(srcConfigs, dstConfigs []*types.StorageConfig) ([]driv
 			r.backupPath = backup
 		}
 
-		if _, err := os.Stat(filepath.Dir(src.Path)); err != nil {
-			if mkErr := os.MkdirAll(filepath.Dir(src.Path), 0o700); mkErr != nil {
-				cleanupDriveRedirects(redirects)
-				return nil, fmt.Errorf("create dir for drive redirect %s: %w", src.Path, mkErr)
-			}
-			r.createdDir = true
-		}
-
 		if linkErr := os.Symlink(dstConfigs[i].Path, src.Path); linkErr != nil {
 			if r.backupPath != "" {
 				_ = os.Rename(r.backupPath, src.Path)
@@ -206,30 +205,68 @@ func createDriveRedirects(srcConfigs, dstConfigs []*types.StorageConfig) ([]driv
 	return redirects, nil
 }
 
-// cleanupDriveRedirects unwinds in reverse so a shared dir is removed only after its sibling symlinks are gone.
 func cleanupDriveRedirects(redirects []driveRedirect) {
-	for _, r := range slices.Backward(redirects) {
+	for _, r := range redirects {
 		_ = os.Remove(r.symlinkPath)
 		if r.backupPath != "" {
 			_ = os.Rename(r.backupPath, r.symlinkPath)
 		}
-		if r.createdDir {
-			_ = os.Remove(filepath.Dir(r.symlinkPath))
+	}
+}
+
+// holdRedirectDirs recreates missing parents of redirected source paths and holds their ops locks: the dirs are recordless, and the GC orphan scan reaps any unlocked recordless dir mid-clone. Release drops the locks and removes the dirs.
+func holdRedirectDirs(ctx context.Context, srcConfigs, dstConfigs []*types.StorageConfig) (func(), error) {
+	var dirs []string
+	seen := make(map[string]struct{})
+	for _, i := range redirectedDriveIndices(srcConfigs, dstConfigs) {
+		dir := filepath.Dir(srcConfigs[i].Path)
+		if _, ok := seen[dir]; ok {
+			continue
+		}
+		seen[dir] = struct{}{}
+		if _, err := os.Stat(dir); errors.Is(err, fs.ErrNotExist) {
+			dirs = append(dirs, dir)
+		}
+	}
+	slices.Sort(dirs)
+	locks := make([]*flock.Lock, 0, len(dirs))
+	release := func() {
+		for i := len(locks) - 1; i >= 0; i-- {
+			_ = locks[i].Unlock(ctx)
+			_ = os.Remove(dirs[i])
+		}
+	}
+	for _, dir := range dirs {
+		l, err := lockRecreatedDir(ctx, dir)
+		if err != nil {
+			release()
+			return nil, err
+		}
+		locks = append(locks, l)
+	}
+	return release, nil
+}
+
+// lockRecreatedDir mkdirs+locks with retry: a concurrent GC collect can remove the still-empty dir between MkdirAll and the flock open.
+func lockRecreatedDir(ctx context.Context, dir string) (*flock.Lock, error) {
+	for {
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			return nil, fmt.Errorf("recreate source dir: %w", err)
+		}
+		l := flock.NewTransient(filepath.Join(dir, hypervisor.OpsLockName))
+		err := l.Lock(ctx)
+		if err == nil || !errors.Is(err, fs.ErrNotExist) {
+			return l, err
 		}
 	}
 }
 
-// recoverStaleBackup restores a crashed-clone backup; caller must hold the COW lock.
+// recoverStaleBackup clears a crashed clone's redirect symlink and restores its backup; caller must hold the COW lock. A symlink at a source drive path can only be a redirect leftover, and a dead source leaves no backup.
 func recoverStaleBackup(cowPath string) {
-	backup := cowPath + cloneBackupSuffix
-	if _, err := os.Stat(backup); err != nil {
-		return
-	}
-	fi, err := os.Lstat(cowPath)
-	if err == nil && fi.Mode()&os.ModeSymlink != 0 {
+	if fi, err := os.Lstat(cowPath); err == nil && fi.Mode()&os.ModeSymlink != 0 {
 		_ = os.Remove(cowPath)
 	}
-	_ = os.Rename(backup, cowPath)
+	_ = os.Rename(cowPath+cloneBackupSuffix, cowPath)
 }
 
 func buildNetworkOverrides(networkConfigs []*types.NetworkConfig) []fcNetworkOverride {

--- a/hypervisor/firecracker/clone_test.go
+++ b/hypervisor/firecracker/clone_test.go
@@ -41,9 +41,7 @@ func TestRedirectedDriveIndices(t *testing.T) {
 	}
 }
 
-// The redirect set and the re-anchor set must be the same drives: both loops
-// derive from redirectedDriveIndices, and this pins createDriveRedirects to
-// it — a symlink appears exactly where the shared function says.
+// Pins createDriveRedirects to redirectedDriveIndices: a symlink appears exactly where the shared function says.
 func TestCreateDriveRedirectsMatchesIndices(t *testing.T) {
 	dir := t.TempDir()
 	src := []*types.StorageConfig{

--- a/hypervisor/firecracker/clone_test.go
+++ b/hypervisor/firecracker/clone_test.go
@@ -117,18 +117,34 @@ func TestHoldRedirectDirsFencesGCAndCleansUp(t *testing.T) {
 // A clone killed mid-window leaves a dangling redirect symlink with no backup; the next acquire must clear it or every later clone fails with EEXIST.
 func TestRecoverStaleBackupClearsDanglingRedirect(t *testing.T) {
 	dir := t.TempDir()
+	runRoot := filepath.Join(dir, "run")
 	cow := filepath.Join(dir, "cow.raw")
-	if err := os.Symlink(filepath.Join(dir, "deleted-clone-cow.raw"), cow); err != nil {
+	if err := os.Symlink(filepath.Join(runRoot, "CLONE", "cow.raw"), cow); err != nil {
 		t.Fatalf("setup symlink: %v", err)
 	}
 
-	recoverStaleBackup(cow)
+	recoverStaleBackup(runRoot, cow)
 
 	if _, err := os.Lstat(cow); !errors.Is(err, fs.ErrNotExist) {
 		t.Fatalf("dangling redirect not cleared: %v", err)
 	}
 	if err := os.Symlink("target", cow); err != nil {
 		t.Fatalf("path not reusable after recovery: %v", err)
+	}
+}
+
+// Imported metadata can name any path; a symlink that is not one of cocoon's own redirects must survive recovery.
+func TestRecoverStaleBackupPreservesForeignSymlink(t *testing.T) {
+	dir := t.TempDir()
+	cow := filepath.Join(dir, "cow.raw")
+	if err := os.Symlink("/etc/hosts", cow); err != nil {
+		t.Fatalf("setup symlink: %v", err)
+	}
+
+	recoverStaleBackup(filepath.Join(dir, "run"), cow)
+
+	if fi, err := os.Lstat(cow); err != nil || fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("foreign symlink must be preserved: fi=%v err=%v", fi, err)
 	}
 }
 
@@ -140,7 +156,7 @@ func TestRecoverStaleBackupRestoresBackup(t *testing.T) {
 		t.Fatalf("setup symlink: %v", err)
 	}
 
-	recoverStaleBackup(cow)
+	recoverStaleBackup(filepath.Join(dir, "run"), cow)
 
 	if fi, err := os.Lstat(cow); err != nil || !fi.Mode().IsRegular() {
 		t.Fatalf("backup not restored over redirect: fi=%v err=%v", fi, err)

--- a/hypervisor/firecracker/clone_test.go
+++ b/hypervisor/firecracker/clone_test.go
@@ -8,6 +8,8 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/cocoonstack/cocoon/hypervisor"
+	"github.com/cocoonstack/cocoon/lock/flock"
 	"github.com/cocoonstack/cocoon/types"
 )
 
@@ -55,6 +57,11 @@ func TestCreateDriveRedirectsMatchesIndices(t *testing.T) {
 		{Path: writeTestFile(t, dir, "clone-data.img")},
 	}
 
+	release, err := holdRedirectDirs(t.Context(), src, dst)
+	if err != nil {
+		t.Fatalf("holdRedirectDirs: %v", err)
+	}
+	defer release()
 	redirects, err := createDriveRedirects(src, dst)
 	if err != nil {
 		t.Fatalf("createDriveRedirects: %v", err)
@@ -79,7 +86,8 @@ func TestCreateDriveRedirectsMatchesIndices(t *testing.T) {
 	}
 }
 
-func TestCleanupDriveRedirectsRemovesRecreatedDir(t *testing.T) {
+// The recreated source dir is recordless: while redirects live, its held ops lock is the only thing keeping the GC orphan scan from reaping it mid-clone.
+func TestHoldRedirectDirsFencesGCAndCleansUp(t *testing.T) {
 	dir := t.TempDir()
 	gone := filepath.Join(dir, "gone")
 	src := []*types.StorageConfig{
@@ -91,14 +99,54 @@ func TestCleanupDriveRedirectsRemovesRecreatedDir(t *testing.T) {
 		{Path: writeTestFile(t, dir, "clone-data-x.raw")},
 	}
 
-	redirects, err := createDriveRedirects(src, dst)
+	release, err := holdRedirectDirs(t.Context(), src, dst)
 	if err != nil {
-		t.Fatalf("createDriveRedirects: %v", err)
+		t.Fatalf("holdRedirectDirs: %v", err)
 	}
-	cleanupDriveRedirects(redirects)
+	gcLock := flock.New(filepath.Join(gone, hypervisor.OpsLockName))
+	if got, tryErr := gcLock.TryLock(t.Context()); tryErr != nil || got {
+		t.Fatalf("GC ops TryLock must fail while redirect dirs are held: got=%v err=%v", got, tryErr)
+	}
 
+	release()
 	if _, err := os.Stat(gone); !errors.Is(err, fs.ErrNotExist) {
-		t.Fatalf("recreated source dir not removed on unwind: %v", err)
+		t.Fatalf("recreated source dir not removed on release: %v", err)
+	}
+}
+
+// A clone killed mid-window leaves a dangling redirect symlink with no backup; the next acquire must clear it or every later clone fails with EEXIST.
+func TestRecoverStaleBackupClearsDanglingRedirect(t *testing.T) {
+	dir := t.TempDir()
+	cow := filepath.Join(dir, "cow.raw")
+	if err := os.Symlink(filepath.Join(dir, "deleted-clone-cow.raw"), cow); err != nil {
+		t.Fatalf("setup symlink: %v", err)
+	}
+
+	recoverStaleBackup(cow)
+
+	if _, err := os.Lstat(cow); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("dangling redirect not cleared: %v", err)
+	}
+	if err := os.Symlink("target", cow); err != nil {
+		t.Fatalf("path not reusable after recovery: %v", err)
+	}
+}
+
+func TestRecoverStaleBackupRestoresBackup(t *testing.T) {
+	dir := t.TempDir()
+	cow := filepath.Join(dir, "cow.raw")
+	backup := writeTestFile(t, dir, "cow.raw"+cloneBackupSuffix)
+	if err := os.Symlink("dangling-target", cow); err != nil {
+		t.Fatalf("setup symlink: %v", err)
+	}
+
+	recoverStaleBackup(cow)
+
+	if fi, err := os.Lstat(cow); err != nil || !fi.Mode().IsRegular() {
+		t.Fatalf("backup not restored over redirect: fi=%v err=%v", fi, err)
+	}
+	if _, err := os.Stat(backup); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("backup file left behind: %v", err)
 	}
 }
 

--- a/hypervisor/firecracker/clone_test.go
+++ b/hypervisor/firecracker/clone_test.go
@@ -116,9 +116,12 @@ func TestHoldRedirectDirsFencesGCAndCleansUp(t *testing.T) {
 
 // A clone killed mid-window leaves a dangling redirect symlink with no backup; the next acquire must clear it or every later clone fails with EEXIST.
 func TestRecoverStaleBackupClearsDanglingRedirect(t *testing.T) {
-	dir := t.TempDir()
-	runRoot := filepath.Join(dir, "run")
-	cow := filepath.Join(dir, "cow.raw")
+	runRoot := t.TempDir()
+	srcDir := filepath.Join(runRoot, "GONE")
+	if err := os.Mkdir(srcDir, 0o750); err != nil {
+		t.Fatalf("setup src dir: %v", err)
+	}
+	cow := filepath.Join(srcDir, "cow.raw")
 	if err := os.Symlink(filepath.Join(runRoot, "CLONE", "cow.raw"), cow); err != nil {
 		t.Fatalf("setup symlink: %v", err)
 	}
@@ -133,15 +136,16 @@ func TestRecoverStaleBackupClearsDanglingRedirect(t *testing.T) {
 	}
 }
 
-// Imported metadata can name any path; a symlink that is not one of cocoon's own redirects must survive recovery.
+// Imported metadata can name any path; a symlink outside the run root must survive recovery even when its target points into the run root.
 func TestRecoverStaleBackupPreservesForeignSymlink(t *testing.T) {
 	dir := t.TempDir()
-	cow := filepath.Join(dir, "cow.raw")
-	if err := os.Symlink("/etc/hosts", cow); err != nil {
+	runRoot := filepath.Join(dir, "run")
+	cow := filepath.Join(dir, "current-cow")
+	if err := os.Symlink(filepath.Join(runRoot, "LIVE", "cow.raw"), cow); err != nil {
 		t.Fatalf("setup symlink: %v", err)
 	}
 
-	recoverStaleBackup(filepath.Join(dir, "run"), cow)
+	recoverStaleBackup(runRoot, cow)
 
 	if fi, err := os.Lstat(cow); err != nil || fi.Mode()&os.ModeSymlink == 0 {
 		t.Fatalf("foreign symlink must be preserved: fi=%v err=%v", fi, err)

--- a/hypervisor/firecracker/clone_test.go
+++ b/hypervisor/firecracker/clone_test.go
@@ -1,6 +1,8 @@
 package firecracker
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
@@ -42,22 +44,15 @@ func TestRedirectedDriveIndices(t *testing.T) {
 // it — a symlink appears exactly where the shared function says.
 func TestCreateDriveRedirectsMatchesIndices(t *testing.T) {
 	dir := t.TempDir()
-	mk := func(name, content string) string {
-		p := filepath.Join(dir, name)
-		if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
-			t.Fatalf("setup %s: %v", name, err)
-		}
-		return p
-	}
 	src := []*types.StorageConfig{
 		{Path: filepath.Join(dir, "gone", "layer.img")}, // shared layer, same both sides
 		{Path: filepath.Join(dir, "gone", "cow.raw")},   // source path no longer exists
-		{Path: mk("data.img", "data")},                  // source still present: backed up
+		{Path: writeTestFile(t, dir, "data.img")},       // source still present: backed up
 	}
 	dst := []*types.StorageConfig{
 		{Path: src[0].Path},
-		{Path: mk("clone-cow.raw", "cow")},
-		{Path: mk("clone-data.img", "data2")},
+		{Path: writeTestFile(t, dir, "clone-cow.raw")},
+		{Path: writeTestFile(t, dir, "clone-data.img")},
 	}
 
 	redirects, err := createDriveRedirects(src, dst)
@@ -82,4 +77,36 @@ func TestCreateDriveRedirectsMatchesIndices(t *testing.T) {
 			t.Errorf("drive %d links to %q, want %q", i, target, dst[i].Path)
 		}
 	}
+}
+
+func TestCleanupDriveRedirectsRemovesRecreatedDir(t *testing.T) {
+	dir := t.TempDir()
+	gone := filepath.Join(dir, "gone")
+	src := []*types.StorageConfig{
+		{Path: filepath.Join(gone, "cow.raw")},
+		{Path: filepath.Join(gone, "data-x.raw")},
+	}
+	dst := []*types.StorageConfig{
+		{Path: writeTestFile(t, dir, "clone-cow.raw")},
+		{Path: writeTestFile(t, dir, "clone-data-x.raw")},
+	}
+
+	redirects, err := createDriveRedirects(src, dst)
+	if err != nil {
+		t.Fatalf("createDriveRedirects: %v", err)
+	}
+	cleanupDriveRedirects(redirects)
+
+	if _, err := os.Stat(gone); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("recreated source dir not removed on unwind: %v", err)
+	}
+}
+
+func writeTestFile(t *testing.T, dir, name string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(name), 0o600); err != nil {
+		t.Fatalf("setup %s: %v", name, err)
+	}
+	return p
 }

--- a/hypervisor/firecracker/cowlock.go
+++ b/hypervisor/firecracker/cowlock.go
@@ -30,20 +30,20 @@ func (fc *Firecracker) withSourceWritableDisksLocked(ctx context.Context, config
 	if mkErr := os.MkdirAll(lockDir, 0o700); mkErr != nil {
 		return fmt.Errorf("create clone lock dir: %w", mkErr)
 	}
-	return withPathsLocked(ctx, lockDir, paths, fn)
+	return withPathsLocked(ctx, fc.Conf.RunDir(), lockDir, paths, fn)
 }
 
 func (fc *Firecracker) cloneLockDir() string {
 	return filepath.Join(fc.Conf.RunDir(), hypervisor.CloneLocksDirName)
 }
 
-func withPathsLocked(ctx context.Context, lockDir string, paths []string, fn func() error) error {
+func withPathsLocked(ctx context.Context, runRoot, lockDir string, paths []string, fn func() error) error {
 	if len(paths) == 0 {
 		return fn()
 	}
 	return withCOWPathLocked(ctx, lockDir, paths[0], func() error {
-		recoverStaleBackup(paths[0])
-		return withPathsLocked(ctx, lockDir, paths[1:], fn)
+		recoverStaleBackup(runRoot, paths[0])
+		return withPathsLocked(ctx, runRoot, lockDir, paths[1:], fn)
 	})
 }
 

--- a/hypervisor/firecracker/cowlock.go
+++ b/hypervisor/firecracker/cowlock.go
@@ -2,40 +2,57 @@ package firecracker
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
 	"slices"
 
+	"github.com/cocoonstack/cocoon/hypervisor"
 	"github.com/cocoonstack/cocoon/lock/flock"
 	"github.com/cocoonstack/cocoon/types"
 )
 
-// withSourceWritableDisksLocked locks the source's writable disks in sorted order (deadlock-free), self-healing interrupted swaps on acquire; the fresh-inode window after a concurrent rm is closed by ensureSourceAlive under the lock.
-func (*Firecracker) withSourceWritableDisksLocked(ctx context.Context, configs []*types.StorageConfig, fn func() error) error {
+// withSourceWritableDisksLocked locks the source's writable disks in sorted order (deadlock-free), self-healing interrupted swaps on acquire.
+func (fc *Firecracker) withSourceWritableDisksLocked(ctx context.Context, configs []*types.StorageConfig, fn func() error) error {
 	paths := make([]string, 0, len(configs))
 	for _, sc := range configs {
 		if sc.Role == types.StorageRoleCOW || sc.Role == types.StorageRoleData {
 			paths = append(paths, sc.Path)
 		}
 	}
-	slices.Sort(paths)
-	return withPathsLocked(ctx, paths, fn)
-}
-
-func withPathsLocked(ctx context.Context, paths []string, fn func() error) error {
 	if len(paths) == 0 {
 		return fn()
 	}
-	return withCOWPathLocked(ctx, paths[0], func() error {
+	slices.Sort(paths)
+	lockDir := fc.cloneLockDir()
+	if mkErr := os.MkdirAll(lockDir, 0o700); mkErr != nil {
+		return fmt.Errorf("create clone lock dir: %w", mkErr)
+	}
+	return withPathsLocked(ctx, lockDir, paths, fn)
+}
+
+func (fc *Firecracker) cloneLockDir() string {
+	return filepath.Join(fc.Conf.RunDir(), hypervisor.CloneLocksDirName)
+}
+
+func withPathsLocked(ctx context.Context, lockDir string, paths []string, fn func() error) error {
+	if len(paths) == 0 {
+		return fn()
+	}
+	return withCOWPathLocked(ctx, lockDir, paths[0], func() error {
 		recoverStaleBackup(paths[0])
-		return withPathsLocked(ctx, paths[1:], fn)
+		return withPathsLocked(ctx, lockDir, paths[1:], fn)
 	})
 }
 
-func withCOWPathLocked(ctx context.Context, cowPath string, fn func() error) error {
-	l := flock.New(cowPath + ".clone.lock")
+func withCOWPathLocked(ctx context.Context, lockDir, cowPath string, fn func() error) error {
+	sum := sha256.Sum256([]byte(cowPath))
+	l := flock.NewTransient(filepath.Join(lockDir, hex.EncodeToString(sum[:8])+"-"+filepath.Base(cowPath)+".clone.lock"))
 	if lockErr := l.Lock(ctx); lockErr != nil {
 		return lockErr
 	}
-	// Do NOT remove the lock file after unlock — flock synchronizes on the inode, not the pathname.
 	defer func() { _ = l.Unlock(ctx) }()
 
 	return fn()

--- a/hypervisor/firecracker/cowlock_test.go
+++ b/hypervisor/firecracker/cowlock_test.go
@@ -1,6 +1,8 @@
 package firecracker
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,49 +11,63 @@ import (
 	"github.com/cocoonstack/cocoon/types"
 )
 
-func TestEnsureSourceAliveAbortsOnDeletedSource(t *testing.T) {
+func TestCloneLockDeadSourceSucceeds(t *testing.T) {
 	fc := newTestFC(t)
-	const srcID = "SRCVM"
-	srcDir := fc.Conf.VMRunDir(srcID)
+	srcDir := fc.Conf.VMRunDir("GONE")
 	configs := []*types.StorageConfig{
 		{Path: filepath.Join(srcDir, "cow.raw"), Role: types.StorageRoleCOW},
+		{Path: filepath.Join(srcDir, "data-x.raw"), Role: types.StorageRoleData},
 	}
 
-	if err := fc.ensureSourceAlive(t.Context(), configs); err == nil {
-		t.Fatal("expected error for missing source record")
-	}
-
-	if err := fc.ReserveVM(t.Context(), srcID, &types.VMConfig{Name: "src"}, nil, srcDir, fc.Conf.VMLogDir(srcID)); err != nil {
-		t.Fatalf("reserve: %v", err)
-	}
-	if err := fc.ensureSourceAlive(t.Context(), configs); err != nil {
-		t.Fatalf("live source rejected: %v", err)
-	}
-}
-
-func TestEnsureSourceAliveSkipsWithoutWritableDisks(t *testing.T) {
-	fc := newTestFC(t)
-	configs := []*types.StorageConfig{{Path: "/some/layer.erofs", Role: types.StorageRoleLayer}}
-	if err := fc.ensureSourceAlive(t.Context(), configs); err != nil {
-		t.Fatalf("layer-only configs must not require a record: %v", err)
-	}
-}
-
-func TestCloneLockLivesNextToDisk(t *testing.T) {
-	cow := filepath.Join(t.TempDir(), "cow.raw")
 	called := false
-	if err := withCOWPathLocked(t.Context(), cow, func() error {
+	if err := fc.withSourceWritableDisksLocked(t.Context(), configs, func() error {
 		called = true
 		return nil
 	}); err != nil {
-		t.Fatalf("lock: %v", err)
+		t.Fatalf("dead-source lock: %v", err)
 	}
 	if !called {
 		t.Fatal("fn not called")
 	}
-	if _, err := os.Stat(cow + ".clone.lock"); err != nil {
-		t.Fatalf("lock file not beside the disk: %v", err)
+	if _, err := os.Stat(srcDir); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("source dir must not be resurrected by locking: %v", err)
 	}
+	assertNoLockResidue(t, fc.cloneLockDir())
+}
+
+func TestCloneLockHeldThenCleaned(t *testing.T) {
+	fc := newTestFC(t)
+	cow := filepath.Join(fc.Conf.VMRunDir("GONE"), "cow.raw")
+	lockDir := fc.cloneLockDir()
+	if err := os.MkdirAll(lockDir, 0o700); err != nil {
+		t.Fatalf("setup lock dir: %v", err)
+	}
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- withCOWPathLocked(t.Context(), lockDir, cow, func() error {
+			close(entered)
+			<-release
+			return nil
+		})
+	}()
+	<-entered
+
+	entries, err := os.ReadDir(lockDir)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("want exactly one lock file while held, got %d (%v)", len(entries), err)
+	}
+
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatalf("locked fn: %v", err)
+	}
+	if err := withCOWPathLocked(t.Context(), lockDir, cow, func() error { return nil }); err != nil {
+		t.Fatalf("relock after release: %v", err)
+	}
+	assertNoLockResidue(t, lockDir)
 }
 
 func newTestFC(t *testing.T) *Firecracker {
@@ -66,4 +82,18 @@ func newTestFC(t *testing.T) *Firecracker {
 		t.Fatalf("new firecracker: %v", err)
 	}
 	return fc
+}
+
+func assertNoLockResidue(t *testing.T, lockDir string) {
+	t.Helper()
+	entries, err := os.ReadDir(lockDir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return
+		}
+		t.Fatalf("read lock dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("lock residue after release: %v", entries)
+	}
 }

--- a/hypervisor/gc.go
+++ b/hypervisor/gc.go
@@ -20,6 +20,9 @@ import (
 	"github.com/cocoonstack/cocoon/utils"
 )
 
+// gcReservedDirNames are run-root subdirs that are infrastructure, not VM dirs: "db" holds vms.json/vms.lock (when RootDir == RunDir), clone-locks/ holds FC clone flocks.
+var gcReservedDirNames = map[string]struct{}{"db": {}, CloneLocksDirName: {}}
+
 // VMGCSnapshot is the ReadDB-phase data for any hypervisor GC module (CH + FC share the shape).
 type VMGCSnapshot struct {
 	blobIDs     map[string]struct{}
@@ -48,6 +51,9 @@ func (s VMGCSnapshot) sweepDirs(runRoot string) []string {
 		}
 	}
 	for _, name := range s.runDirs {
+		if _, ok := gcReservedDirNames[name]; ok {
+			continue
+		}
 		add(filepath.Join(runRoot, name))
 	}
 	for _, dir := range s.recRunDirs {
@@ -95,10 +101,8 @@ func (b *Backend) BuildGCModule() gc.Module[VMGCSnapshot] {
 			return snap, nil
 		},
 		Resolve: func(_ context.Context, snap VMGCSnapshot, _ map[string]any) []string {
-			// "db" holds vms.json/vms.lock (when RootDir == RunDir).
-			reserved := map[string]struct{}{"db": {}, CloneLocksDirName: {}}
-			runOrphans := utils.FilterUnreferenced(snap.runDirs, snap.vmIDs, reserved)
-			logOrphans := utils.FilterUnreferenced(snap.logDirs, snap.vmIDs, reserved)
+			runOrphans := utils.FilterUnreferenced(snap.runDirs, snap.vmIDs, gcReservedDirNames)
+			logOrphans := utils.FilterUnreferenced(snap.logDirs, snap.vmIDs, gcReservedDirNames)
 			for _, id := range snap.staleCreate {
 				snap.reasons[id] = "stale-creating"
 			}

--- a/hypervisor/gc.go
+++ b/hypervisor/gc.go
@@ -15,6 +15,7 @@ import (
 	"github.com/projecteru2/core/log"
 
 	"github.com/cocoonstack/cocoon/gc"
+	"github.com/cocoonstack/cocoon/lock/flock"
 	"github.com/cocoonstack/cocoon/types"
 	"github.com/cocoonstack/cocoon/utils"
 )
@@ -95,7 +96,7 @@ func (b *Backend) BuildGCModule() gc.Module[VMGCSnapshot] {
 		},
 		Resolve: func(_ context.Context, snap VMGCSnapshot, _ map[string]any) []string {
 			// "db" holds vms.json/vms.lock (when RootDir == RunDir).
-			reserved := map[string]struct{}{"db": {}}
+			reserved := map[string]struct{}{"db": {}, CloneLocksDirName: {}}
 			runOrphans := utils.FilterUnreferenced(snap.runDirs, snap.vmIDs, reserved)
 			logOrphans := utils.FilterUnreferenced(snap.logDirs, snap.vmIDs, reserved)
 			for _, id := range snap.staleCreate {
@@ -135,6 +136,7 @@ func (b *Backend) gcCollect(ctx context.Context, ids []string, snap VMGCSnapshot
 	logger := log.WithFunc("gc." + b.Typ)
 	errs := b.sweepStaleCaptureDirs(ctx, snap.sweepDirs(b.Conf.RunDir()))
 	errs = append(errs, b.sweepOrphanDirs(ctx, snap.orphanDirs)...)
+	errs = append(errs, b.sweepStaleCloneLocks(ctx)...)
 	// Only fully-reclaimed ids lose their DB record: unrecording a skipped VM would strand a live VMM/dirs with no owner and let network GC tear it down.
 	safeToUnrecord := make([]string, 0, len(ids))
 	for _, id := range ids {
@@ -184,6 +186,34 @@ func (b *Backend) sweepStaleCaptureDirs(ctx context.Context, runDirs []string) [
 				return err == nil && info.ModTime().Before(cutoff)
 			})...)
 		})
+	}
+	return errs
+}
+
+// sweepStaleCloneLocks reclaims crash-orphaned lock files past the grace age via TryLock+Unlock, not a bare remove, so a live waiter can't be split onto a fresh inode.
+func (b *Backend) sweepStaleCloneLocks(ctx context.Context) []error {
+	dir := filepath.Join(b.Conf.RunDir(), CloneLocksDirName)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	logger := log.WithFunc("gc." + b.Typ)
+	cutoff := time.Now().Add(-CreatingStateGCGrace)
+	var errs []error
+	for _, e := range entries {
+		info, infoErr := e.Info()
+		if infoErr != nil || info.ModTime().After(cutoff) {
+			continue
+		}
+		l := flock.NewTransient(filepath.Join(dir, e.Name()))
+		if ok, tryErr := l.TryLock(ctx); tryErr != nil || !ok {
+			continue
+		}
+		if unlockErr := l.Unlock(ctx); unlockErr != nil {
+			errs = append(errs, unlockErr)
+			continue
+		}
+		logger.Infof(ctx, "collected clone lock %s reason=stale-clone-lock", e.Name())
 	}
 	return errs
 }

--- a/hypervisor/gc_test.go
+++ b/hypervisor/gc_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -96,6 +97,16 @@ func TestSweepStaleCaptureDirsCoversPersistedRunDir(t *testing.T) {
 	}
 	if _, err := os.Stat(stale); !os.IsNotExist(err) {
 		t.Fatal("stale staging in a migrated run dir must be reclaimed")
+	}
+}
+
+// A reserved dir swept as a VM run dir would get an ops.lock planted inside it by withOpsTryLock.
+func TestSweepDirsSkipsReservedNames(t *testing.T) {
+	snap := VMGCSnapshot{runDirs: []string{"db", CloneLocksDirName, "SOMEVM"}}
+	got := snap.sweepDirs("/root")
+	want := []string{"/root/SOMEVM"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("sweepDirs = %v, want %v", got, want)
 	}
 }
 

--- a/hypervisor/utils.go
+++ b/hypervisor/utils.go
@@ -35,6 +35,9 @@ const (
 	// OpsLockName is the per-VM cross-process mutation lock file (in the VM run dir).
 	OpsLockName = "ops.lock"
 
+	// CloneLocksDirName holds FC clone locks under the backend run root, outside any VM dir — a clone must be able to lock a source whose dir is already gone.
+	CloneLocksDirName = "clone-locks"
+
 	// restoreStagingName is the restore staging dir inside the VM run dir; snapshot capture dirs use the "snapshot-" prefix. restoreDirtyName is the tombstone marking the destructive restore phase — cleared only by FinalizeRestore, never by GC.
 	restoreStagingName = ".restore-staging"
 	restoreDirtyName   = ".restore-dirty"

--- a/lock/flock/flock.go
+++ b/lock/flock/flock.go
@@ -2,7 +2,10 @@ package flock
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
+	"os"
 	"time"
 
 	"github.com/gofrs/flock"
@@ -16,14 +19,20 @@ var _ lock.Locker = (*Lock)(nil)
 
 // Lock provides in-process (channel) + cross-process (flock) mutual exclusion.
 type Lock struct {
-	path string
-	ch   chan struct{}
-	fl   *flock.Flock // active flock fd, non-nil while held
+	path      string
+	ch        chan struct{}
+	fl        *flock.Flock // active flock fd, non-nil while held
+	transient bool
 }
 
 // New returns a Lock guarding path; the lock file is created on first acquire.
 func New(path string) *Lock {
 	return &Lock{path: path, ch: make(chan struct{}, 1)}
+}
+
+// NewTransient returns a Lock that unlinks its file on Unlock; Lock retries if it acquires an already-unlinked inode instead of splitting the lock.
+func NewTransient(path string) *Lock {
+	return &Lock{path: path, ch: make(chan struct{}, 1), transient: true}
 }
 
 func (l *Lock) Lock(ctx context.Context) error {
@@ -32,16 +41,21 @@ func (l *Lock) Lock(ctx context.Context) error {
 	case <-ctx.Done():
 		return fmt.Errorf("acquire lock %s: %w", l.path, ctx.Err())
 	}
-	ok, err := l.commitFlock(func(fl *flock.Flock) (bool, error) {
-		return fl.TryLockContext(ctx, retryDelay)
-	})
-	if err != nil {
-		return fmt.Errorf("acquire flock %s: %w", l.path, err)
+	for {
+		ok, err := l.commitFlock(func(fl *flock.Flock) (bool, error) {
+			return fl.TryLockContext(ctx, retryDelay)
+		})
+		if err != nil {
+			return fmt.Errorf("acquire flock %s: %w", l.path, err)
+		}
+		if !ok {
+			return fmt.Errorf("acquire flock %s: %w", l.path, ctx.Err())
+		}
+		if l.pathBound() {
+			return nil
+		}
+		l.dropFlock()
 	}
-	if !ok {
-		return fmt.Errorf("acquire flock %s: %w", l.path, ctx.Err())
-	}
-	return nil
 }
 
 // TryLock returns (false, nil) if the lock is currently held by another caller.
@@ -51,15 +65,30 @@ func (l *Lock) TryLock(_ context.Context) (bool, error) {
 	default:
 		return false, nil
 	}
-	return l.commitFlock(func(fl *flock.Flock) (bool, error) {
+	ok, err := l.commitFlock(func(fl *flock.Flock) (bool, error) {
 		return fl.TryLock()
 	})
+	if err != nil || !ok {
+		return ok, err
+	}
+	if !l.pathBound() {
+		l.dropFlock()
+		<-l.ch
+		return false, nil
+	}
+	return true, nil
 }
 
 func (l *Lock) Unlock(_ context.Context) error {
 	var err error
 	if l.fl != nil {
-		err = l.fl.Unlock()
+		// Unlink before funlock: still holding a verified lock, so no waiter can win the pathname until it rebinds to a fresh inode.
+		if l.transient {
+			if rmErr := os.Remove(l.path); rmErr != nil && !errors.Is(rmErr, fs.ErrNotExist) {
+				err = rmErr
+			}
+		}
+		err = errors.Join(err, l.fl.Unlock())
 		l.fl = nil
 	}
 	select {
@@ -83,4 +112,23 @@ func (l *Lock) commitFlock(acquire func(*flock.Flock) (bool, error)) (bool, erro
 	}
 	l.fl = fl
 	return true, nil
+}
+
+// pathBound reports whether the held fd is still the inode bound to path; false means the file was unlinked (and possibly recreated) while waiting.
+func (l *Lock) pathBound() bool {
+	if !l.transient {
+		return true
+	}
+	held, err := l.fl.Stat()
+	if err != nil {
+		return false
+	}
+	cur, err := os.Stat(l.path)
+	return err == nil && os.SameFile(held, cur)
+}
+
+// dropFlock releases the kernel lock while keeping the in-process token, for requeueing on a fresh inode.
+func (l *Lock) dropFlock() {
+	_ = l.fl.Close()
+	l.fl = nil
 }

--- a/lock/flock/flock.go
+++ b/lock/flock/flock.go
@@ -58,7 +58,6 @@ func (l *Lock) Lock(ctx context.Context) error {
 	}
 }
 
-// TryLock returns (false, nil) if the lock is currently held by another caller.
 func (l *Lock) TryLock(_ context.Context) (bool, error) {
 	select {
 	case l.ch <- struct{}{}:

--- a/lock/flock/flock_test.go
+++ b/lock/flock/flock_test.go
@@ -2,6 +2,9 @@ package flock
 
 import (
 	"context"
+	"errors"
+	"io/fs"
+	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -145,10 +148,8 @@ func TestConcurrentLockUnlock(t *testing.T) {
 	)
 
 	var wg sync.WaitGroup
-	wg.Add(50)
 	for range 50 {
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			if err := l.Lock(ctx); err != nil {
 				t.Errorf("Lock: %v", err)
 				return
@@ -159,7 +160,7 @@ func TestConcurrentLockUnlock(t *testing.T) {
 			if err := l.Unlock(ctx); err != nil {
 				t.Errorf("Unlock: %v", err)
 			}
-		}()
+		})
 	}
 	wg.Wait()
 
@@ -174,6 +175,61 @@ func TestUnlockWithoutLock(t *testing.T) {
 
 	if err := l.Unlock(ctx); err != nil {
 		t.Fatalf("Unlock on unheld lock should not error, got: %v", err)
+	}
+}
+
+func TestTransientUnlinksOnUnlock(t *testing.T) {
+	path := lockPath(t)
+	l := NewTransient(path)
+	ctx := t.Context()
+
+	if err := l.Lock(ctx); err != nil {
+		t.Fatalf("Lock: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("lock file missing while held: %v", err)
+	}
+	if err := l.Unlock(ctx); err != nil {
+		t.Fatalf("Unlock: %v", err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("lock file not unlinked after Unlock: %v", err)
+	}
+}
+
+func TestTransientWaiterRequeuesAcrossUnlink(t *testing.T) {
+	path := lockPath(t)
+	ctx := t.Context()
+	l1, l2 := NewTransient(path), NewTransient(path)
+
+	if err := l1.Lock(ctx); err != nil {
+		t.Fatalf("l1 Lock: %v", err)
+	}
+
+	acquired := make(chan error, 1)
+	go func() { acquired <- l2.Lock(ctx) }()
+
+	select {
+	case err := <-acquired:
+		t.Fatalf("l2 Lock should block while l1 holds, got: %v", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	if err := l1.Unlock(ctx); err != nil {
+		t.Fatalf("l1 Unlock: %v", err)
+	}
+	if err := <-acquired; err != nil {
+		t.Fatalf("l2 Lock across unlink: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("path not rebound while l2 holds: %v", err)
+	}
+
+	if err := l2.Unlock(ctx); err != nil {
+		t.Fatalf("l2 Unlock: %v", err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("residue after final Unlock: %v", err)
 	}
 }
 

--- a/lock/lock.go
+++ b/lock/lock.go
@@ -6,5 +6,6 @@ import "context"
 type Locker interface {
 	Lock(ctx context.Context) error
 	Unlock(ctx context.Context) error
+	// TryLock returns (false, nil) when the lock is already held by another caller.
 	TryLock(ctx context.Context) (bool, error)
 }


### PR DESCRIPTION
## Problem

v0.5.0 (#118) broke every FC clone whose snapshot outlived its source VM — the sandboxd warm-pool steady state (golden exported then destroyed, refills via `vm clone --from-dir`) and FC snapshot import+clone generally. Two gates caused it: clone locks moved into the source VM's run dir with no MkdirAll (`acquire flock <srcDir>/cow.raw.clone.lock: no such file or directory`), and `ensureSourceAlive` rejected any source without a live record. 100% reproducible: `vm run → snapshot save → snapshot export → vm rm → vm clone --from-dir`.

The restored contract: a successfully exported snapshot is a self-contained artifact — clone works regardless of whether the source VM still exists. The only residual coupling is the source-absolute drive path embedded in FC vmstate, resolved by the transient symlink redirect; it needs the source's directory path as a mount point for milliseconds, never the source VM itself.

## Mechanism

- **lock/flock `NewTransient`**: unlink on Unlock (before funlock, under the held lock) + inode re-verify after every acquire (fstat vs path, requeue on mismatch). Deleting a lock file becomes race-free, which unlocks the rest:
- **FC clone locks return to a stable `clone-locks/` dir** (sha8-named), transient — empty at rest, no fresh-inode split, no accumulation. `ensureSourceAlive` deleted; a clone racing `vm rm` of its source now proceeds standalone instead of aborting.
- **`holdRedirectDirs`**: recreated source dirs are recordless, so the clone holds their ops locks (the same fence create uses for pre-record dirs) — the GC orphan scan cannot reap them mid-clone; released and removed with the redirect window.
- **`recoverStaleBackup`** heals a crashed clone's dangling redirect (dead source leaves no backup), guarded to only touch symlinks inside the managed run root — imported metadata is untrusted and COW/Data paths are exempt from root validation, so anything foreign is preserved.
- **GC**: reserved run-root subdirs (`db`, `clone-locks`) excluded from both the orphan scan and the capture-dir sweep (the sweep was planting a permanent `ops.lock` inside them); crash-orphaned clone locks past the grace age reclaimed via TryLock + verified unlink.

## Evidence (bare-metal testbed, isolated root + pinned binaries)

- Baseline v0.5.0: dead-source clone fails 100% with the exact flock ENOENT from the regression report.
- Fixed: single and 4x-concurrent dead-source clones all Running with vsock exec alive; `clone-locks/` empty at rest; source dir not resurrected.
- Clone racing `vm rm --force` ×5 rounds: all resolve clean; `gc` collects nothing.
- GC-race stress: 12 dead-source clones (8 sequential + 4 concurrent) under a continuous `cocoon gc` loop — **920,086 gc cycles, 0 failures, 12/12 clones healthy**.
- Dangling-redirect heal: planted crash leftover; the next clone heals it and succeeds; the recordless leftover dir is reaped by gc as orphan-runDir.
- `go test -race ./...` green (linux container), `make lint` 0 issues on linux+darwin.

## Review dispositions

Adversarial review ran to convergence over four rounds. Accepted: the GC reap fence, the dangling-redirect heal, and the untrusted-metadata symlink guard (keyed on the link's own location, not its target). Declined with rationale:

- Pre-existing recordless source dir vs GC race: the failure is loud, GC removes the leftover, and the retry deterministically succeeds via the locked recreate path — self-healing; fixing it would add a DB read to the clone path.
- Same-ID create lock inversion: VM IDs are generated ULIDs in every product path; a colliding caller-provided ID is unreachable in shipped binaries.

Line budget: production net +127, tests net +192.

E2E catalog: FC-T13..T15 added in cocoon-specs (dead-source clone, concurrent dead-source clones, clone-vs-rm race) — the gap that let this regress: every prior clone case ran with the source alive.