### PR TITLE
feat(os-image): mask redroid device identity + fix flaky arm64 apt

### DIFF
--- a/os-image/ubuntu/22.04-redroid-16.0-gms-h264/Dockerfile
+++ b/os-image/ubuntu/22.04-redroid-16.0-gms-h264/Dockerfile
@@ -31,13 +31,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=secret,id=cocoon_install_agent \
     --mount=type=secret,id=daemon_json \
     APT_OPTS='-o Acquire::Retries=10 -o Acquire::http::Timeout=120' && \
-    # GitHub runners are on Azure; ports.ubuntu.com (arm64) is slow/flaky under
-    # QEMU emulation. Fetch from the Azure mirror, which is local to the runner.
-    sed -i -e 's|http://ports.ubuntu.com/ubuntu-ports|http://azure.ports.ubuntu.com/ubuntu-ports|g' \
-           -e 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
-           -e 's|http://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
-           /etc/apt/sources.list && \
-    apt-get $APT_OPTS update && apt-get $APT_OPTS install -y --no-install-recommends \
+    # The emulated arm64 apt (ports.ubuntu.com under QEMU) intermittently times
+    # out refreshing indices; retry the update a few times before giving up.
+    aptup() { for i in 1 2 3 4 5 6; do apt-get $APT_OPTS update && return 0; echo "apt update retry $i" >&2; sleep 20; done; return 1; } && \
+    aptup && apt-get $APT_OPTS install -y --no-install-recommends \
     linux-image-virtual \
     initramfs-tools \
     systemd systemd-sysv systemd-timesyncd \
@@ -53,7 +50,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
     echo "deb [arch=${ARCH} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu jammy ${DOCKER_CHANNEL}" \
         > /etc/apt/sources.list.d/docker.list && \
-    apt-get $APT_OPTS update && apt-get $APT_OPTS install -y --no-install-recommends \
+    aptup && apt-get $APT_OPTS install -y --no-install-recommends \
         docker-ce docker-ce-cli containerd.io && \
     mkdir -p /etc/docker && \
     cp /run/secrets/daemon_json /etc/docker/daemon.json && \
@@ -109,7 +106,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 #     Tight/JPEG/ZRLE/Hextile/Raw framebuffer on the same port. There is no X
 #     server or framebuffer scraping hop. ---
 RUN APT_OPTS='-o Acquire::Retries=10 -o Acquire::http::Timeout=120' && \
-    apt-get $APT_OPTS update && apt-get $APT_OPTS install -y --no-install-recommends \
+    aptup() { for i in 1 2 3 4 5 6; do apt-get $APT_OPTS update && return 0; echo "apt update retry $i" >&2; sleep 20; done; return 1; } && \
+    aptup && apt-get $APT_OPTS install -y --no-install-recommends \
     adb libjpeg-turbo8 zlib1g && \
     case "$TARGETARCH" in amd64|arm64) ;; *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; esac && \
     install -d /usr/local/share/scrcpy /tmp/scrcpy-rfb && \

--- a/os-image/ubuntu/22.04-redroid-16.0-gms-h264/Dockerfile
+++ b/os-image/ubuntu/22.04-redroid-16.0-gms-h264/Dockerfile
@@ -33,10 +33,11 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     APT_OPTS='-o Acquire::Retries=10 -o Acquire::http::Timeout=120' && \
     # The emulated arm64 apt hits ports.ubuntu.com, which times out intermittently
     # from CI: apt-get update then only warns and exits 0, leaving an empty index
-    # so the install fails "Unable to locate package". Point arm64 at a CDN mirror
-    # and retry update+install as ONE unit, so a failed install re-runs update
-    # instead of hammering a stale/empty package list.
-    if [ "$TARGETARCH" = arm64 ]; then sed -i 's|http://ports.ubuntu.com/ubuntu-ports|http://mirrors.edge.kernel.org/ubuntu-ports|g' /etc/apt/sources.list; fi && \
+    # so the install fails "Unable to locate package". Add a reliable MIT mirror as
+    # a redundant source (apt fetches indexes from both, so either responding is
+    # enough) and retry update+install as ONE unit, so a failed install re-runs
+    # update instead of hammering a stale/empty package list.
+    if [ "$TARGETARCH" = arm64 ]; then sed 's|http://ports.ubuntu.com/ubuntu-ports|http://mirrors.mit.edu/ubuntu-ports|g' /etc/apt/sources.list > /etc/apt/sources.list.d/mit-ports.list; fi && \
     apt_ensure() { for i in 1 2 3 4 5 6 7 8; do apt-get $APT_OPTS update && apt-get $APT_OPTS install -y --no-install-recommends "$@" && return 0; echo "apt retry $i for: $*" >&2; sleep 15; done; return 1; } && \
     apt_ensure \
     linux-image-virtual \
@@ -110,7 +111,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 #     Tight/JPEG/ZRLE/Hextile/Raw framebuffer on the same port. There is no X
 #     server or framebuffer scraping hop. ---
 RUN APT_OPTS='-o Acquire::Retries=10 -o Acquire::http::Timeout=120' && \
-    if [ "$TARGETARCH" = arm64 ]; then sed -i 's|http://ports.ubuntu.com/ubuntu-ports|http://mirrors.edge.kernel.org/ubuntu-ports|g' /etc/apt/sources.list; fi && \
+    if [ "$TARGETARCH" = arm64 ]; then sed 's|http://ports.ubuntu.com/ubuntu-ports|http://mirrors.mit.edu/ubuntu-ports|g' /etc/apt/sources.list > /etc/apt/sources.list.d/mit-ports.list; fi && \
     apt_ensure() { for i in 1 2 3 4 5 6 7 8; do apt-get $APT_OPTS update && apt-get $APT_OPTS install -y --no-install-recommends "$@" && return 0; echo "apt retry $i for: $*" >&2; sleep 15; done; return 1; } && \
     apt_ensure \
     adb libjpeg-turbo8 zlib1g && \

--- a/os-image/ubuntu/22.04-redroid-16.0-gms-h264/Dockerfile
+++ b/os-image/ubuntu/22.04-redroid-16.0-gms-h264/Dockerfile
@@ -32,16 +32,16 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=secret,id=daemon_json \
     APT_OPTS='-o Acquire::Retries=10 -o Acquire::http::Timeout=120' && \
     # The emulated arm64 apt (ports.ubuntu.com under QEMU) intermittently times
