### PR TITLE
feat(vm): replace --on-demand with --restore-mode copy|ondemand|mmap

### DIFF
--- a/cmd/core/vmconfig.go
+++ b/cmd/core/vmconfig.go
@@ -85,7 +85,10 @@ func CloneVMConfigFromFlags(cmd *cobra.Command, snapCfg types.SnapshotConfig) (*
 		noDirectIO, _ = cmd.Flags().GetBool("no-direct-io")
 	}
 
-	onDemand, _ := cmd.Flags().GetBool("on-demand")
+	restoreMode, err := restoreModeFromFlags(cmd)
+	if err != nil {
+		return nil, err
+	}
 	dataDiskRaw, _ := cmd.Flags().GetStringArray("data-disk")
 	dataDisks, err := parseDataDiskFlags(dataDiskRaw)
 	if err != nil {
@@ -108,8 +111,8 @@ func CloneVMConfigFromFlags(cmd *cobra.Command, snapCfg types.SnapshotConfig) (*
 			Windows:       snapCfg.Windows,
 			SharedMemory:  snapCfg.SharedMemory,
 		},
-		DataDisks: dataDisks,
-		OnDemand:  onDemand,
+		DataDisks:   dataDisks,
+		RestoreMode: restoreMode,
 	}, nil
 }
 
@@ -121,11 +124,14 @@ func RestoreVMConfigFromFlags(cmd *cobra.Command, vm *types.VM, snapCfg types.Sn
 	}
 	cfg := snapCfg.Config
 	cfg.Network = vm.Config.Network
-	onDemand, _ := cmd.Flags().GetBool("on-demand")
+	restoreMode, err := restoreModeFromFlags(cmd)
+	if err != nil {
+		return nil, err
+	}
 	result := &types.VMConfig{
-		Config:   cfg,
-		Name:     vm.Config.Name,
-		OnDemand: onDemand,
+		Config:      cfg,
+		Name:        vm.Config.Name,
+		RestoreMode: restoreMode,
 	}
 	if err := result.Validate(); err != nil {
 		return nil, fmt.Errorf("snapshot config: %w", err)
@@ -285,4 +291,14 @@ func normalizeDataDiskSpecs(specs []types.DataDiskSpec) error {
 		}
 	}
 	return nil
+}
+
+func restoreModeFromFlags(cmd *cobra.Command) (string, error) {
+	mode, _ := cmd.Flags().GetString("restore-mode")
+	switch mode {
+	case "", "copy", "ondemand", "mmap":
+		return mode, nil
+	default:
+		return "", fmt.Errorf("--restore-mode must be copy, ondemand or mmap, got %q", mode)
+	}
 }

