### PR TITLE
perf: parallelize the FC golden-clone burst path

### DIFF
--- a/cmd/vm/reseed.go
+++ b/cmd/vm/reseed.go
@@ -35,9 +35,12 @@ func (h Handler) Reseed(cmd *cobra.Command, args []string) error {
 	return reseedVM(ctx, vm, regenMachineID)
 }
 
-// reseedAfterResume re-inspects then fires the best-effort reseed: Clone/Restore return an in-process *types.VM whose VsockSocket is zero, and a stale value would silently no-op.
+// reseedAfterResume fires the best-effort reseed, re-inspecting only when the in-process record lacks VsockSocket — a zero value would silently no-op.
 func (h Handler) reseedAfterResume(ctx context.Context, hyper hypervisor.Hypervisor, vm *types.VM, regenMachineID bool) {
-	signalReseed(ctx, refreshVM(ctx, hyper, vm), regenMachineID)
+	if vm.VsockSocket == "" {
+		vm = refreshVM(ctx, hyper, vm)
+	}
+	signalReseed(ctx, vm, regenMachineID)
 }
 
 // reseedVM pushes fresh entropy and a CRNG reseed order over vsock; only a failed dial retries (the agent re-listens shortly after resume) — a live agent's reply is final.

--- a/cmd/vm/run.go
+++ b/cmd/vm/run.go
@@ -473,7 +473,6 @@ func prereserveVM(ctx context.Context, hyper hypervisor.Hypervisor, vmID string,
 		return nil, nil, err
 	}
 	if err := r.PrereserveVM(ctx, vmID, vmCfg, blobIDs); err != nil {
-		// The write may have committed despite the error (fsync after rename); rollback is idempotent either way.
 		r.RollbackCreate(ctx, vmID, vmCfg.Name)
 		unlock()
 		return nil, nil, fmt.Errorf("reserve VM record: %w", err)

--- a/hypervisor/create.go
+++ b/hypervisor/create.go
@@ -15,7 +15,8 @@ import (
 // ReserveVM inserts a "creating" placeholder under id, failing on id/name collision. Re-reserving the placeholder this same create claimed via PrereserveVM adopts it (refreshing blob pins and dirs).
 func (b *Backend) ReserveVM(ctx context.Context, id string, vmCfg *types.VMConfig, blobIDs map[string]struct{}, runDir, logDir string) error {
 	now := time.Now()
-	return b.DB.Update(ctx, func(idx *VMIndex) error {
+	// NoSync: a placeholder lost to power failure only re-exposes resources the GC orphan sweep already reclaims.
+	return b.DB.UpdateNoSync(ctx, func(idx *VMIndex) error {
 		if existing := idx.VMs[id]; existing != nil {
 			if existing.State == types.VMStateCreating && existing.Config.Name == vmCfg.Name {
 				existing.ImageBlobIDs = blobIDs

--- a/hypervisor/create.go
+++ b/hypervisor/create.go
@@ -15,8 +15,8 @@ import (
 // ReserveVM inserts a "creating" placeholder under id, failing on id/name collision. Re-reserving the placeholder this same create claimed via PrereserveVM adopts it (refreshing blob pins and dirs).
 func (b *Backend) ReserveVM(ctx context.Context, id string, vmCfg *types.VMConfig, blobIDs map[string]struct{}, runDir, logDir string) error {
 	now := time.Now()
-	// NoSync: a placeholder lost to power failure only re-exposes resources the GC orphan sweep already reclaims.
-	return b.DB.UpdateNoSync(ctx, func(idx *VMIndex) error {
+	// NoDirSync: a placeholder rolled back by power failure only re-exposes resources the GC orphan sweep already reclaims.
+	return b.DB.UpdateNoDirSync(ctx, func(idx *VMIndex) error {
 		if existing := idx.VMs[id]; existing != nil {
 			if existing.State == types.VMStateCreating && existing.Config.Name == vmCfg.Name {
 				existing.ImageBlobIDs = blobIDs

--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -22,6 +22,8 @@ import (
 
 const cloneBackupSuffix = ".cocoon-clone-backup"
 
+var errBindSetup = errors.New("bind-mount clone redirect unavailable")
+
 type driveRedirect struct {
 	symlinkPath string
 	backupPath  string
@@ -70,35 +72,15 @@ func (fc *Firecracker) cloneAfterExtract(ctx context.Context, vmID string, vmCfg
 	}
 
 	sockPath := hypervisor.SocketPath(runDir)
-	pid, launchErr := fc.launchProcess(ctx, &hypervisor.VMRecord{
-		VM:     types.VM{ID: vmID},
-		RunDir: runDir,
-		LogDir: logDir,
-	}, sockPath, net.NetnsPath)
-	if launchErr != nil {
-		fc.MarkError(ctx, vmID)
-		return nil, fmt.Errorf("launch FC: %w", launchErr)
+	launch := func() (int, error) {
+		return fc.launchProcess(ctx, &hypervisor.VMRecord{
+			VM:     types.VM{ID: vmID},
+			RunDir: runDir,
+			LogDir: logDir,
+		}, sockPath, net.NetnsPath)
 	}
-
-	// FC snapshot/load wants source-absolute drive paths; symlink-redirect the source COW. The lock covers only the redirect window — FC holds the drive fds once load returns, so resume and re-anchor run lock-free.
-	if cloneErr := fc.withSourceWritableDisksLocked(ctx, meta.StorageConfigs, func() error {
-		releaseDirs, holdErr := holdRedirectDirs(ctx, meta.StorageConfigs, storageConfigs)
-		if holdErr != nil {
-			return holdErr
-		}
-		defer releaseDirs()
-		redirects, redirectErr := createDriveRedirects(meta.StorageConfigs, storageConfigs)
-		if redirectErr != nil {
-			return fmt.Errorf("drive redirect: %w", redirectErr)
-		}
-		defer cleanupDriveRedirects(redirects)
-
-		if loadErr := loadSnapshotFC(ctx, sockPath, runDir, buildNetworkOverrides(networkConfigs), hypervisor.VsockSockPath(runDir)); loadErr != nil {
-			return fmt.Errorf("snapshot/load: %w", loadErr)
-		}
-		return nil
-	}); cloneErr != nil {
-		fc.AbortLaunch(ctx, pid, sockPath, runDir, runtimeFiles)
+	pid, cloneErr := fc.loadCloneSnapshot(ctx, launch, sockPath, runDir, networkConfigs, meta.StorageConfigs, storageConfigs)
+	if cloneErr != nil {
 		fc.MarkError(ctx, vmID)
 		return nil, cloneErr
 	}
@@ -122,6 +104,72 @@ func (fc *Firecracker) cloneAfterExtract(ctx context.Context, vmID string, vmCfg
 
 	logger.Infof(ctx, "VM %s cloned from snapshot", vmID)
 	return info, nil
+}
+
+// loadCloneSnapshot launches FC and drives snapshot/load. Fast path bind-mounts the clone disks over the source-absolute paths in a private mount namespace (no host mutation, siblings run parallel); a missing/symlinked source or denied unshare falls back to symlink-redirects under the source-disk locks.
+func (fc *Firecracker) loadCloneSnapshot(
+	ctx context.Context,
+	launch func() (int, error),
+	sockPath, runDir string,
+	networkConfigs []*types.NetworkConfig,
+	srcConfigs, dstConfigs []*types.StorageConfig,
+) (int, error) {
+	netOverrides := buildNetworkOverrides(networkConfigs)
+	vsockPath := hypervisor.VsockSockPath(runDir)
+
+	if binds, ok := bindableRedirects(srcConfigs, dstConfigs); ok {
+		pid, err := launchWithBinds(binds, launch)
+		switch {
+		case err == nil:
+			if loadErr := loadSnapshotFC(ctx, sockPath, runDir, netOverrides, vsockPath); loadErr != nil {
+				fc.AbortLaunch(ctx, pid, sockPath, runDir, runtimeFiles)
+				return 0, fmt.Errorf("snapshot/load: %w", loadErr)
+			}
+			return pid, nil
+		case !errors.Is(err, errBindSetup):
+			return 0, fmt.Errorf("launch FC: %w", err)
+		}
+	}
+
+	pid, err := launch()
+	if err != nil {
+		return 0, fmt.Errorf("launch FC: %w", err)
+	}
+	// FC holds the drive fds once load returns, so the locks cover only the redirect window; resume and re-anchor run lock-free.
+	if lockErr := fc.withSourceWritableDisksLocked(ctx, srcConfigs, func() error {
+		releaseDirs, holdErr := holdRedirectDirs(ctx, srcConfigs, dstConfigs)
+		if holdErr != nil {
+			return holdErr
+		}
+		defer releaseDirs()
+		redirects, redirectErr := createDriveRedirects(srcConfigs, dstConfigs)
+		if redirectErr != nil {
+			return fmt.Errorf("drive redirect: %w", redirectErr)
+		}
+		defer cleanupDriveRedirects(redirects)
+
+		if loadErr := loadSnapshotFC(ctx, sockPath, runDir, netOverrides, vsockPath); loadErr != nil {
+			return fmt.Errorf("snapshot/load: %w", loadErr)
+		}
+		return nil
+	}); lockErr != nil {
+		fc.AbortLaunch(ctx, pid, sockPath, runDir, runtimeFiles)
+		return 0, lockErr
+	}
+	return pid, nil
+}
+
+// bindableRedirects returns dst-over-src bind pairs; ok=false when any source is not a pristine regular file (missing, or a crashed clone's symlink awaiting the locked path's healing).
+func bindableRedirects(srcConfigs, dstConfigs []*types.StorageConfig) ([][2]string, bool) {
+	var binds [][2]string
+	for _, i := range redirectedDriveIndices(srcConfigs, dstConfigs) {
+		fi, err := os.Lstat(srcConfigs[i].Path)
+		if err != nil || !fi.Mode().IsRegular() {
+			return nil, false
+		}
+		binds = append(binds, [2]string{srcConfigs[i].Path, dstConfigs[i].Path})
+	}
+	return binds, len(binds) > 0
 }
 
 func (fc *Firecracker) resumeAndReanchorClone(

--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -147,6 +147,7 @@ func (fc *Firecracker) loadCloneSnapshot(
 		}
 	}
 
+	// TODO: retire this symlink fallback once mount-ns has soaked a release — dead sources need only the dir locks plus a placeholder mountpoint to bind over.
 	pid, err := launch()
 	if err != nil {
 		return 0, fmt.Errorf("launch FC: %w", err)

--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -159,19 +159,6 @@ func (fc *Firecracker) loadCloneSnapshot(
 	return pid, nil
 }
 
-// bindableRedirects returns dst-over-src bind pairs; ok=false when any source is not a pristine regular file (missing, or a crashed clone's symlink awaiting the locked path's healing).
-func bindableRedirects(srcConfigs, dstConfigs []*types.StorageConfig) ([][2]string, bool) {
-	var binds [][2]string
-	for _, i := range redirectedDriveIndices(srcConfigs, dstConfigs) {
-		fi, err := os.Lstat(srcConfigs[i].Path)
-		if err != nil || !fi.Mode().IsRegular() {
-			return nil, false
-		}
-		binds = append(binds, [2]string{srcConfigs[i].Path, dstConfigs[i].Path})
-	}
-	return binds, len(binds) > 0
-}
-
 func (fc *Firecracker) resumeAndReanchorClone(
 	ctx context.Context,
 	pid int,
@@ -226,6 +213,19 @@ func redirectedDriveIndices(srcConfigs, dstConfigs []*types.StorageConfig) []int
 		}
 	}
 	return indices
+}
+
+// bindableRedirects returns dst-over-src bind pairs; ok=false when any source is not a pristine regular file (missing, or a crashed clone's symlink awaiting the locked path's healing).
+func bindableRedirects(srcConfigs, dstConfigs []*types.StorageConfig) ([][2]string, bool) {
+	var binds [][2]string
+	for _, i := range redirectedDriveIndices(srcConfigs, dstConfigs) {
+		fi, err := os.Lstat(srcConfigs[i].Path)
+		if err != nil || !fi.Mode().IsRegular() {
+			return nil, false
+		}
+		binds = append(binds, [2]string{srcConfigs[i].Path, dstConfigs[i].Path})
+	}
+	return binds, len(binds) > 0
 }
 
 func createDriveRedirects(srcConfigs, dstConfigs []*types.StorageConfig) ([]driveRedirect, error) {

--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -79,15 +79,10 @@ func (fc *Firecracker) cloneAfterExtract(ctx context.Context, vmID string, vmCfg
 			LogDir: logDir,
 		}, sockPath, net.NetnsPath)
 	}
-	pid, cloneErr := fc.loadCloneSnapshot(ctx, launch, sockPath, runDir, networkConfigs, meta.StorageConfigs, storageConfigs)
+	pid, cloneErr := fc.startCloneVM(ctx, launch, sockPath, runDir, networkConfigs, meta.StorageConfigs, storageConfigs)
 	if cloneErr != nil {
 		fc.MarkError(ctx, vmID)
 		return nil, cloneErr
-	}
-
-	if resumeErr := fc.resumeAndReanchorClone(ctx, pid, sockPath, runDir, meta.StorageConfigs, storageConfigs); resumeErr != nil {
-		fc.MarkError(ctx, vmID)
-		return nil, resumeErr
 	}
 
 	info := &types.VM{
@@ -106,7 +101,24 @@ func (fc *Firecracker) cloneAfterExtract(ctx context.Context, vmID string, vmCfg
 	return info, nil
 }
 
-// loadCloneSnapshot launches FC and drives snapshot/load. Fast path bind-mounts the clone disks over the source-absolute paths in a private mount namespace (no host mutation, siblings run parallel); a missing/symlinked source or denied unshare falls back to symlink-redirects under the source-disk locks.
+// startCloneVM launches FC, drives snapshot/load, then resumes and re-anchors. The load fast path bind-mounts the clone disks over the source-absolute paths in a private mount namespace (no host mutation, siblings run parallel); a missing/symlinked source or denied unshare falls back to symlink-redirects under the source-disk locks.
+func (fc *Firecracker) startCloneVM(
+	ctx context.Context,
+	launch func() (int, error),
+	sockPath, runDir string,
+	networkConfigs []*types.NetworkConfig,
+	srcConfigs, dstConfigs []*types.StorageConfig,
+) (int, error) {
+	pid, err := fc.loadCloneSnapshot(ctx, launch, sockPath, runDir, networkConfigs, srcConfigs, dstConfigs)
+	if err != nil {
+		return 0, err
+	}
+	if err := fc.resumeAndReanchorClone(ctx, pid, sockPath, runDir, srcConfigs, dstConfigs); err != nil {
+		return 0, err
+	}
+	return pid, nil
+}
+
 func (fc *Firecracker) loadCloneSnapshot(
 	ctx context.Context,
 	launch func() (int, error),
@@ -117,7 +129,7 @@ func (fc *Firecracker) loadCloneSnapshot(
 	netOverrides := buildNetworkOverrides(networkConfigs)
 	vsockPath := hypervisor.VsockSockPath(runDir)
 
-	if binds, ok := bindableRedirects(srcConfigs, dstConfigs); ok {
+	if binds := bindableRedirects(srcConfigs, dstConfigs); len(binds) > 0 {
 		pid, err := launchWithBinds(binds, launch)
 		switch {
 		case err == nil:
@@ -215,17 +227,17 @@ func redirectedDriveIndices(srcConfigs, dstConfigs []*types.StorageConfig) []int
 	return indices
 }
 
-// bindableRedirects returns dst-over-src bind pairs; ok=false when any source is not a pristine regular file (missing, or a crashed clone's symlink awaiting the locked path's healing).
-func bindableRedirects(srcConfigs, dstConfigs []*types.StorageConfig) ([][2]string, bool) {
+// bindableRedirects returns dst-over-src bind pairs; nil when any source is not a pristine regular file (missing, or a crashed clone's symlink awaiting the locked path's healing).
+func bindableRedirects(srcConfigs, dstConfigs []*types.StorageConfig) [][2]string {
 	var binds [][2]string
 	for _, i := range redirectedDriveIndices(srcConfigs, dstConfigs) {
 		fi, err := os.Lstat(srcConfigs[i].Path)
 		if err != nil || !fi.Mode().IsRegular() {
-			return nil, false
+			return nil
 		}
 		binds = append(binds, [2]string{srcConfigs[i].Path, dstConfigs[i].Path})
 	}
-	return binds, len(binds) > 0
+	return binds
 }
 
 func createDriveRedirects(srcConfigs, dstConfigs []*types.StorageConfig) ([]driveRedirect, error) {

--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -231,14 +231,19 @@ func redirectedDriveIndices(srcConfigs, dstConfigs []*types.StorageConfig) []int
 	return indices
 }
 
-// bindableRedirects returns dst-over-src bind pairs; nil when any source is not a pristine regular file (missing, or a crashed clone's symlink awaiting the locked path's healing).
+// bindableRedirects returns dst-over-src bind pairs; nil when any source is not a pristine regular file (missing, or a crashed clone's symlink awaiting the locked path's healing) or a dst repeats — a shared dst inode would mask a detached sibling bind in verifyDriveFDs.
 func bindableRedirects(srcConfigs, dstConfigs []*types.StorageConfig) [][2]string {
 	var binds [][2]string
+	seen := make(map[string]struct{})
 	for _, i := range redirectedDriveIndices(srcConfigs, dstConfigs) {
 		fi, err := os.Lstat(srcConfigs[i].Path)
 		if err != nil || !fi.Mode().IsRegular() {
 			return nil
 		}
+		if _, dup := seen[dstConfigs[i].Path]; dup {
+			return nil
+		}
+		seen[dstConfigs[i].Path] = struct{}{}
 		binds = append(binds, [2]string{srcConfigs[i].Path, dstConfigs[i].Path})
 	}
 	return binds

--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -137,6 +137,10 @@ func (fc *Firecracker) loadCloneSnapshot(
 				fc.AbortLaunch(ctx, pid, sockPath, runDir, runtimeFiles)
 				return 0, fmt.Errorf("snapshot/load: %w", loadErr)
 			}
+			if verifyErr := verifyDriveFDs(pid, binds); verifyErr != nil {
+				fc.AbortLaunch(ctx, pid, sockPath, runDir, runtimeFiles)
+				return 0, fmt.Errorf("bind redirect lost during load (source mutated concurrently, retry): %w", verifyErr)
+			}
 			return pid, nil
 		case !errors.Is(err, errBindSetup):
 			return 0, fmt.Errorf("launch FC: %w", err)

--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -69,9 +69,18 @@ func (fc *Firecracker) cloneAfterExtract(ctx context.Context, vmID string, vmCfg
 		return nil, err
 	}
 
-	// FC snapshot/load wants source-absolute drive paths; symlink-redirect the source COW.
 	sockPath := hypervisor.SocketPath(runDir)
-	var pid int
+	pid, launchErr := fc.launchProcess(ctx, &hypervisor.VMRecord{
+		VM:     types.VM{ID: vmID},
+		RunDir: runDir,
+		LogDir: logDir,
+	}, sockPath, net.NetnsPath)
+	if launchErr != nil {
+		fc.MarkError(ctx, vmID)
+		return nil, fmt.Errorf("launch FC: %w", launchErr)
+	}
+
+	// FC snapshot/load wants source-absolute drive paths; symlink-redirect the source COW. The lock covers only the redirect window — FC holds the drive fds once load returns, so resume and re-anchor run lock-free.
 	if cloneErr := fc.withSourceWritableDisksLocked(ctx, meta.StorageConfigs, func() error {
 		releaseDirs, holdErr := holdRedirectDirs(ctx, meta.StorageConfigs, storageConfigs)
 		if holdErr != nil {
@@ -84,20 +93,19 @@ func (fc *Firecracker) cloneAfterExtract(ctx context.Context, vmID string, vmCfg
 		}
 		defer cleanupDriveRedirects(redirects)
 
-		var launchErr error
-		pid, launchErr = fc.launchProcess(ctx, &hypervisor.VMRecord{
-			VM:     types.VM{ID: vmID},
-			RunDir: runDir,
-			LogDir: logDir,
-		}, sockPath, net.NetnsPath)
-		if launchErr != nil {
-			return fmt.Errorf("launch FC: %w", launchErr)
+		if loadErr := loadSnapshotFC(ctx, sockPath, runDir, buildNetworkOverrides(networkConfigs), hypervisor.VsockSockPath(runDir)); loadErr != nil {
+			return fmt.Errorf("snapshot/load: %w", loadErr)
 		}
-
-		return fc.restoreAndResumeClone(ctx, pid, sockPath, runDir, networkConfigs, meta.StorageConfigs, storageConfigs)
+		return nil
 	}); cloneErr != nil {
+		fc.AbortLaunch(ctx, pid, sockPath, runDir, runtimeFiles)
 		fc.MarkError(ctx, vmID)
 		return nil, cloneErr
+	}
+
+	if resumeErr := fc.resumeAndReanchorClone(ctx, pid, sockPath, runDir, meta.StorageConfigs, storageConfigs); resumeErr != nil {
+		fc.MarkError(ctx, vmID)
+		return nil, resumeErr
 	}
 
 	info := &types.VM{
@@ -116,11 +124,10 @@ func (fc *Firecracker) cloneAfterExtract(ctx context.Context, vmID string, vmCfg
 	return info, nil
 }
 
-func (fc *Firecracker) restoreAndResumeClone(
+func (fc *Firecracker) resumeAndReanchorClone(
 	ctx context.Context,
 	pid int,
 	sockPath, runDir string,
-	networkConfigs []*types.NetworkConfig,
 	srcConfigs, dstConfigs []*types.StorageConfig,
 ) (err error) {
 	defer func() {
@@ -129,11 +136,6 @@ func (fc *Firecracker) restoreAndResumeClone(
 		}
 	}()
 
-	// network_overrides repoints FC at the clone's TAP; vsock_override retargets the snapshot UDS.
-	netOverrides := buildNetworkOverrides(networkConfigs)
-	if err = loadSnapshotFC(ctx, sockPath, runDir, netOverrides, hypervisor.VsockSockPath(runDir)); err != nil {
-		return fmt.Errorf("snapshot/load: %w", err)
-	}
 	hc := utils.NewSocketHTTPClient(sockPath)
 	if err = resumeVM(ctx, hc); err != nil {
 		return fmt.Errorf("resume: %w", err)

--- a/hypervisor/firecracker/clone_test.go
+++ b/hypervisor/firecracker/clone_test.go
@@ -176,6 +176,7 @@ func TestBindableRedirects(t *testing.T) {
 		t.Fatalf("setup symlink: %v", err)
 	}
 	dst := writeTestFile(t, dir, "clone-cow.raw")
+	regular2 := writeTestFile(t, dir, "data.raw")
 	sc := func(p string) []*types.StorageConfig { return []*types.StorageConfig{{Path: p}} }
 
 	tests := []struct {
@@ -187,6 +188,12 @@ func TestBindableRedirects(t *testing.T) {
 		{"missing source", sc(filepath.Join(dir, "gone.raw")), sc(dst), nil},
 		{"symlinked source", sc(linked), sc(dst), nil},
 		{"no redirects", sc(regular), sc(regular), nil},
+		{
+			"duplicate dst",
+			[]*types.StorageConfig{{Path: regular}, {Path: regular2}},
+			[]*types.StorageConfig{{Path: dst}, {Path: dst}},
+			nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/hypervisor/firecracker/clone_test.go
+++ b/hypervisor/firecracker/clone_test.go
@@ -182,18 +182,16 @@ func TestBindableRedirects(t *testing.T) {
 		name     string
 		src, dst []*types.StorageConfig
 		want     [][2]string
-		wantOK   bool
 	}{
-		{"regular source", sc(regular), sc(dst), [][2]string{{regular, dst}}, true},
-		{"missing source", sc(filepath.Join(dir, "gone.raw")), sc(dst), nil, false},
-		{"symlinked source", sc(linked), sc(dst), nil, false},
-		{"no redirects", sc(regular), sc(regular), nil, false},
+		{"regular source", sc(regular), sc(dst), [][2]string{{regular, dst}}},
+		{"missing source", sc(filepath.Join(dir, "gone.raw")), sc(dst), nil},
+		{"symlinked source", sc(linked), sc(dst), nil},
+		{"no redirects", sc(regular), sc(regular), nil},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, ok := bindableRedirects(tt.src, tt.dst)
-			if ok != tt.wantOK || !slices.Equal(got, tt.want) {
-				t.Errorf("got (%v, %v), want (%v, %v)", got, ok, tt.want, tt.wantOK)
+			if got := bindableRedirects(tt.src, tt.dst); !slices.Equal(got, tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/hypervisor/firecracker/clone_test.go
+++ b/hypervisor/firecracker/clone_test.go
@@ -168,6 +168,37 @@ func TestRecoverStaleBackupRestoresBackup(t *testing.T) {
 	}
 }
 
+func TestBindableRedirects(t *testing.T) {
+	dir := t.TempDir()
+	regular := writeTestFile(t, dir, "cow.raw")
+	linked := filepath.Join(dir, "linked.raw")
+	if err := os.Symlink(regular, linked); err != nil {
+		t.Fatalf("setup symlink: %v", err)
+	}
+	dst := writeTestFile(t, dir, "clone-cow.raw")
+	sc := func(p string) []*types.StorageConfig { return []*types.StorageConfig{{Path: p}} }
+
+	tests := []struct {
+		name     string
+		src, dst []*types.StorageConfig
+		want     [][2]string
+		wantOK   bool
+	}{
+		{"regular source", sc(regular), sc(dst), [][2]string{{regular, dst}}, true},
+		{"missing source", sc(filepath.Join(dir, "gone.raw")), sc(dst), nil, false},
+		{"symlinked source", sc(linked), sc(dst), nil, false},
+		{"no redirects", sc(regular), sc(regular), nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := bindableRedirects(tt.src, tt.dst)
+			if ok != tt.wantOK || !slices.Equal(got, tt.want) {
+				t.Errorf("got (%v, %v), want (%v, %v)", got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
 func writeTestFile(t *testing.T, dir, name string) string {
 	t.Helper()
 	p := filepath.Join(dir, name)

--- a/hypervisor/firecracker/cowbind_linux.go
+++ b/hypervisor/firecracker/cowbind_linux.go
@@ -4,7 +4,10 @@ package firecracker
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"runtime"
+	"strconv"
 
 	"golang.org/x/sys/unix"
 )
@@ -38,4 +41,31 @@ func launchWithBinds(binds [][2]string, launch func() (int, error)) (int, error)
 	}()
 	r := <-ch
 	return r.pid, r.err
+}
+
+// verifyDriveFDs confirms pid holds an open fd for every bind's clone-side inode: unlinking a mountpoint path from another namespace detaches the bind (mount_namespaces(7)), so a concurrent source restore/delete inside the bind→load window would silently hand FC the source's writable disk.
+func verifyDriveFDs(pid int, binds [][2]string) error {
+	fdDir := filepath.Join("/proc", strconv.Itoa(pid), "fd")
+	entries, err := os.ReadDir(fdDir)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", fdDir, err)
+	}
+	open := make(map[[2]uint64]struct{}, len(entries))
+	for _, e := range entries {
+		var st unix.Stat_t
+		if statErr := unix.Stat(filepath.Join(fdDir, e.Name()), &st); statErr != nil {
+			continue
+		}
+		open[[2]uint64{st.Dev, st.Ino}] = struct{}{}
+	}
+	for _, b := range binds {
+		var st unix.Stat_t
+		if statErr := unix.Stat(b[1], &st); statErr != nil {
+			return fmt.Errorf("stat %s: %w", b[1], statErr)
+		}
+		if _, ok := open[[2]uint64{st.Dev, st.Ino}]; !ok {
+			return fmt.Errorf("%s is not held open by the VMM", b[1])
+		}
+	}
+	return nil
 }

--- a/hypervisor/firecracker/cowbind_linux.go
+++ b/hypervisor/firecracker/cowbind_linux.go
@@ -1,0 +1,41 @@
+//go:build linux
+
+package firecracker
+
+import (
+	"fmt"
+	"runtime"
+
+	"golang.org/x/sys/unix"
+)
+
+// launchWithBinds runs launch on a throwaway locked thread inside a private mount namespace with each dst bind-mounted over its src, so FC resolves source-absolute drive paths without touching the host namespace. The thread is never unlocked: it dies with the goroutine, taking the namespace along.
+func launchWithBinds(binds [][2]string, launch func() (int, error)) (int, error) {
+	type result struct {
+		pid int
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		runtime.LockOSThread()
+		// Go threads share CLONE_FS; unshare it or CLONE_NEWNS is refused.
+		if err := unix.Unshare(unix.CLONE_FS | unix.CLONE_NEWNS); err != nil {
+			ch <- result{0, fmt.Errorf("%w: unshare: %w", errBindSetup, err)}
+			return
+		}
+		if err := unix.Mount("", "/", "", unix.MS_REC|unix.MS_PRIVATE, ""); err != nil {
+			ch <- result{0, fmt.Errorf("%w: make mounts private: %w", errBindSetup, err)}
+			return
+		}
+		for _, b := range binds {
+			if err := unix.Mount(b[1], b[0], "", unix.MS_BIND, ""); err != nil {
+				ch <- result{0, fmt.Errorf("%w: bind %s over %s: %w", errBindSetup, b[1], b[0], err)}
+				return
+			}
+		}
+		pid, err := launch()
+		ch <- result{pid, err}
+	}()
+	r := <-ch
+	return r.pid, r.err
+}

--- a/hypervisor/firecracker/cowbind_linux_test.go
+++ b/hypervisor/firecracker/cowbind_linux_test.go
@@ -1,0 +1,31 @@
+//go:build linux
+
+package firecracker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestVerifyDriveFDs(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "clone-cow.raw")
+	if err := os.WriteFile(dst, []byte("x"), 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	binds := [][2]string{{filepath.Join(dir, "src.raw"), dst}}
+
+	if err := verifyDriveFDs(os.Getpid(), binds); err == nil {
+		t.Fatal("want error while dst is not open")
+	}
+
+	f, err := os.Open(dst)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close() //nolint:errcheck
+	if err := verifyDriveFDs(os.Getpid(), binds); err != nil {
+		t.Fatalf("verify with open fd: %v", err)
+	}
+}

--- a/hypervisor/firecracker/cowbind_other.go
+++ b/hypervisor/firecracker/cowbind_other.go
@@ -5,3 +5,7 @@ package firecracker
 func launchWithBinds(_ [][2]string, _ func() (int, error)) (int, error) {
 	return 0, errBindSetup
 }
+
+func verifyDriveFDs(int, [][2]string) error {
+	return errBindSetup
+}

--- a/hypervisor/firecracker/cowbind_other.go
+++ b/hypervisor/firecracker/cowbind_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package firecracker
+
+func launchWithBinds(_ [][2]string, _ func() (int, error)) (int, error) {
+	return 0, errBindSetup
+}

--- a/storage/json/json.go
+++ b/storage/json/json.go
@@ -49,8 +49,8 @@ func (s *Store[T]) Update(ctx context.Context, fn func(*T) error) error {
 	return s.withLocked(ctx, func() error { return s.writeRaw(fn, utils.Sync) })
 }
 
-// UpdateNoSync runs fn read-modify-write under the store lock, persisting without fsync.
-func (s *Store[T]) UpdateNoSync(ctx context.Context, fn func(*T) error) error {
+// UpdateNoDirSync runs fn read-modify-write under the store lock, fsyncing the file but not the parent dir.
+func (s *Store[T]) UpdateNoDirSync(ctx context.Context, fn func(*T) error) error {
 	return s.withLocked(ctx, func() error { return s.writeRaw(fn, utils.NoSync) })
 }
 
@@ -73,7 +73,7 @@ func (s *Store[T]) writeRaw(fn func(*T) error, sync utils.SyncMode) error {
 	if sync == utils.Sync {
 		return utils.AtomicWriteJSON(s.filePath, data)
 	}
-	return utils.AtomicWriteJSONNoSync(s.filePath, data)
+	return utils.AtomicWriteJSONNoDirSync(s.filePath, data)
 }
 
 func (s *Store[T]) load() (*T, error) {

--- a/storage/json/json.go
+++ b/storage/json/json.go
@@ -36,14 +36,7 @@ func (s *Store[T]) ReadRaw(fn func(*T) error) error {
 
 // WriteRaw loads, mutates, atomically writes back — unlocked.
 func (s *Store[T]) WriteRaw(fn func(*T) error) error {
-	data, err := s.load()
-	if err != nil {
-		return err
-	}
-	if err := fn(data); err != nil {
-		return err
-	}
-	return utils.AtomicWriteJSON(s.filePath, data)
+	return s.writeRaw(fn, utils.Sync)
 }
 
 // With runs fn read-only under the store lock.
@@ -53,7 +46,12 @@ func (s *Store[T]) With(ctx context.Context, fn func(*T) error) error {
 
 // Update runs fn read-modify-write under the store lock.
 func (s *Store[T]) Update(ctx context.Context, fn func(*T) error) error {
-	return s.withLocked(ctx, func() error { return s.WriteRaw(fn) })
+	return s.withLocked(ctx, func() error { return s.writeRaw(fn, utils.Sync) })
+}
+
+// UpdateNoSync runs fn read-modify-write under the store lock, persisting without fsync.
+func (s *Store[T]) UpdateNoSync(ctx context.Context, fn func(*T) error) error {
+	return s.withLocked(ctx, func() error { return s.writeRaw(fn, utils.NoSync) })
 }
 
 func (s *Store[T]) TryLock(ctx context.Context) (bool, error) {
@@ -62,6 +60,20 @@ func (s *Store[T]) TryLock(ctx context.Context) (bool, error) {
 
 func (s *Store[T]) Unlock(ctx context.Context) error {
 	return s.locker.Unlock(ctx)
+}
+
+func (s *Store[T]) writeRaw(fn func(*T) error, sync utils.SyncMode) error {
+	data, err := s.load()
+	if err != nil {
+		return err
+	}
+	if err := fn(data); err != nil {
+		return err
+	}
+	if sync == utils.Sync {
+		return utils.AtomicWriteJSON(s.filePath, data)
+	}
+	return utils.AtomicWriteJSONNoSync(s.filePath, data)
 }
 
 func (s *Store[T]) load() (*T, error) {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -15,7 +15,7 @@ type Store[T any] interface {
 	With(ctx context.Context, fn func(*T) error) error
 	// Update performs a read-modify-write under lock; persists only if fn returns nil.
 	Update(ctx context.Context, fn func(*T) error) error
-	// UpdateNoDirSync is Update without the rename's parent-dir fsync: content is never torn, only the mutation may roll back on power failure — for placeholder states GC re-derives.
+	// UpdateNoDirSync is Update without the rename's parent-dir fsync: content is never torn, only the mutation may roll back on power failure — for placeholder states GC re-derives. Requires a metadata-journaling filesystem (ext4/XFS) where a crashed rename resolves to the old or new entry, never to none.
 	UpdateNoDirSync(ctx context.Context, fn func(*T) error) error
 
 	// ReadRaw deserializes and passes to fn without locking; caller must already hold the lock via TryLock.

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -15,8 +15,8 @@ type Store[T any] interface {
 	With(ctx context.Context, fn func(*T) error) error
 	// Update performs a read-modify-write under lock; persists only if fn returns nil.
 	Update(ctx context.Context, fn func(*T) error) error
-	// UpdateNoSync is Update without fsync, for placeholder states GC re-derives after power loss.
-	UpdateNoSync(ctx context.Context, fn func(*T) error) error
+	// UpdateNoDirSync is Update without the rename's parent-dir fsync: content is never torn, only the mutation may roll back on power failure — for placeholder states GC re-derives.
+	UpdateNoDirSync(ctx context.Context, fn func(*T) error) error
 
 	// ReadRaw deserializes and passes to fn without locking; caller must already hold the lock via TryLock.
 	ReadRaw(fn func(*T) error) error

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -15,6 +15,8 @@ type Store[T any] interface {
 	With(ctx context.Context, fn func(*T) error) error
 	// Update performs a read-modify-write under lock; persists only if fn returns nil.
 	Update(ctx context.Context, fn func(*T) error) error
+	// UpdateNoSync is Update without fsync, for placeholder states GC re-derives after power loss.
+	UpdateNoSync(ctx context.Context, fn func(*T) error) error
 
 	// ReadRaw deserializes and passes to fn without locking; caller must already hold the lock via TryLock.
 	ReadRaw(fn func(*T) error) error

--- a/utils/atomic.go
+++ b/utils/atomic.go
@@ -20,22 +20,27 @@ type SyncMode bool
 
 // AtomicWriteFile writes data via temp + fsync + rename so readers never see a partial file.
 func AtomicWriteFile(path string, data []byte, perm os.FileMode) error {
-	return atomicWriteFile(path, data, perm, true)
+	return atomicWriteFile(path, data, perm, true, true)
 }
 
 // AtomicWriteFileNoSync is AtomicWriteFile without fsyncs, for transient run-dir files regenerated on the next launch.
 func AtomicWriteFileNoSync(path string, data []byte, perm os.FileMode) error {
-	return atomicWriteFile(path, data, perm, false)
+	return atomicWriteFile(path, data, perm, false, false)
 }
 
 // AtomicWriteJSON marshals v to JSON and writes it atomically.
 func AtomicWriteJSON(path string, v any) error {
-	return atomicWriteJSON(path, v, true)
+	return atomicWriteJSON(path, v, true, true)
 }
 
 // AtomicWriteJSONNoSync marshals v and writes it atomically without fsync (see AtomicWriteFileNoSync).
 func AtomicWriteJSONNoSync(path string, v any) error {
-	return atomicWriteJSON(path, v, false)
+	return atomicWriteJSON(path, v, false, false)
+}
+
+// AtomicWriteJSONNoDirSync fsyncs the file but not the parent dir: content is never torn on any filesystem, only the rename may be lost to power failure.
+func AtomicWriteJSONNoDirSync(path string, v any) error {
+	return atomicWriteJSON(path, v, true, false)
 }
 
 // ReadJSONFile loads path and unmarshals it into v.
@@ -85,7 +90,7 @@ func SyncTree(dir string) error {
 	return SyncParentDir(filepath.Dir(dir))
 }
 
-func atomicWriteFile(path string, data []byte, perm os.FileMode, sync bool) error {
+func atomicWriteFile(path string, data []byte, perm os.FileMode, fileSync, dirSync bool) error {
 	dir := filepath.Dir(path)
 	tmp, err := os.CreateTemp(dir, ".tmp-*")
 	if err != nil {
@@ -103,7 +108,7 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode, sync bool) erro
 	if _, err = tmp.Write(data); err != nil {
 		return fmt.Errorf("write temp file: %w", err)
 	}
-	if sync {
+	if fileSync {
 		if err = tmp.Sync(); err != nil {
 			return fmt.Errorf("sync temp file: %w", err)
 		}
@@ -117,7 +122,7 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode, sync bool) erro
 	if err = os.Rename(tmpPath, path); err != nil {
 		return fmt.Errorf("rename temp to target: %w", err)
 	}
-	if sync {
+	if dirSync {
 		if err = SyncParentDir(dir); err != nil {
 			return fmt.Errorf("sync parent dir: %w", err)
 		}
@@ -125,13 +130,13 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode, sync bool) erro
 	return nil
 }
 
-func atomicWriteJSON(path string, v any, sync bool) error {
+func atomicWriteJSON(path string, v any, fileSync, dirSync bool) error {
 	data, err := json.Marshal(v)
 	if err != nil {
 		return fmt.Errorf("marshal JSON: %w", err)
 	}
 	data = append(data, '\n')
-	return atomicWriteFile(path, data, 0o644, sync)
+	return atomicWriteFile(path, data, 0o644, fileSync, dirSync)
 }
 
 func syncFile(path string) (err error) {


### PR DESCRIPTION
## What

Four hot-path optimizations for the FC golden-clone burst, plus one shared index-write cut:

1. **Lock-window shrink** (`6940d2b`) — FC launch moves before the source-disk flock; the lock now covers only redirect-create → `snapshot/load` → redirect-cleanup. FC holds the drive fds once load returns 204, so resume and drive re-anchor run lock-free.
2. **Relaxed placeholder index writes** (`b3ae096`, hardened in `e81b2d6`+`c783e1c`) — `PrereserveVM` and the CloneSetup adoption rewrite the full VM index through `ReserveVM`; both now use a new `Store.UpdateNoDirSync`, which keeps the temp-file fsync and skips only the parent-dir fsync. Content is therefore never torn on any filesystem (no `auto_da_alloc` reliance); the only thing power failure can lose is the rename, i.e. the placeholder mutation itself — which merely re-exposes resources the GC orphan sweep already reclaims. `FinalizeClone`/`FinalizeCreate` stay fully synced.
3. **Private-mount-namespace clone redirects** (`c5699b3`, hardened in `e81b2d6`+`c783e1c`) — instead of renaming/symlinking the source COW in the host namespace (which is why the flock exists), the clone bind-mounts its disks over the source-absolute paths inside a private mount namespace on a throwaway locked thread. Zero host mutation → sibling clones need no lock at all. Because unlinking a mountpoint path from another namespace detaches the bind (mount_namespaces(7)), a source restore/delete racing the unlocked bind→load window could re-expose the source disk; after load the clone verifies every redirected clone inode is among the VMM's open fds (`verifyDriveFDs`; duplicate bind destinations are rejected up front so a shared inode cannot mask a detached sibling) and aborts cleanly otherwise. The relaxed index write states its crash contract: metadata-journaling filesystem (ext4/XFS). Missing/symlinked sources or unshare-denied environments (no CAP_SYS_ADMIN, or docker without `apparmor=unconfined`) fall back to the locked redirect path, which also heals crash leftovers.
4. **Reseed re-inspect skip** (`fc90c20`) — clone/restore already return records with runtime sockets set; the extra full-index `Inspect` per clone now runs only when `VsockSocket` is empty.

## Measured (bare-metal testbed, 16-core, ext4 on NVMe, rt:24.04 guest, 1vCPU/512M; A=master, B=1+2, C=all)

| metric | A | B | C |
|---|---|---|---|
| FC serial clone p50 | 29ms | 27ms | 27ms |
| FC burst16 per-clone p50 / wall | 126 / 201-220ms | 92-102 / 151-182ms | 85 / 146-161ms |
| FC burst64 per-clone p50 / max / wall | 813 / 996 / 998ms | 696 / 948 / 953ms | **488 / 853 / 862ms** |
| CH serial clone p50 | 44ms | 42ms | 42ms |

The bind path pays more the bigger the burst (64-burst per-clone p50 −40% vs master). Dead-source clones (fallback path) show no regression (serial 24ms, burst16 p50 80-82ms, B≈C).

## Functional evidence (binary C on the testbed)

- Both backends: clone+exec, stop/start cold boot, snapshot-of-clone → clone-of-clone — all green.
- Bind path proven live: clone's `cow.raw` visible bind-mounted over the source path in `/proc/<fcpid>/mountinfo`; exec/cold-boot/chain OK on top of it.
- `vm run` create path (shares the NoSync placeholder) green on FC and CH.
- Kill injection: 5× SIGKILL at 5-30ms mid-clone on bind path AND fallback; next clone heals, 0 stale backups, 0 symlinked COWs, exact process census afterwards.
- `go test -race ./...` (golang:1.26, linux): 29 packages ok.

## Measured skips (from the same finding list)

- COW-copy fsync removal: golden COW is 8.8MB warm — not the burst bottleneck; dropping it risks a torn COW after power loss with a finalized record.
- mkfs.ext4 template cache: mkfs on 10G sparse measured at 9ms — not worth the cache + duplicate-UUID hazards.
- Socket poll interval: launch left the serialized window entirely; 1ms poll is off the contended path.

Remaining burst serializer at 16-way (~85ms p50 vs 27ms serial) is the VM-index flock + ext4 journal + per-clone CLI process startup — separate follow-up. CH burst per-clone (~450ms vs 42ms serial) is memory-restore bandwidth, unrelated to these locks — also follow-up.