-    # out refreshing indices; retry the update a few times before giving up.
-    aptup() { for i in 1 2 3 4 5 6; do apt-get $APT_OPTS update && return 0; echo "apt update retry $i" >&2; sleep 20; done; return 1; } && \
-    aptup && apt-get $APT_OPTS install -y --no-install-recommends \
+    # out; retry every apt operation a few times before giving up.
+    aptget() { for i in 1 2 3 4 5 6; do apt-get $APT_OPTS "$@" && return 0; echo "apt retry $i: $*" >&2; sleep 20; done; return 1; } && \
+    aptget update && aptget install -y --no-install-recommends \
     linux-image-virtual \
     initramfs-tools \
     systemd systemd-sysv systemd-timesyncd \
     udev kmod iproute2 iputils-ping curl wget ca-certificates gnupg \
     openssh-server \
     && \
-    apt-get $APT_OPTS install -y --no-install-recommends \
+    aptget install -y --no-install-recommends \
         linux-modules-extra-"$(ls /lib/modules/ | sort -V | tail -1)" && \
     # --- Docker engine (latest stable) from Docker's official apt repo ---
     install -m 0755 -d /etc/apt/keyrings && \
@@ -50,7 +50,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
     echo "deb [arch=${ARCH} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu jammy ${DOCKER_CHANNEL}" \
         > /etc/apt/sources.list.d/docker.list && \
-    aptup && apt-get $APT_OPTS install -y --no-install-recommends \
+    aptget update && aptget install -y --no-install-recommends \
         docker-ce docker-ce-cli containerd.io && \
     mkdir -p /etc/docker && \
     cp /run/secrets/daemon_json /etc/docker/daemon.json && \
@@ -106,8 +106,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 #     Tight/JPEG/ZRLE/Hextile/Raw framebuffer on the same port. There is no X
 #     server or framebuffer scraping hop. ---
 RUN APT_OPTS='-o Acquire::Retries=10 -o Acquire::http::Timeout=120' && \
-    aptup() { for i in 1 2 3 4 5 6; do apt-get $APT_OPTS update && return 0; echo "apt update retry $i" >&2; sleep 20; done; return 1; } && \
-    aptup && apt-get $APT_OPTS install -y --no-install-recommends \
+    aptget() { for i in 1 2 3 4 5 6; do apt-get $APT_OPTS "$@" && return 0; echo "apt retry $i: $*" >&2; sleep 20; done; return 1; } && \
+    aptget update && aptget install -y --no-install-recommends \
     adb libjpeg-turbo8 zlib1g && \
     case "$TARGETARCH" in amd64|arm64) ;; *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; esac && \
     install -d /usr/local/share/scrcpy /tmp/scrcpy-rfb && \

--- a/os-image/ubuntu/22.04-redroid-16.0-gms-h264/Dockerfile
+++ b/os-image/ubuntu/22.04-redroid-16.0-gms-h264/Dockerfile
@@ -31,17 +31,21 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=secret,id=cocoon_install_agent \
     --mount=type=secret,id=daemon_json \
     APT_OPTS='-o Acquire::Retries=10 -o Acquire::http::Timeout=120' && \
-    # The emulated arm64 apt (ports.ubuntu.com under QEMU) intermittently times
-    # out; retry every apt operation a few times before giving up.
-    aptget() { for i in 1 2 3 4 5 6; do apt-get $APT_OPTS "$@" && return 0; echo "apt retry $i: $*" >&2; sleep 20; done; return 1; } && \
-    aptget update && aptget install -y --no-install-recommends \
+    # The emulated arm64 apt hits ports.ubuntu.com, which times out intermittently
+    # from CI: apt-get update then only warns and exits 0, leaving an empty index
+    # so the install fails "Unable to locate package". Point arm64 at a CDN mirror
+    # and retry update+install as ONE unit, so a failed install re-runs update
+    # instead of hammering a stale/empty package list.
+    if [ "$TARGETARCH" = arm64 ]; then sed -i 's|http://ports.ubuntu.com/ubuntu-ports|http://mirrors.edge.kernel.org/ubuntu-ports|g' /etc/apt/sources.list; fi && \
+    apt_ensure() { for i in 1 2 3 4 5 6 7 8; do apt-get $APT_OPTS update && apt-get $APT_OPTS install -y --no-install-recommends "$@" && return 0; echo "apt retry $i for: $*" >&2; sleep 15; done; return 1; } && \
+    apt_ensure \
     linux-image-virtual \
     initramfs-tools \
     systemd systemd-sysv systemd-timesyncd \
     udev kmod iproute2 iputils-ping curl wget ca-certificates gnupg \
     openssh-server \
     && \
-    aptget install -y --no-install-recommends \
+    apt_ensure \
         linux-modules-extra-"$(ls /lib/modules/ | sort -V | tail -1)" && \
     # --- Docker engine (latest stable) from Docker's official apt repo ---
     install -m 0755 -d /etc/apt/keyrings && \
@@ -50,7 +54,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
     echo "deb [arch=${ARCH} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu jammy ${DOCKER_CHANNEL}" \
         > /etc/apt/sources.list.d/docker.list && \
-    aptget update && aptget install -y --no-install-recommends \
+    apt_ensure \
         docker-ce docker-ce-cli containerd.io && \
     mkdir -p /etc/docker && \
     cp /run/secrets/daemon_json /etc/docker/daemon.json && \
@@ -106,8 +110,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 #     Tight/JPEG/ZRLE/Hextile/Raw framebuffer on the same port. There is no X
 #     server or framebuffer scraping hop. ---
 RUN APT_OPTS='-o Acquire::Retries=10 -o Acquire::http::Timeout=120' && \
-    aptget() { for i in 1 2 3 4 5 6; do apt-get $APT_OPTS "$@" && return 0; echo "apt retry $i: $*" >&2; sleep 20; done; return 1; } && \
-    aptget update && aptget install -y --no-install-recommends \
+    if [ "$TARGETARCH" = arm64 ]; then sed -i 's|http://ports.ubuntu.com/ubuntu-ports|http://mirrors.edge.kernel.org/ubuntu-ports|g' /etc/apt/sources.list; fi && \
+    apt_ensure() { for i in 1 2 3 4 5 6 7 8; do apt-get $APT_OPTS update && apt-get $APT_OPTS install -y --no-install-recommends "$@" && return 0; echo "apt retry $i for: $*" >&2; sleep 15; done; return 1; } && \
+    apt_ensure \
     adb libjpeg-turbo8 zlib1g && \
     case "$TARGETARCH" in amd64|arm64) ;; *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; esac && \
     install -d /usr/local/share/scrcpy /tmp/scrcpy-rfb && \

--- a/os-image/ubuntu/22.04-redroid-16.0-gms-h264/Dockerfile
+++ b/os-image/ubuntu/22.04-redroid-16.0-gms-h264/Dockerfile
@@ -31,6 +31,12 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=secret,id=cocoon_install_agent \
     --mount=type=secret,id=daemon_json \
     APT_OPTS='-o Acquire::Retries=10 -o Acquire::http::Timeout=120' && \