--- a/cmd/core/vmconfig_test.go
+++ b/cmd/core/vmconfig_test.go
@@ -1,0 +1,40 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestRestoreModeFromFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    string
+		want    string
+		wantErr bool
+	}{
+		{name: "default empty", mode: "", want: ""},
+		{name: "copy", mode: "copy", want: "copy"},
+		{name: "ondemand", mode: "ondemand", want: "ondemand"},
+		{name: "mmap", mode: "mmap", want: "mmap"},
+		{name: "invalid", mode: "lazy", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			cmd.Flags().String("restore-mode", "", "")
+			if tt.mode != "" {
+				if err := cmd.Flags().Set("restore-mode", tt.mode); err != nil {
+					t.Fatalf("set flag: %v", err)
+				}
+			}
+			got, err := restoreModeFromFlags(cmd)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/vm/commands.go
+++ b/cmd/vm/commands.go
@@ -157,7 +157,7 @@ func Command(h Actions) *cobra.Command {
 		},
 		RunE: h.Restore,
 	}
-	restoreCmd.Flags().Bool("on-demand", false, "use UFFD on-demand memory loading for faster restore (CH only; snapshot file must remain on disk)")
+	restoreCmd.Flags().String("restore-mode", "", "memory restore mode: copy|ondemand|mmap (CH only; ondemand/mmap require the snapshot file to remain on disk)")
 	restoreCmd.Flags().String("from-dir", "", "restore from a snapshot directory (must contain snapshot.json) instead of the local snapshot DB; mutually exclusive with positional SNAPSHOT")
 	restoreCmd.Flags().Bool("force", false, "skip the snapshot-belongs-to-VM check (only meaningful with --from-dir; risk of restoring to an unrelated lineage)")
 	cliutil.AddOutputFlag(restoreCmd)
@@ -356,7 +356,7 @@ func addCloneFlags(cmd *cobra.Command) {
 	cmd.Flags().String("network", "", "CNI conflist name (empty = inherit from source VM)")
 	cmd.Flags().String("bridge", "", "use TAP-on-bridge instead of CNI (value is bridge device, e.g. cni0)")
 	cmd.Flags().Bool("no-direct-io", false, "disable O_DIRECT on writable disks (inherit from snapshot if not set)")
-	cmd.Flags().Bool("on-demand", false, "use UFFD on-demand memory loading for faster clone (CH only; snapshot file must remain on disk)")
+	cmd.Flags().String("restore-mode", "", "memory restore mode: copy|ondemand|mmap (CH only; ondemand/mmap require the snapshot file to remain on disk)")
 	cmd.Flags().Bool("pull", false, "auto-pull base image if not found locally (for cross-node clone)")
 	cmd.Flags().StringArray("data-disk", nil, "create and hot-add an extra data disk to the clone: size=20G[,name=...][,fstype=ext4|none]; repeatable (CH only)")
 	cmd.Flags().String("from-dir", "", "clone from a snapshot directory (must contain snapshot.json) instead of the local snapshot DB; mutually exclusive with positional SNAPSHOT")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -105,7 +105,7 @@ Applies to `cocoon vm clone`:
 | `--network` | empty (inherit)          | CNI conflist name (empty = inherit from source VM)       |
 | `--bridge`  | empty                    | TAP-on-bridge mode (value is bridge device); mutually exclusive with `--network` |
 | `--no-direct-io` | `false` (inherit)  | Disable O_DIRECT on writable disks (inherit from snapshot if not set) |
-| `--on-demand` | `false`             | Use UFFD on-demand memory loading for faster clone (CH only; snapshot file must remain on disk) |
+| `--restore-mode` | `copy`           | Memory restore mode: `copy`, `ondemand` (UFFD) or `mmap` (CoW map, shares page cache across clones); CH only, non-copy modes require the snapshot file to remain on disk |
 | `--pull`  | `false`              | Auto-pull base image if not found locally (for cross-node clone)      |
 | `--from-dir` | empty                | Clone from a snapshot directory (must contain `snapshot.json`); mutually exclusive with positional `SNAPSHOT` |
 | `--data-disk` | empty (repeatable)  | Create a fresh data disk for the clone and hot-add it after restore: `size=20G[,name=...][,fstype=ext4|none]` (CH only; names must not collide with disks inherited from the snapshot) |
@@ -134,7 +134,7 @@ Applies to `cocoon vm restore`:
 
 | Flag          | Default | Description                                                                                            |
 | ------------- | ------- | ------------------------------------------------------------------------------------------------------ |
-| `--on-demand` | `false` | Use UFFD on-demand memory loading for faster restore (CH only; snapshot file must remain on disk)      |
+| `--restore-mode` | `copy` | Memory restore mode: `copy`, `ondemand` (UFFD) or `mmap` (CoW map); CH only, non-copy modes require the snapshot file to remain on disk |
 | `--from-dir`  | empty   | Restore from a snapshot directory (must contain `snapshot.json`); mutually exclusive with positional `SNAPSHOT` |
 | `--force`     | `false` | Skip the snapshot-belongs-to-VM check (only meaningful with `--from-dir`)                              |
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -105,7 +105,7 @@ Applies to `cocoon vm clone`:
 | `--network` | empty (inherit)          | CNI conflist name (empty = inherit from source VM)       |
 | `--bridge`  | empty                    | TAP-on-bridge mode (value is bridge device); mutually exclusive with `--network` |
 | `--no-direct-io` | `false` (inherit)  | Disable O_DIRECT on writable disks (inherit from snapshot if not set) |
-| `--restore-mode` | `copy`           | Memory restore mode: `copy`, `ondemand` (UFFD) or `mmap` (CoW map, shares page cache across clones); CH only, non-copy modes require the snapshot file to remain on disk |
+| `--restore-mode` | `copy`           | Memory restore mode: `copy`, `ondemand` (UFFD) or `mmap` (CoW map, shares page cache across clones); CH only, non-copy modes require the snapshot file to remain on disk and a CH build with matching support — an older CH silently ignores the field and restores by copy |
 | `--pull`  | `false`              | Auto-pull base image if not found locally (for cross-node clone)      |
 | `--from-dir` | empty                | Clone from a snapshot directory (must contain `snapshot.json`); mutually exclusive with positional `SNAPSHOT` |
 | `--data-disk` | empty (repeatable)  | Create a fresh data disk for the clone and hot-add it after restore: `size=20G[,name=...][,fstype=ext4|none]` (CH only; names must not collide with disks inherited from the snapshot) |
@@ -134,7 +134,7 @@ Applies to `cocoon vm restore`:
 
 | Flag          | Default | Description                                                                                            |
 | ------------- | ------- | ------------------------------------------------------------------------------------------------------ |
-| `--restore-mode` | `copy` | Memory restore mode: `copy`, `ondemand` (UFFD) or `mmap` (CoW map); CH only, non-copy modes require the snapshot file to remain on disk |
+| `--restore-mode` | `copy` | Memory restore mode: `copy`, `ondemand` (UFFD) or `mmap` (CoW map); CH only, non-copy modes require the snapshot file to remain on disk and a CH build with matching support — an older CH silently ignores the field and restores by copy |
 | `--from-dir`  | empty   | Restore from a snapshot directory (must contain `snapshot.json`); mutually exclusive with positional `SNAPSHOT` |
 | `--force`     | `false` | Skip the snapshot-belongs-to-VM check (only meaningful with `--from-dir`)                              |
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,7 +6,7 @@ Requirements, install paths, the doctor script, and a first VM.
 
 - Linux with KVM (x86_64 or aarch64)
 - Root access (sudo)
-- [Cloud Hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor) v51.0+ (for Windows VMs, use our [CH fork](https://github.com/cocoonstack/cloud-hypervisor/tree/dev) and [firmware fork](https://github.com/cocoonstack/rust-hypervisor-firmware/tree/dev) for full compatibility — see [known issues](known-issues.md))
+- [Cloud Hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor) v51.0+ (for Windows VMs and `--restore-mode mmap`, use our [CH fork](https://github.com/cocoonstack/cloud-hypervisor/tree/dev) and [firmware fork](https://github.com/cocoonstack/rust-hypervisor-firmware/tree/dev) for full compatibility — see [known issues](known-issues.md))
 - [Firecracker](https://github.com/firecracker-microvm/firecracker) v1.16+ (optional, for `--fc` backend; `vm clone` requires >= v1.16 for the vsock override)
 - `qemu-img` (from qemu-utils, for cloud images)
 - `mkfs.erofs` from erofs-utils **>= 1.8** (for OCI images; 1.7.x tar mode

--- a/hypervisor/cloudhypervisor/clone.go
+++ b/hypervisor/cloudhypervisor/clone.go
@@ -156,7 +156,7 @@ func (ch *CloudHypervisor) restoreAndResumeClone(
 
 	hc := utils.NewSocketHTTPClient(sockPath)
 
-	if err = restoreVM(ctx, hc, runDir, opts.vmCfg.OnDemand); err != nil {
+	if err = restoreVM(ctx, hc, runDir, opts.vmCfg.RestoreMode); err != nil {
 		return fmt.Errorf("vm.restore: %w", err)
 	}
 

--- a/hypervisor/cloudhypervisor/restore.go
+++ b/hypervisor/cloudhypervisor/restore.go
@@ -99,7 +99,7 @@ func (ch *CloudHypervisor) restoreAfterExtract(ctx context.Context, vmID string,
 
 	hc := utils.NewSocketHTTPClient(sockPath)
 
-	if err = restoreVM(ctx, hc, rec.RunDir, vmCfg.OnDemand); err != nil {
+	if err = restoreVM(ctx, hc, rec.RunDir, vmCfg.RestoreMode); err != nil {
 		return nil, fmt.Errorf("vm.restore: %w", err)
 	}
 	if err = resumeVM(ctx, hc); err != nil {

--- a/hypervisor/cloudhypervisor/utils.go
+++ b/hypervisor/cloudhypervisor/utils.go
@@ -31,6 +31,8 @@ const (
 
 	// chMemoryRestoreOnDemand lazily pages in guest memory via userfaultfd instead of a full upfront copy.
 	chMemoryRestoreOnDemand chMemoryRestoreMode = "OnDemand"
+	// chMemoryRestoreMmap maps the snapshot file copy-on-write, sharing page cache across clones of one snapshot.
+	chMemoryRestoreMmap chMemoryRestoreMode = "Mmap"
 )
 
 var runtimeFiles = []string{hypervisor.APISocketName, pidFileName, hypervisor.ConsoleSockName, cmdlineFileName, hypervisor.VsockSockName}
@@ -163,14 +165,17 @@ func snapshotVM(ctx context.Context, hc *http.Client, destDir string) error {
 	return err
 }
 
-func restoreVM(ctx context.Context, hc *http.Client, sourceDir string, onDemand bool) error {
+func restoreVM(ctx context.Context, hc *http.Client, sourceDir, restoreMode string) error {
 	hc.Timeout = hypervisor.VMMemTransferTimeout
 	defer func() { hc.Timeout = utils.HTTPTimeout }()
 	cfg := chRestoreConfig{
 		SourceURL: "file://" + sourceDir,
 	}
-	if onDemand {
+	switch restoreMode {
+	case "ondemand":
 		cfg.MemoryRestoreMode = chMemoryRestoreOnDemand
+	case "mmap":
+		cfg.MemoryRestoreMode = chMemoryRestoreMmap
 	}
 	body, err := json.Marshal(cfg)
 	if err != nil {

--- a/types/vm.go
+++ b/types/vm.go
@@ -30,10 +30,10 @@ type VMConfig struct {
 	Config
 	Name string `json:"name"`
 
-	OnDemand  bool           `json:"-"` // use UFFD on-demand memory restore (CH only); transient, not persisted
-	User      string         `json:"-"`
-	Password  string         `json:"-"`
-	DataDisks []DataDiskSpec `json:"-"` // populated from --data-disk; consumed by Create
+	RestoreMode string         `json:"-"` // memory restore mode: copy|ondemand|mmap (CH only); transient, not persisted
+	User        string         `json:"-"`
+	Password    string         `json:"-"`
+	DataDisks   []DataDiskSpec `json:"-"` // populated from --data-disk; consumed by Create
 }
 
 // Validate checks that VMConfig fields are within acceptable ranges.


### PR DESCRIPTION
## What

Replaces the bool `--on-demand` flag on `vm clone` / `vm restore` with `--restore-mode copy|ondemand|mmap`, passed straight through to Cloud Hypervisor's `memory_restore_mode` restore field. `--on-demand` is removed rather than aliased: it mapped to the same single CH enum field, and a second spelling buys nothing.

- Empty/`copy` omits the field (wire behavior identical to before — old CH binaries unaffected).
- `ondemand` → `OnDemand` (UFFD lazy restore, unchanged semantics).
- `mmap` → `Mmap` (new CH mode, cocoonstack/cloud-hypervisor#1): CoW-maps the snapshot memory file so clones of one snapshot share page cache. Measured on 16 cores: 16-way clone burst per-clone p50 450ms → 79ms vs copy.
- Invalid values fail at flag parse; FC ignores the field exactly as it ignored `--on-demand` (flag help says CH only).
- `types.VMConfig.OnDemand bool` → `RestoreMode string`, still transient (`json:"-"`), never persisted.

## Evidence

- `make lint` dual-platform 0 issues; `go test -race ./...` 28 pkgs ok; new table test for the flag validation.
- On-hardware e2e (bare metal, CH build with mmap support): `--restore-mode mmap` clone boots + exec ✓, default copy ✓, `--restore-mode ondemand` clone via UFFD ✓, invalid value rejected at parse ✓, `--on-demand` now unknown flag ✓, `vm restore --restore-mode mmap` after stop ✓.

Note: `mmap`/`ondemand` require the snapshot file to remain on disk for the VM lifetime; `mmap` additionally requires it unchanged (documented in the CH PR).
