### PR TITLE
fix: harden cocoon for sub-1500-MTU / high-vCPU cloud hosts (CH rlimits + CNI MTU/MSS)

### DIFF
--- a/doctor/check.sh
+++ b/doctor/check.sh
@@ -96,7 +96,14 @@ generate_cni_conflist() {
     local gateway
     gateway=$(echo "$network_part" | awk -F. '{printf "%s.%s.%s.1", $1, $2, $3}')
 
-    info "generating CNI conflist: subnet=${subnet} gateway=${gateway}"
+    # Match the host egress MTU (GCP is 1460, not 1500) so the bridge and TAPs do not
+    # blackhole large packets on the way out.
+    local host_iface host_mtu
+    host_iface=$(ip route show default 2>/dev/null | awk '/default/{print $5; exit}')
+    host_mtu=$(ip link show "$host_iface" 2>/dev/null | sed -n 's/.* mtu \([0-9]\{1,\}\).*/\1/p')
+    host_mtu=${host_mtu:-1500}
+
+    info "generating CNI conflist: subnet=${subnet} gateway=${gateway} mtu=${host_mtu}"
     mkdir -p "$COCOON_CNI_CONF_DIR"
     cat > "$CNI_CONFLIST" <<CNIEOF
 {
@@ -106,6 +113,7 @@ generate_cni_conflist() {
     {
       "type": "bridge",
       "bridge": "cni0",
+      "mtu": ${host_mtu},
       "isGateway": true,
       "ipMasq": true,
       "hairpinMode": true,
@@ -317,6 +325,19 @@ check_iptables_rule "FORWARD -i cni0 -j ACCEPT" \
     FORWARD -i cni0 -j ACCEPT
 check_iptables_rule "FORWARD -o cni0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT" \
     FORWARD -o cni0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+
+# Clamp TCP MSS to the path MTU: on a host whose egress MTU is below the bridge's
+# (e.g. GCP's 1460), guests otherwise blackhole large TLS/data packets that carry DF.
+mss_desc="mangle FORWARD TCPMSS clamp-mss-to-pmtu"
+if iptables -t mangle -C FORWARD -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu 2>/dev/null; then
+    pass "$mss_desc"
+else
+    fail "$mss_desc"
+    if $FIX; then
+        iptables -t mangle -A FORWARD -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu 2>/dev/null \
+            && fixed "$mss_desc" || warn "failed to add MSS clamp"
+    fi
+fi
 
 # ---------------------------------------------------------------------------
 # 7. CNI configuration

--- a/hypervisor/cloudhypervisor/start.go
+++ b/hypervisor/cloudhypervisor/start.go
@@ -7,7 +7,6 @@ import (
 	"syscall"
 
 	"github.com/projecteru2/core/log"
-	"golang.org/x/sys/unix"
 
 	"github.com/cocoonstack/cocoon/hypervisor"
 )
@@ -37,7 +36,6 @@ func (ch *CloudHypervisor) launchProcess(ctx context.Context, rec *hypervisor.VM
 		defer logFile.Close() //nolint:errcheck
 	}
 
-	raiseVMMRlimits(ctx)
 	// shell out: the cloud-hypervisor binary is the authoritative VMM.
 	cmd := exec.Command(ch.conf.CHBinary, args...) //nolint:gosec
 	// Setpgid so CH survives if this process exits.
@@ -60,19 +58,4 @@ func (ch *CloudHypervisor) launchProcess(ctx context.Context, rec *hypervisor.VM
 	// Daemon mode: parent must wait() or zombie blocks IsProcessAlive on stop/delete.
 	go cmd.Wait() //nolint:errcheck
 	return pid, nil
-}
-
-func raiseVMMRlimits(ctx context.Context) {
-	logger := log.WithFunc("cloudhypervisor.raiseVMMRlimits")
-	inf := unix.Rlimit{Cur: unix.RLIM_INFINITY, Max: unix.RLIM_INFINITY}
-	if err := unix.Setrlimit(unix.RLIMIT_MEMLOCK, &inf); err != nil {
-		logger.Warnf(ctx, "raise RLIMIT_MEMLOCK: %v", err)
-	}
-	var nofile unix.Rlimit
-	if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &nofile); err == nil && nofile.Cur < nofile.Max {
-		nofile.Cur = nofile.Max
-		if err := unix.Setrlimit(unix.RLIMIT_NOFILE, &nofile); err != nil {
-			logger.Warnf(ctx, "raise RLIMIT_NOFILE: %v", err)
-		}
-	}
 }

--- a/hypervisor/cloudhypervisor/start.go
+++ b/hypervisor/cloudhypervisor/start.go
@@ -62,10 +62,6 @@ func (ch *CloudHypervisor) launchProcess(ctx context.Context, rec *hypervisor.VM
 	return pid, nil
 }
 
-// raiseVMMRlimits lifts the limits the forked VMM inherits: CH allocates an io_uring
-// ring plus eventfds per virtio-blk queue, and num_queues scales with vCPU, so a
-// high-vCPU multi-disk guest otherwise exhausts the default RLIMIT_MEMLOCK/NOFILE and
-// fails to activate its disks.
 func raiseVMMRlimits(ctx context.Context) {
 	logger := log.WithFunc("cloudhypervisor.raiseVMMRlimits")
 	inf := unix.Rlimit{Cur: unix.RLIM_INFINITY, Max: unix.RLIM_INFINITY}

--- a/hypervisor/cloudhypervisor/start.go
+++ b/hypervisor/cloudhypervisor/start.go
@@ -7,6 +7,7 @@ import (
 	"syscall"
 
 	"github.com/projecteru2/core/log"
+	"golang.org/x/sys/unix"
 
 	"github.com/cocoonstack/cocoon/hypervisor"
 )
@@ -36,6 +37,7 @@ func (ch *CloudHypervisor) launchProcess(ctx context.Context, rec *hypervisor.VM
 		defer logFile.Close() //nolint:errcheck
 	}
 
+	raiseVMMRlimits(ctx)
 	// shell out: the cloud-hypervisor binary is the authoritative VMM.
 	cmd := exec.Command(ch.conf.CHBinary, args...) //nolint:gosec
 	// Setpgid so CH survives if this process exits.
@@ -58,4 +60,23 @@ func (ch *CloudHypervisor) launchProcess(ctx context.Context, rec *hypervisor.VM
 	// Daemon mode: parent must wait() or zombie blocks IsProcessAlive on stop/delete.
 	go cmd.Wait() //nolint:errcheck
 	return pid, nil
+}
+
+// raiseVMMRlimits lifts the limits the forked VMM inherits: CH allocates an io_uring
+// ring plus eventfds per virtio-blk queue, and num_queues scales with vCPU, so a
+// high-vCPU multi-disk guest otherwise exhausts the default RLIMIT_MEMLOCK/NOFILE and
+// fails to activate its disks.
+func raiseVMMRlimits(ctx context.Context) {
+	logger := log.WithFunc("cloudhypervisor.raiseVMMRlimits")
+	inf := unix.Rlimit{Cur: unix.RLIM_INFINITY, Max: unix.RLIM_INFINITY}
+	if err := unix.Setrlimit(unix.RLIMIT_MEMLOCK, &inf); err != nil {
+		logger.Warnf(ctx, "raise RLIMIT_MEMLOCK: %v", err)
+	}
+	var nofile unix.Rlimit
+	if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &nofile); err == nil && nofile.Cur < nofile.Max {
+		nofile.Cur = nofile.Max
+		if err := unix.Setrlimit(unix.RLIMIT_NOFILE, &nofile); err != nil {
+			logger.Warnf(ctx, "raise RLIMIT_NOFILE: %v", err)
+		}
+	}
 }

--- a/hypervisor/start.go
+++ b/hypervisor/start.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/projecteru2/core/log"
+	"golang.org/x/sys/unix"
 
 	"github.com/cocoonstack/cocoon/types"
 	"github.com/cocoonstack/cocoon/utils"
@@ -137,6 +138,7 @@ func (b *Backend) LaunchVMProcess(ctx context.Context, spec LaunchSpec) (pid int
 		defer restore()
 	}
 
+	raiseVMMRlimits(ctx)
 	if err = spec.Cmd.Start(); err != nil {
 		return 0, fmt.Errorf("exec %s: %w", binaryName, err)
 	}
@@ -158,4 +160,19 @@ func (b *Backend) LaunchVMProcess(ctx context.Context, spec LaunchSpec) (pid int
 func (b *Backend) AbortLaunch(ctx context.Context, pid int, sockPath, runDir string, runtimeFiles []string) {
 	_ = utils.TerminateProcess(ctx, pid, b.Conf.BinaryName(), sockPath, b.Conf.TerminateGracePeriod())
 	CleanupRuntimeFiles(ctx, runDir, runtimeFiles)
+}
+
+func raiseVMMRlimits(ctx context.Context) {
+	logger := log.WithFunc("hypervisor.raiseVMMRlimits")
+	inf := unix.Rlimit{Cur: unix.RLIM_INFINITY, Max: unix.RLIM_INFINITY}
+	if err := unix.Setrlimit(unix.RLIMIT_MEMLOCK, &inf); err != nil {
+		logger.Warnf(ctx, "raise RLIMIT_MEMLOCK: %v", err)
+	}
+	var nofile unix.Rlimit
+	if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &nofile); err == nil && nofile.Cur < nofile.Max {
+		nofile.Cur = nofile.Max
+		if err := unix.Setrlimit(unix.RLIMIT_NOFILE, &nofile); err != nil {
+			logger.Warnf(ctx, "raise RLIMIT_NOFILE: %v", err)
+		}
+	}
 }


### PR DESCRIPTION
Two independent robustness fixes surfaced while validating cocoon on a GCP C4A
(arm64) host, each verified on that hardware.

## 1. Raise RLIMIT_MEMLOCK / RLIMIT_NOFILE before launching the VMM (`hypervisor/cloudhypervisor/start.go`)

Cloud Hypervisor allocates an io_uring ring plus eventfds per virtio-blk queue, and
`num_queues` scales with vCPU. A high-vCPU multi-disk guest — e.g. an 8-vCPU, 10-disk
Android VM = 80 queues — exhausts the process defaults (`RLIMIT_MEMLOCK` ~93 MiB,
`RLIMIT_NOFILE` soft 1024) and fails:

```
virtio device activation failed: CloneEventFd(... "Too many open files")
thread 'vmm' panicked ... -> CH aborts
```

(preceded by `failed to create new AsyncIo: I/O error` once memlock is exhausted).
`raiseVMMRlimits` lifts both before the fork; the VMM inherits them.

**Verified (arm64 testbed):** without the fix an 8-vCPU VM needs a manual
`ulimit -l unlimited; ulimit -n 1048576` wrapper to boot; with it, a plain
`cocoon vm run --cpu 8 --memory 8G` boots in ~29 s with **0** io_uring/disk errors.

## 2. Match CNI bridge MTU to the host + clamp forward MSS (`doctor/check.sh`)

On a host whose egress MTU is below the CNI bridge default 1500 (GCP is **1460**),
guests silently blackhole large DF packets: small requests and ping work, but reaching
a CDN with a big TLS cert chain times out (the VM sends 1500-byte segments that the
1460-MTU host egress drops, and the ICMP frag-needed never makes it back). Fix:

- set the bridge `mtu` in the generated conflist to the detected host egress MTU, and
- add a `mangle FORWARD -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu`
  rule so existing hosts are fixed immediately, without a bridge rebuild.

**Verified (arm64 testbed):** before, `curl https://p0.meituan.net` from a guest times
out after 8 s (0 bytes); after the clamp it returns in ~0.2 s. The conflist regenerates
with `"mtu": 1460` on a GCP host.