+    # GitHub runners are on Azure; ports.ubuntu.com (arm64) is slow/flaky under
+    # QEMU emulation. Fetch from the Azure mirror, which is local to the runner.
+    sed -i -e 's|http://ports.ubuntu.com/ubuntu-ports|http://azure.ports.ubuntu.com/ubuntu-ports|g' \
+           -e 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
+           -e 's|http://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
+           /etc/apt/sources.list && \
     apt-get $APT_OPTS update && apt-get $APT_OPTS install -y --no-install-recommends \
     linux-image-virtual \
     initramfs-tools \
@@ -102,7 +108,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 #     50. Non-H.264 clients fall back to a lazily decoded
 #     Tight/JPEG/ZRLE/Hextile/Raw framebuffer on the same port. There is no X
 #     server or framebuffer scraping hop. ---
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN APT_OPTS='-o Acquire::Retries=10 -o Acquire::http::Timeout=120' && \
+    apt-get $APT_OPTS update && apt-get $APT_OPTS install -y --no-install-recommends \
     adb libjpeg-turbo8 zlib1g && \
     case "$TARGETARCH" in amd64|arm64) ;; *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; esac && \
     install -d /usr/local/share/scrcpy /tmp/scrcpy-rfb && \

--- a/os-image/ubuntu/22.04-redroid-16.0-gms-h264/README.md
+++ b/os-image/ubuntu/22.04-redroid-16.0-gms-h264/README.md
@@ -88,10 +88,13 @@ on every cold boot. This lets apps that only inspect identity properties run.
 
 It only touches cosmetic identity props and does **not** defeat deeper checks:
 
-- **The GPU/driver props stay visible.** `ro.hardware.egl` (`angle`),
+- **The virtual GPU stays visible.** `ro.hardware.egl` (`angle`),
   `ro.hardware.vulkan` (`pastel`), and `ro.board.platform` name the GL/Vulkan
   driver `.so`; renaming them to a non-existent driver aborts OpenGL
-  (`couldn't find an OpenGL ES implementation`), so they are left as-is.
+  (`couldn't find an OpenGL ES implementation`), so they are left as-is. The
+  renderer is unmaskable regardless: the stack is ANGLE on SwiftShader (software),
+  so `glGetString(GL_RENDERER)` reports `ANGLE … SwiftShader` — a louder emulator
+  tell than these props.
 - **The x86 runtime stays visible.** `ro.product.cpu.abi`/`abilist`,
   `ro.dalvik.vm.native.bridge`, `ro.bionic.arch`, and `dalvik.vm.isa.*` still
   report `x86_64` / `libndk`. These are deliberately left alone: they are

--- a/os-image/ubuntu/22.04-redroid-16.0-gms-h264/README.md
+++ b/os-image/ubuntu/22.04-redroid-16.0-gms-h264/README.md
@@ -73,7 +73,7 @@ still require a WebView provider.
 ## Device identity masking
 
 `mask-device.rc` runs `mask-device.sh` as root on boot, using Magisk's
-`resetprop` (bundled as `/system/bin/magisk_rp`) to rewrite the redroid/emulator
+`resetprop` (installed as `/system/bin/resetprop`) to rewrite the redroid/emulator
 giveaway properties — `ro.product.*`, `ro.build.fingerprint`, `ro.hardware`,
 `ro.product.cpu.abilist`, `ro.dalvik.vm.native.bridge`, build type/tags — to a
 real device (Pixel 8). `build.prop` cannot change these: `ro.hardware` comes from

--- a/os-image/ubuntu/22.04-redroid-16.0-gms-h264/README.md
+++ b/os-image/ubuntu/22.04-redroid-16.0-gms-h264/README.md
@@ -72,20 +72,28 @@ still require a WebView provider.
 
 ## Device identity masking
 
-`mask-device.rc` runs `mask-device.sh` as root on boot, using Magisk's
-`resetprop` (installed as `/system/bin/resetprop`) to rewrite the redroid/emulator
-giveaway properties — `ro.product.*`, `ro.build.fingerprint`, `ro.hardware`,
-`ro.product.cpu.abilist`, `ro.dalvik.vm.native.bridge`, build type/tags — to a
-real device (Pixel 8). `build.prop` cannot change these: `ro.hardware` comes from
-`androidboot`, the plain `ro.product.*` are set with precedence, and abilist /
-native.bridge are runtime. This lets apps that only inspect properties run.
+`mask-device.rc` runs `mask-device.sh` as root on `boot_completed`, using
+Magisk's `resetprop` (installed as `/system/bin/resetprop`) to rewrite the
+redroid giveaway properties to a real device (Pixel 8 / Tensor "zuma"). redroid
+stamps its identity on every partition, so the mask covers each scope
+(system/vendor/product/odm/system_ext/vendor_dlkm), not just the global props:
+`ro.product.*` identity, `ro.*.build.fingerprint`, `build.id`/`type`/`tags`/
+`flavor`/`description`, `ro.*.product.cpu.abi`/`abilist`, `ro.hardware*`,
+`ro.bootloader`, `ro.board.platform`, `ro.build.user`/`host`, verified-boot
+state; and it deletes the redroid-internal `ro.boot.redroid_*` hints. `build.prop`
+cannot carry these: `ro.hardware` comes from `androidboot`, the plain
+`ro.product.*` are set with precedence, and abilist / native.bridge are runtime.
+The mask re-applies on every cold boot. This lets apps that only inspect
+properties run.
 
-It does **not** defeat deeper checks: redroid runs with SELinux disabled (real
+It does **not** defeat deeper checks. redroid runs with SELinux disabled (real
 devices are enforcing) and cannot pass Play Integrity hardware attestation (no
-TEE, uncertified GMS). Apps enforcing those — e.g. Meituan — still detect the
-container regardless of masking; they need real ARM hardware. On x86, ARM apps
-also run under `libndk` translation, which some native anti-tamper SDKs detect
-directly (e.g. Damai crashes in `libndk`); a native arm64 build avoids that.
+TEE, uncertified GMS). On x86 the runtime itself stays visible — `ro.bionic.arch`
+and `dalvik.vm.isa.*` still report `x86_64`, and ARM apps run under `libndk`
+translation, which some native anti-tamper SDKs detect directly (e.g. Damai
+crashes in `libndk`; a native arm64 build avoids that). Apps enforcing any of
+these — e.g. Meituan — still detect the container regardless of masking and need
+real ARM hardware.
 
 ## VNC clients
 

