### PR TITLE
fix(oci): decompress gzip arm64 kernel on import for CH direct-boot

### DIFF
--- a/images/oci/boot.go
+++ b/images/oci/boot.go
@@ -2,13 +2,16 @@ package oci
 
 import (
 	"archive/tar"
+	"bufio"
 	"cmp"
+	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -126,11 +129,30 @@ func scanBootFiles(ctx context.Context, r io.Reader, workDir, namePrefix string)
 		if createErr != nil {
 			return "", "", fmt.Errorf("create %s: %w", filepath.Base(dstPath), createErr)
 		}
-		if _, copyErr := io.Copy(f, tr); copyErr != nil { //nolint:gosec
-			_ = f.Close()
-			return "", "", fmt.Errorf("write %s: %w", filepath.Base(dstPath), copyErr)
+		// CH on arm64 direct-boots only a raw kernel Image, but Ubuntu ships the
+		// arm64 vmlinuz gzip-compressed; decompress it (x86 bzImage is not gzip).
+		src := io.Reader(tr)
+		var gz *gzip.Reader
+		if isKernel && runtime.GOARCH == "arm64" {
+			br := bufio.NewReader(tr)
+			src = br
+			if magic, _ := br.Peek(2); len(magic) == 2 && magic[0] == 0x1f && magic[1] == 0x8b {
+				var gzErr error
+				if gz, gzErr = gzip.NewReader(br); gzErr != nil {
+					_ = f.Close()
+					return "", "", fmt.Errorf("gunzip %s: %w", filepath.Base(dstPath), gzErr)
+				}
+				src = gz
+			}
+		}
+		_, copyErr := io.Copy(f, src) //nolint:gosec
+		if gz != nil {
+			_ = gz.Close()
 		}
 		_ = f.Close()
+		if copyErr != nil {
+			return "", "", fmt.Errorf("write %s: %w", filepath.Base(dstPath), copyErr)
+		}
 
 		if isKernel {
 			kernelPath = dstPath

--- a/images/oci/boot.go
+++ b/images/oci/boot.go
@@ -18,6 +18,9 @@ import (
 	"github.com/projecteru2/core/log"
 )
 
+// maxKernelBytes bounds arm64 gzip decompression against a bomb; real kernels are under 100 MiB.
+const maxKernelBytes = 512 << 20
+
 func healCachedBootFiles(ctx context.Context, conf *Config, layers []v1.Layer, results []pullLayerResult, workDir string) {
 	logger := log.WithFunc("oci.healCachedBootFiles")
 
@@ -142,16 +145,19 @@ func scanBootFiles(ctx context.Context, r io.Reader, workDir, namePrefix string)
 					_ = f.Close()
 					return "", "", fmt.Errorf("gunzip %s: %w", filepath.Base(dstPath), gzErr)
 				}
-				src = gz
+				src = io.LimitReader(gz, maxKernelBytes+1)
 			}
 		}
-		_, copyErr := io.Copy(f, src) //nolint:gosec
+		written, copyErr := io.Copy(f, src) //nolint:gosec
 		if gz != nil {
 			_ = gz.Close()
 		}
 		_ = f.Close()
 		if copyErr != nil {
 			return "", "", fmt.Errorf("write %s: %w", filepath.Base(dstPath), copyErr)
+		}
+		if gz != nil && written > maxKernelBytes {
+			return "", "", fmt.Errorf("decompressed kernel %s exceeds %d bytes", filepath.Base(dstPath), maxKernelBytes)
 		}
 
 		if isKernel {


### PR DESCRIPTION
## Problem

An OCI VM image fails to boot on **arm64** with:

```
Fatal error: VmBoot(UefiLoad(UefiTooBig))
  Cannot load the UEFI binary in memory
  UEFI image too big
```

Root cause: Cloud Hypervisor on arm64 can only direct-boot a **raw kernel Image**,
but Ubuntu ships the arm64 kernel as a **gzip-compressed** `vmlinuz`. `cocoon vm debug`
confirms cocoon passes `--kernel .../vmlinuz` (direct boot, correct), but CH arm64
cannot parse the gzip stream and falls back to treating it as a UEFI payload — which
overflows the firmware region. `images/oci/boot.go` extracted the kernel with a plain
`io.Copy`, never decompressing. amd64 is unaffected: x86 `bzImage` is self-extracting
and not gzip.

## Fix

Decompress the kernel when extracting boot files on arm64 — peek the gzip magic
(`1f 8b`) and stream through `gzip.Reader`; everything else (x86 bzImage, an
already-raw arm64 Image, initrd) is copied verbatim.

## Validation (real arm64 hardware — GCP C4A Axion bare metal, aarch64)

Env: cocoon `master`, CH `dev` (v54.0.0) built on the box, erofs-utils 1.8.

- **Before**: fresh `cocoon vm run` of an arm64 image → `UefiTooBig`, VM dies. Manually
  `zcat`-ing the cached kernel to a raw `Image` made it boot — confirming the cause.
- **After (this fix)**: cleared the OCI cache, fresh `cocoon image pull` → the extracted
  kernel is now `Linux kernel ARM64 boot executable Image` (decompressed automatically at
  import), and a fresh `cocoon vm run` reaches `boot_completed=1` in ~35s with `5555` up —
  **no manual intervention**.
- Downstream: the ReDroid 16 arm64 image boots, masks to Pixel 8, runs native arm64
  (`abi=arm64-v8a`, no libndk); Damai and Meituan install as native arm64 and render their
  UIs — apps that crash in `libndk` on x86 run cleanly here.