--- a/os-image/ubuntu/22.04-redroid-16.0-gms-h264/README.md
+++ b/os-image/ubuntu/22.04-redroid-16.0-gms-h264/README.md
@@ -74,26 +74,35 @@ still require a WebView provider.
 
 `mask-device.rc` runs `mask-device.sh` as root on `boot_completed`, using
 Magisk's `resetprop` (installed as `/system/bin/resetprop`) to rewrite the
-redroid giveaway properties to a real device (Pixel 8 / Tensor "zuma"). redroid
-stamps its identity on every partition, so the mask covers each scope
+redroid **identity** properties to a real device (Pixel 8 / Tensor "zuma").
+redroid stamps its identity on every partition, so the mask covers each scope
 (system/vendor/product/odm/system_ext/vendor_dlkm), not just the global props:
-`ro.product.*` identity, `ro.*.build.fingerprint`, `build.id`/`type`/`tags`/
-`flavor`/`description`, `ro.*.product.cpu.abi`/`abilist`, `ro.hardware*`,
-`ro.bootloader`, `ro.board.platform`, `ro.build.user`/`host`, verified-boot
-state; and it deletes the redroid-internal `ro.boot.redroid_*` hints. `build.prop`
-cannot carry these: `ro.hardware` comes from `androidboot`, the plain
-`ro.product.*` are set with precedence, and abilist / native.bridge are runtime.
-The mask re-applies on every cold boot. This lets apps that only inspect
-properties run.
+`ro.product.*` (model/brand/manufacturer/device/name), `ro.*.build.fingerprint`,
+`build.id`/`type`/`tags`/`version.incremental`, global `build.flavor`/
+`description`/`display.id`/`product`, `ro.hardware`/`.egl`/`.vulkan`,
+`ro.bootloader`, `ro.board.platform`/`ro.product.board`, `ro.build.user`/`host`,
+verified-boot state; and it deletes the redroid-internal `ro.boot.redroid_*`
+hints. `build.prop` cannot carry these (`ro.hardware` comes from `androidboot`,
+the plain `ro.product.*` are precedence-set). The mask re-applies on every cold
+boot. This lets apps that only inspect identity properties run.
 
-It does **not** defeat deeper checks. redroid runs with SELinux disabled (real
-devices are enforcing) and cannot pass Play Integrity hardware attestation (no
-TEE, uncertified GMS). On x86 the runtime itself stays visible — `ro.bionic.arch`
-and `dalvik.vm.isa.*` still report `x86_64`, and ARM apps run under `libndk`
-translation, which some native anti-tamper SDKs detect directly (e.g. Damai
-crashes in `libndk`; a native arm64 build avoids that). Apps enforcing any of
-these — e.g. Meituan — still detect the container regardless of masking and need
-real ARM hardware.
+It only touches cosmetic identity props and does **not** defeat deeper checks:
+
+- **The x86 runtime stays visible.** `ro.product.cpu.abi`/`abilist`,
+  `ro.dalvik.vm.native.bridge`, `ro.bionic.arch`, and `dalvik.vm.isa.*` still
+  report `x86_64` / `libndk`. These are deliberately left alone: they are
+  consumed by the runtime, so faking them would break libndk ARM translation if
+  zygote restarts, and they only add cross-check inconsistencies (bionic/ISA
+  would still say x86). ARM apps run under `libndk`, which some native anti-tamper
+  SDKs detect directly (e.g. Damai crashes in `libndk`; a native arm64 build
+  avoids that).
+- **`ro.debuggable=1` stays.** A real user build reports `0`, but setting `0`
+  tears down the scrcpy/remoteview adb tunnel, so it is left enabled.
+- **SELinux is disabled** (real devices are enforcing) and the container cannot
+  pass **Play Integrity** hardware attestation (no TEE, uncertified GMS).
+
+Apps enforcing any of these — e.g. Meituan — still detect the container
+regardless of masking and need real ARM hardware.
 
 ## VNC clients
 

--- a/os-image/ubuntu/22.04-redroid-16.0-gms-h264/README.md
+++ b/os-image/ubuntu/22.04-redroid-16.0-gms-h264/README.md
@@ -68,7 +68,24 @@ SystemUI navigation bar and recents — disabling it removes the on-screen butto
 
 The Camera2 application and Chromium WebView test shell (`Browser2`) are removed
 physically. Android System WebView is retained because Chrome and other apps
-still require a WebView provider. Meituan and Damai are not included.
+still require a WebView provider.
+
+## Device identity masking
+
+`mask-device.rc` runs `mask-device.sh` as root on boot, using Magisk's
+`resetprop` (bundled as `/system/bin/magisk_rp`) to rewrite the redroid/emulator
+giveaway properties — `ro.product.*`, `ro.build.fingerprint`, `ro.hardware`,
+`ro.product.cpu.abilist`, `ro.dalvik.vm.native.bridge`, build type/tags — to a
+real device (Pixel 8). `build.prop` cannot change these: `ro.hardware` comes from
+`androidboot`, the plain `ro.product.*` are set with precedence, and abilist /
+native.bridge are runtime. This lets apps that only inspect properties run.
+
+It does **not** defeat deeper checks: redroid runs with SELinux disabled (real
+devices are enforcing) and cannot pass Play Integrity hardware attestation (no
+TEE, uncertified GMS). Apps enforcing those — e.g. Meituan — still detect the
+container regardless of masking; they need real ARM hardware. On x86, ARM apps
+also run under `libndk` translation, which some native anti-tamper SDKs detect
+directly (e.g. Damai crashes in `libndk`); a native arm64 build avoids that.
 
 ## VNC clients
 

--- a/os-image/ubuntu/22.04-redroid-16.0-gms-h264/README.md
+++ b/os-image/ubuntu/22.04-redroid-16.0-gms-h264/README.md
@@ -79,15 +79,19 @@ redroid stamps its identity on every partition, so the mask covers each scope
 (system/vendor/product/odm/system_ext/vendor_dlkm), not just the global props:
 `ro.product.*` (model/brand/manufacturer/device/name), `ro.*.build.fingerprint`,
 `build.id`/`type`/`tags`/`version.incremental`, global `build.flavor`/
-`description`/`display.id`/`product`, `ro.hardware`/`.egl`/`.vulkan`,
-`ro.bootloader`, `ro.board.platform`/`ro.product.board`, `ro.build.user`/`host`,
-verified-boot state; and it deletes the redroid-internal `ro.boot.redroid_*`
-hints. `build.prop` cannot carry these (`ro.hardware` comes from `androidboot`,
-the plain `ro.product.*` are precedence-set). The mask re-applies on every cold
-boot. This lets apps that only inspect identity properties run.
+`description`/`display.id`/`product`, `ro.hardware`, `ro.bootloader`,
+`ro.product.board`, `ro.build.user`/`host`, verified-boot state; and it deletes
+the redroid-internal `ro.boot.redroid_*` hints and the `ro.hardware.gralloc`
+redroid tag. `build.prop` cannot carry these (`ro.hardware` comes from
+`androidboot`, the plain `ro.product.*` are precedence-set). The mask re-applies
+on every cold boot. This lets apps that only inspect identity properties run.
 
 It only touches cosmetic identity props and does **not** defeat deeper checks:
 
+- **The GPU/driver props stay visible.** `ro.hardware.egl` (`angle`),
+  `ro.hardware.vulkan` (`pastel`), and `ro.board.platform` name the GL/Vulkan
+  driver `.so`; renaming them to a non-existent driver aborts OpenGL
+  (`couldn't find an OpenGL ES implementation`), so they are left as-is.
 - **The x86 runtime stays visible.** `ro.product.cpu.abi`/`abilist`,
   `ro.dalvik.vm.native.bridge`, `ro.bionic.arch`, and `dalvik.vm.isa.*` still
   report `x86_64` / `libndk`. These are deliberately left alone: they are

--- a/os-image/ubuntu/22.04-redroid-16.0-gms-h264/mask-device.rc
+++ b/os-image/ubuntu/22.04-redroid-16.0-gms-h264/mask-device.rc
@@ -1,0 +1,10 @@
+service mask_device /system/bin/sh /system/etc/mask-device.sh
+    class late_start
+    user root
+    group root
+    oneshot
+    disabled
+    seclabel u:r:su:s0
+
+on property:sys.boot_completed=1
+    start mask_device

--- a/os-image/ubuntu/22.04-redroid-16.0-gms-h264/mask-device.sh
+++ b/os-image/ubuntu/22.04-redroid-16.0-gms-h264/mask-device.sh
@@ -9,28 +9,50 @@
 # Play-Integrity hardware attestation — apps enforcing those still detect the
 # container. It only clears the property-level tells.
 RP="/system/bin/resetprop -n"
+DEL="/system/bin/resetprop --delete"
 FP="google/shiba/shiba:16/AP41.240925.009/12345678:user/release-keys"
 
-for suf in "" .system .vendor .product .odm .system_ext; do
+# redroid stamps identity and build descriptors on EVERY partition
+# (system/vendor/product/odm/system_ext/vendor_dlkm), so a naive getprop scan of
+# any one partition must not reveal redroid/userdebug/test-keys.
+for suf in "" .system .vendor .product .odm .system_ext .vendor_dlkm; do
     $RP "ro.product${suf}.model" "Pixel 8"
     $RP "ro.product${suf}.brand" google
     $RP "ro.product${suf}.manufacturer" Google
     $RP "ro.product${suf}.device" shiba
     $RP "ro.product${suf}.name" shiba
+    $RP "ro${suf}.build.fingerprint" "$FP"
+    $RP "ro${suf}.build.type" user
+    $RP "ro${suf}.build.tags" release-keys
+    $RP "ro${suf}.build.id" AP41.240925.009
+    $RP "ro${suf}.product.cpu.abilist" arm64-v8a
+    $RP "ro${suf}.product.cpu.abilist64" arm64-v8a
 done
-for k in ro.build.fingerprint ro.system.build.fingerprint ro.vendor.build.fingerprint \
-         ro.product.build.fingerprint ro.bootimage.build.fingerprint; do
-    $RP "$k" "$FP"
-done
-$RP ro.build.type user
-$RP ro.build.tags release-keys
+$RP ro.bootimage.build.fingerprint "$FP"
 $RP ro.build.flavor shiba-user
+$RP ro.build.description "shiba-user 16 AP41.240925.009 12345678 release-keys"
+$RP ro.build.display.id AP41.240925.009
+$RP ro.build.version.incremental 12345678
+$RP ro.build.product shiba
 $RP ro.hardware shiba
 $RP ro.boot.hardware shiba
 $RP ro.hardware.egl mali
 $RP ro.dalvik.vm.native.bridge 0
-$RP ro.product.cpu.abilist arm64-v8a
-$RP ro.product.cpu.abilist64 arm64-v8a
+$RP ro.product.cpu.abi arm64-v8a
+$RP ro.product.board zuma
+$RP ro.board.platform zuma
+$RP ro.bootloader shiba-1.4-11893630
+$RP ro.build.user android-build
+$RP ro.build.host abfarm-release.google.com
 $RP ro.boot.verifiedbootstate green
 $RP ro.boot.flash.locked 1
 $RP ro.boot.veritymode enforcing
+
+# Drop the redroid-internal boot hints (their names literally contain "redroid")
+# and the redroid gralloc tag; they are consumed at boot and cosmetic afterwards.
+for p in ro.boot.redroid_dpi ro.boot.redroid_fps ro.boot.redroid_gpu_mode \
+         ro.boot.redroid_height ro.boot.redroid_width ro.boot.redroid_net_dns1 \
+         ro.boot.redroid_net_dns2 ro.boot.redroid_net_ndns ro.boot.use_redroid_c2 \
+         ro.hardware.gralloc; do
+    $DEL "$p"
+done

--- a/os-image/ubuntu/22.04-redroid-16.0-gms-h264/mask-device.sh
+++ b/os-image/ubuntu/22.04-redroid-16.0-gms-h264/mask-device.sh
@@ -8,8 +8,9 @@
 # Only cosmetic identity props are touched. Props that select a driver .so or that
 # the runtime consumes are left alone on purpose: ro.hardware.egl/.vulkan and
 # ro.board.platform name the GL/Vulkan driver (renaming them aborts OpenGL with
-# "couldn't find an OpenGL ES implementation"); rewriting ro.product.cpu.abilist /
-# ro.dalvik.vm.native.bridge would break libndk ARM translation if zygote restarts;
+# "couldn't find an OpenGL ES implementation"); rewriting ro.product.cpu.abi /
+# abilist / ro.dalvik.vm.native.bridge would break libndk translation if zygote
+# restarts;
 # and ro.debuggable=0 tears down the scrcpy/remoteview adb tunnel. Those, plus
 # ro.bionic.arch and dalvik.vm.isa.* (x86_64), stay visible — the x86 runtime and
 # virtual GPU are not maskable and, like SELinux-disabled and no-TEE Play

--- a/os-image/ubuntu/22.04-redroid-16.0-gms-h264/mask-device.sh
+++ b/os-image/ubuntu/22.04-redroid-16.0-gms-h264/mask-device.sh
@@ -5,12 +5,15 @@
 # cannot change these (ro.hardware comes from androidboot, the plain ro.product.*
 # are set with precedence).
 #
-# Only cosmetic identity props are touched. Runtime-consumed props are left as-is
-# on purpose: rewriting ro.product.cpu.abilist / ro.dalvik.vm.native.bridge would
-# break libndk ARM translation if zygote restarts, and ro.debuggable=0 tears down
-# the scrcpy/remoteview adb tunnel. Those, plus ro.bionic.arch and dalvik.vm.isa.*
-# (which report x86_64), remain visible — the x86 runtime is not maskable and,
-# like SELinux-disabled and no-TEE Play Integrity, still gives the container away.
+# Only cosmetic identity props are touched. Props that select a driver .so or that
+# the runtime consumes are left alone on purpose: ro.hardware.egl/.vulkan and
+# ro.board.platform name the GL/Vulkan driver (renaming them aborts OpenGL with
+# "couldn't find an OpenGL ES implementation"); rewriting ro.product.cpu.abilist /
+# ro.dalvik.vm.native.bridge would break libndk ARM translation if zygote restarts;
+# and ro.debuggable=0 tears down the scrcpy/remoteview adb tunnel. Those, plus
+# ro.bionic.arch and dalvik.vm.isa.* (x86_64), stay visible — the x86 runtime and
+# virtual GPU are not maskable and, like SELinux-disabled and no-TEE Play
+# Integrity, still give the container away.
 RP="/system/bin/resetprop -n"
 DEL="/system/bin/resetprop --delete"
 FP="google/shiba/shiba:16/AP41.240925.009/12345678:user/release-keys"
@@ -37,10 +40,7 @@ $RP ro.build.display.id AP41.240925.009
 $RP ro.build.product shiba
 $RP ro.hardware shiba
 $RP ro.boot.hardware shiba
-$RP ro.hardware.egl mali
-$RP ro.hardware.vulkan mali
 $RP ro.product.board zuma
-$RP ro.board.platform zuma
 $RP ro.bootloader shiba-1.4-11893630
 $RP ro.build.user android-build
 $RP ro.build.host abfarm-release.google.com

--- a/os-image/ubuntu/22.04-redroid-16.0-gms-h264/mask-device.sh
+++ b/os-image/ubuntu/22.04-redroid-16.0-gms-h264/mask-device.sh
@@ -8,8 +8,7 @@
 # This does NOT defeat SELinux-state (redroid runs SELinux disabled) or
 # Play-Integrity hardware attestation — apps enforcing those still detect the
 # container. It only clears the property-level tells.
-MG=/system/bin/magisk_rp
-RP="$MG resetprop -n"
+RP="/system/bin/resetprop -n"
 FP="google/shiba/shiba:16/AP41.240925.009/12345678:user/release-keys"
 
 for suf in "" .system .vendor .product .odm .system_ext; do

--- a/os-image/ubuntu/22.04-redroid-16.0-gms-h264/mask-device.sh
+++ b/os-image/ubuntu/22.04-redroid-16.0-gms-h264/mask-device.sh
@@ -1,0 +1,37 @@
+#!/system/bin/sh
+# Rewrite the redroid/emulator giveaway properties to a real device (Pixel 8) via
+# Magisk's resetprop, so anti-emulator apps that only inspect properties do not
+# bail on launch. Runs as root from mask-device.rc on boot_completed; build.prop
+# cannot change these (ro.hardware comes from androidboot, the plain ro.product.*
+# are set with precedence, native.bridge/abilist are runtime).
+#
+# This does NOT defeat SELinux-state (redroid runs SELinux disabled) or
+# Play-Integrity hardware attestation — apps enforcing those still detect the
+# container. It only clears the property-level tells.
+MG=/system/bin/magisk_rp
+RP="$MG resetprop -n"
+FP="google/shiba/shiba:16/AP41.240925.009/12345678:user/release-keys"
+
+for suf in "" .system .vendor .product .odm .system_ext; do
+    $RP "ro.product${suf}.model" "Pixel 8"
+    $RP "ro.product${suf}.brand" google
+    $RP "ro.product${suf}.manufacturer" Google
+    $RP "ro.product${suf}.device" shiba
+    $RP "ro.product${suf}.name" shiba
+done
+for k in ro.build.fingerprint ro.system.build.fingerprint ro.vendor.build.fingerprint \
+         ro.product.build.fingerprint ro.bootimage.build.fingerprint; do
+    $RP "$k" "$FP"
+done
+$RP ro.build.type user
+$RP ro.build.tags release-keys
+$RP ro.build.flavor shiba-user
+$RP ro.hardware shiba
+$RP ro.boot.hardware shiba
+$RP ro.hardware.egl mali
+$RP ro.dalvik.vm.native.bridge 0
+$RP ro.product.cpu.abilist arm64-v8a
+$RP ro.product.cpu.abilist64 arm64-v8a
+$RP ro.boot.verifiedbootstate green
+$RP ro.boot.flash.locked 1
+$RP ro.boot.veritymode enforcing

--- a/os-image/ubuntu/22.04-redroid-16.0-gms-h264/mask-device.sh
+++ b/os-image/ubuntu/22.04-redroid-16.0-gms-h264/mask-device.sh
@@ -1,20 +1,23 @@
 #!/system/bin/sh
-# Rewrite the redroid/emulator giveaway properties to a real device (Pixel 8) via
+# Rewrite the redroid/emulator IDENTITY properties to a real device (Pixel 8) via
 # Magisk's resetprop, so anti-emulator apps that only inspect properties do not
 # bail on launch. Runs as root from mask-device.rc on boot_completed; build.prop
 # cannot change these (ro.hardware comes from androidboot, the plain ro.product.*
-# are set with precedence, native.bridge/abilist are runtime).
+# are set with precedence).
 #
-# This does NOT defeat SELinux-state (redroid runs SELinux disabled) or
-# Play-Integrity hardware attestation — apps enforcing those still detect the
-# container. It only clears the property-level tells.
+# Only cosmetic identity props are touched. Runtime-consumed props are left as-is
+# on purpose: rewriting ro.product.cpu.abilist / ro.dalvik.vm.native.bridge would
+# break libndk ARM translation if zygote restarts, and ro.debuggable=0 tears down
+# the scrcpy/remoteview adb tunnel. Those, plus ro.bionic.arch and dalvik.vm.isa.*
+# (which report x86_64), remain visible — the x86 runtime is not maskable and,
+# like SELinux-disabled and no-TEE Play Integrity, still gives the container away.
 RP="/system/bin/resetprop -n"
 DEL="/system/bin/resetprop --delete"
 FP="google/shiba/shiba:16/AP41.240925.009/12345678:user/release-keys"
 
 # redroid stamps identity and build descriptors on EVERY partition
 # (system/vendor/product/odm/system_ext/vendor_dlkm), so a naive getprop scan of
-# any one partition must not reveal redroid/userdebug/test-keys.
+# any one partition must not reveal redroid/userdebug/test-keys/eng.root.
 for suf in "" .system .vendor .product .odm .system_ext .vendor_dlkm; do
     $RP "ro.product${suf}.model" "Pixel 8"
     $RP "ro.product${suf}.brand" google
@@ -25,20 +28,17 @@ for suf in "" .system .vendor .product .odm .system_ext .vendor_dlkm; do
     $RP "ro${suf}.build.type" user
     $RP "ro${suf}.build.tags" release-keys
     $RP "ro${suf}.build.id" AP41.240925.009
-    $RP "ro${suf}.product.cpu.abilist" arm64-v8a
-    $RP "ro${suf}.product.cpu.abilist64" arm64-v8a
+    $RP "ro${suf}.build.version.incremental" 12345678
 done
 $RP ro.bootimage.build.fingerprint "$FP"
 $RP ro.build.flavor shiba-user
 $RP ro.build.description "shiba-user 16 AP41.240925.009 12345678 release-keys"
 $RP ro.build.display.id AP41.240925.009
-$RP ro.build.version.incremental 12345678
 $RP ro.build.product shiba
 $RP ro.hardware shiba
 $RP ro.boot.hardware shiba
 $RP ro.hardware.egl mali
-$RP ro.dalvik.vm.native.bridge 0
-$RP ro.product.cpu.abi arm64-v8a
+$RP ro.hardware.vulkan mali
 $RP ro.product.board zuma
 $RP ro.board.platform zuma
 $RP ro.bootloader shiba-1.4-11893630

--- a/os-image/ubuntu/22.04-redroid-16.0-gms-h264/redroid-gms16.Dockerfile
+++ b/os-image/ubuntu/22.04-redroid-16.0-gms-h264/redroid-gms16.Dockerfile
@@ -46,15 +46,17 @@ RUN mkdir -p /output/system/app/FossifyLauncher && \
     curl -fsSL "$FOSSIFY_URL" -o /output/system/app/FossifyLauncher/FossifyLauncher.apk && \
     echo "${FOSSIFY_SHA256}  /output/system/app/FossifyLauncher/FossifyLauncher.apk" | sha256sum -c -
 
-# Magisk's resetprop (bundled as /system/bin/magisk_rp) is run as root at boot by
-# mask-device.rc to rewrite the redroid/emulator giveaway props to a real device.
+# Magisk's resetprop applet (installed as /system/bin/resetprop) is run as root at
+# boot by mask-device.rc to rewrite the redroid/emulator giveaway props to a real
+# device. The multi-call libmagisk.so dispatches its applet by argv[0], so the
+# binary must be named resetprop (not magisk_rp, which is "applet not found").
 RUN abi="$([ "$TARGETARCH" = arm64 ] && echo arm64-v8a || echo x86_64)" && \
     curl -fsSL "$MAGISK_URL" -o /tmp/magisk.apk && \
     echo "${MAGISK_SHA256}  /tmp/magisk.apk" | sha256sum -c - && \
     mkdir -p /output/system/bin /tmp/mgk && \
     unzip -o -j /tmp/magisk.apk "lib/$abi/libmagisk.so" -d /tmp/mgk && \
-    install -m 0755 /tmp/mgk/libmagisk.so /output/system/bin/magisk_rp && \
-    test -x /output/system/bin/magisk_rp && \
+    install -m 0755 /tmp/mgk/libmagisk.so /output/system/bin/resetprop && \
+    test -x /output/system/bin/resetprop && \
     rm -rf /tmp/magisk.apk /tmp/mgk
 
 COPY --from=redroid_base /system/build.prop /tmp/system-build.prop
@@ -111,7 +113,7 @@ RUN rm -rf \
     test -f /redroid/system/product/app/TrichromeLibrary/TrichromeLibrary.apk && \
     grep -Fq 'pm install -r -d --force-sdk "$GMS_APK"' \
       /redroid/system/etc/fossify-home.sh && \
-    test -x /redroid/system/bin/magisk_rp && \
+    test -x /redroid/system/bin/resetprop && \
     test -f /redroid/system/etc/init/mask-device.rc && \
     grep -Fq 'resetprop -n' /redroid/system/etc/mask-device.sh && \
     test -x /redroid/cocoon-bake-init && \

--- a/os-image/ubuntu/22.04-redroid-16.0-gms-h264/redroid-gms16.Dockerfile
+++ b/os-image/ubuntu/22.04-redroid-16.0-gms-h264/redroid-gms16.Dockerfile
@@ -20,6 +20,8 @@ ARG NDK_TRANSLATION_COMMIT=68734c52556d3d7a6db34c603dd9276915c29f2f
 ARG NDK_TRANSLATION_MD5=0b2207c490fcb400aa5c87fcf0d52d38
 ARG FOSSIFY_URL=https://github.com/FossifyOrg/Launcher/releases/download/1.10.0/launcher-16-foss-release.apk
 ARG FOSSIFY_SHA256=a603d3d510482feafd73d52a93a1ea9baefd2ca0aae329a14cbf0e21f43638e3
+ARG MAGISK_URL=https://github.com/topjohnwu/Magisk/releases/download/v28.1/Magisk-v28.1.apk
+ARG MAGISK_SHA256=8bfd3346b3da5814f82eff6f1b1b5fedd0ad585f39a25709b23eb54aac45691d
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl unzip && \
@@ -44,6 +46,17 @@ RUN mkdir -p /output/system/app/FossifyLauncher && \
     curl -fsSL "$FOSSIFY_URL" -o /output/system/app/FossifyLauncher/FossifyLauncher.apk && \
     echo "${FOSSIFY_SHA256}  /output/system/app/FossifyLauncher/FossifyLauncher.apk" | sha256sum -c -
 
+# Magisk's resetprop (bundled as /system/bin/magisk_rp) is run as root at boot by
+# mask-device.rc to rewrite the redroid/emulator giveaway props to a real device.
+RUN abi="$([ "$TARGETARCH" = arm64 ] && echo arm64-v8a || echo x86_64)" && \
+    curl -fsSL "$MAGISK_URL" -o /tmp/magisk.apk && \
+    echo "${MAGISK_SHA256}  /tmp/magisk.apk" | sha256sum -c - && \
+    mkdir -p /output/system/bin /tmp/mgk && \
+    unzip -o -j /tmp/magisk.apk "lib/$abi/libmagisk.so" -d /tmp/mgk && \
+    install -m 0755 /tmp/mgk/libmagisk.so /output/system/bin/magisk_rp && \
+    test -x /output/system/bin/magisk_rp && \
+    rm -rf /tmp/magisk.apk /tmp/mgk
+
 COPY --from=redroid_base /system/build.prop /tmp/system-build.prop
 COPY --from=redroid_base /vendor/build.prop /tmp/vendor-build.prop
 # amd64: point the Dalvik native bridge at libndk_translation so ARM apps run
@@ -66,6 +79,8 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
 
 COPY fossify-home.rc /output/system/etc/init/fossify-home.rc
 COPY fossify-home.sh /output/system/etc/fossify-home.sh
+COPY mask-device.rc /output/system/etc/init/mask-device.rc
+COPY mask-device.sh /output/system/etc/mask-device.sh
 COPY cocoon-bake-init.sh /output/cocoon-bake-init
 COPY cocoon-bake-once /output/.cocoon-bake-once
 COPY --from=bake_tools /bin/busybox /output/busybox
@@ -96,6 +111,9 @@ RUN rm -rf \
     test -f /redroid/system/product/app/TrichromeLibrary/TrichromeLibrary.apk && \
     grep -Fq 'pm install -r -d --force-sdk "$GMS_APK"' \
       /redroid/system/etc/fossify-home.sh && \
+    test -x /redroid/system/bin/magisk_rp && \
+    test -f /redroid/system/etc/init/mask-device.rc && \
+    grep -Fq 'resetprop -n' /redroid/system/etc/mask-device.sh && \
     test -x /redroid/cocoon-bake-init && \
     test -x /redroid/busybox && \
     test -f /redroid/.cocoon-bake-once


### PR DESCRIPTION
## Summary

Adds best-effort device-identity masking to the ReDroid 16 GMS image so
anti-emulator apps that only inspect system properties no longer bail on launch,
and fixes the recurring flaky emulated-arm64 apt failure that was blocking the
shared os-image build.

### Device identity masking

- Bundles Magisk's `resetprop` applet as `/system/bin/resetprop` (extracted from
  the pinned Magisk v28.1 APK, per-arch `libmagisk.so`, sha256-checked). The
  binary must be named `resetprop`: `libmagisk.so` is a multi-call binary that
  selects its applet from `argv[0]`.
- `mask-device.rc` starts `mask-device.sh` as root on `sys.boot_completed=1`.
  redroid stamps its identity on **every partition**, so the script rewrites each
  scope (system/vendor/product/odm/system_ext/vendor_dlkm): `ro.product.*`
  identity, `ro.*.build.fingerprint`/`id`/`type`/`tags`/`version.incremental`,
  plus global `build.flavor`/`description`/`display.id`/`product`, `ro.hardware`,
  `ro.bootloader`, `ro.product.board`, `ro.build.user`/`host`, verified-boot
  state — to a Pixel 8 (Tensor "zuma"). It deletes the redroid-internal
  `ro.boot.redroid_*` hints and the `ro.hardware.gralloc` redroid tag. Re-applied
  on every cold boot.

**Honest scope — only cosmetic identity props are touched.** Props that select a
driver `.so` or that the runtime consumes are left as-is on purpose, and still
give the container away to a non-naive detector:

- **GPU driver selectors** (`ro.hardware.egl`=angle, `ro.hardware.vulkan`=pastel,
  `ro.board.platform`): renaming them to a device with no matching
  `libEGL_<name>.so` aborts OpenGL (`couldn't find an OpenGL ES implementation`),
  so they are left real.
- **x86 runtime** (`ro.product.cpu.abi`/`abilist`, `ro.dalvik.vm.native.bridge`,
  `ro.bionic.arch`, `dalvik.vm.isa.*` → `x86_64`/`libndk`): faking them would
  break libndk ARM translation on a zygote restart and only adds cross-check
  inconsistencies. ARM apps run under `libndk`, which some native anti-tamper SDKs
  detect directly (Damai crashes inside `libndk`; a native arm64 build avoids it).
- **`ro.debuggable=1`**: a real user build reports `0`, but `0` tears down the
  scrcpy/remoteview adb tunnel.
- **SELinux disabled** and no **Play Integrity** hardware attestation (no TEE).

Apps enforcing any of these — e.g. Meituan — still detect the container and need
real ARM hardware. Full detail in the README's "Device identity masking" section.

### CI: fix flaky emulated arm64 apt

The shared build bakes the arm64 arch under QEMU, whose apt reaches
`ports.ubuntu.com`. That host times out intermittently from CI, but
`apt-get update` still exits 0 with only warnings, leaving an empty package
index — the subsequent `apt-get install` then fails hard with
`Unable to locate package`. Fix: add `mirrors.mit.edu` as a **redundant**
ubuntu-ports source (either responding populates the index) and retry
`update`+`install` as a single unit. (`mirrors.edge.kernel.org` does not mirror
ubuntu-ports.)

## Validation (amd64, testbed, build `5268d28` → `android:16.0-gms-h264-5268d28`)

Both arches build green in the shared workflow. Runtime, on a fresh `cocoon vm run`:

| Check | Result |
|---|---|
| ADB `5555` / RFB `5900` reachable from cold start | 7s / 25s |
| Mask applied after `boot_completed` | model=`Pixel 8` within ~2s |
| `getprop` identity tell-scan | no redroid / eng.root / BP2A / userdebug / test-keys on any partition |
| Masked props | brand=google, device=shiba, fingerprint=`google/shiba/shiba:16/AP41.240925.009/12345678:user/release-keys`, type=user, tags=release-keys, hardware=shiba, bootloader=shiba-1.4-…, verifiedbootstate=green, flash.locked=1 |
| Residuals left honest | `cpu.abilist=x86_64,arm64-v8a`, `native.bridge=libndk`, `bionic.arch=x86_64`, `egl=angle`, `debuggable=1` |
| OpenGL / rendering | **0** EGL aborts, **0** native SIGABRT; Chrome main pid stable 12s, renderers spawn |
| GMS Core Chimera staged to `/data/app` | yes (v25.08.34) |
| Default HOME / nav bar | Fossify HOME + Launcher3 enabled (SystemUI nav bar intact) |
| `vm stop && vm start` ×2 | ports reconnect ≤25s; mask re-applies within ~2s each cold boot |

## Not yet validated

- **arm64 runtime**: the arm64 image builds and passes `verify-vm-inner.sh` in
  CI, but has not been booted on real ARM hardware. Native-ARM app behaviour
  (e.g. Damai without libndk) is pending an arm64 host.
