### PR TITLE
feat(os-image): render FLAG_SECURE app windows in ReDroid remote view

### DIFF
--- a/os-image/ubuntu/22.04-redroid-16.0-gms-h264/Dockerfile
+++ b/os-image/ubuntu/22.04-redroid-16.0-gms-h264/Dockerfile
@@ -22,7 +22,6 @@ ARG DOCKER_CHANNEL=stable
 ARG SCRCPY_RFB_REPO=cocoonstack/scrcpy-rfb
 ARG SCRCPY_RFB_TAG=master
 ARG SCRCPY_RFB_COMMIT
-ARG SCRCPY_SERVER_SHA256=deacb991ed2509715160ffdc7907e47b4160eb30d1566217e9047fd5b8850cae
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -117,10 +116,6 @@ RUN APT_OPTS='-o Acquire::Retries=10 -o Acquire::http::Timeout=120' && \
     adb libjpeg-turbo8 zlib1g && \
     case "$TARGETARCH" in amd64|arm64) ;; *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; esac && \
     install -d /usr/local/share/scrcpy /tmp/scrcpy-rfb && \
-    curl -fsSL \
-      https://github.com/Genymobile/scrcpy/releases/download/v4.1/scrcpy-server-v4.1 \
-      -o /usr/local/share/scrcpy/scrcpy-server.jar && \
-    echo "$SCRCPY_SERVER_SHA256  /usr/local/share/scrcpy/scrcpy-server.jar" | sha256sum -c - && \
     BASE="https://github.com/$SCRCPY_RFB_REPO/releases/download/$SCRCPY_RFB_TAG" && \
     ARTIFACT="scrcpy-rfb-linux-$TARGETARCH" && \
     curl -fsSL "$BASE/build-info.json" -o /tmp/scrcpy-rfb/build-info.json && \
@@ -128,10 +123,15 @@ RUN APT_OPTS='-o Acquire::Retries=10 -o Acquire::http::Timeout=120' && \
       SCRCPY_RFB_COMMIT="$(sed -n 's/.*"commit": "\([0-9a-f]\{40\}\)".*/\1/p' /tmp/scrcpy-rfb/build-info.json)"; \
     fi && \
     printf '%s' "$SCRCPY_RFB_COMMIT" | grep -Eq '^[0-9a-f]{40}$' && \
-    curl -fsSL "$BASE/$ARTIFACT?commit=$SCRCPY_RFB_COMMIT" -o "/tmp/scrcpy-rfb/$ARTIFACT" && \
-    curl -fsSL "$BASE/$ARTIFACT.sha256?commit=$SCRCPY_RFB_COMMIT" -o "/tmp/scrcpy-rfb/$ARTIFACT.sha256" && \
-    cd /tmp/scrcpy-rfb && sha256sum -c "$ARTIFACT.sha256" && \
+    cd /tmp/scrcpy-rfb && \
+    for f in "$ARTIFACT" scrcpy-server-secure.jar "su1000-linux-$TARGETARCH"; do \
+      curl -fsSL "$BASE/$f?commit=$SCRCPY_RFB_COMMIT" -o "$f" && \
+      curl -fsSL "$BASE/$f.sha256?commit=$SCRCPY_RFB_COMMIT" -o "$f.sha256" && \
+      sha256sum -c "$f.sha256"; \
+    done && \
     install -m 0755 "$ARTIFACT" /usr/local/bin/scrcpy-rfb && \
+    install -m 0644 scrcpy-server-secure.jar /usr/local/share/scrcpy/scrcpy-server.jar && \
+    install -m 0755 "su1000-linux-$TARGETARCH" /usr/local/share/scrcpy/su1000 && \
     cd / && rm -rf /tmp/scrcpy-rfb && \
     apt-get purge -y --auto-remove curl wget gnupg && \
     apt-get clean && \

--- a/os-image/ubuntu/22.04-redroid-16.0-gms-h264/remoteview-run.sh
+++ b/os-image/ubuntu/22.04-redroid-16.0-gms-h264/remoteview-run.sh
@@ -42,22 +42,30 @@ done
 # scrcpy needs the system uid (1000) to create a FLAG_SECURE mirror display, so
 # FLAG_SECURE app windows (bank/login/pay) render instead of going black; su1000
 # drops root->1000, which needs adbd running as root (also lets cleanup kill the
-# uid-1000 server on restart).
+# uid-1000 server on restart). If root is unavailable, fall back to a plain run:
+# the view still works, only FLAG_SECURE windows stay black.
+rooted=false
 adb -s "$REDROID" root >/dev/null 2>&1 || true
 for _ in $(seq 1 30); do
     adb connect "$REDROID" >/dev/null 2>&1 || true
-    [ "$(adb -s "$REDROID" shell id -u 2>/dev/null | tr -d '\r\n ')" = "0" ] && break
+    [ "$(adb -s "$REDROID" shell id -u 2>/dev/null | tr -d '\r\n ')" = "0" ] && { rooted=true; break; }
     sleep 1
 done
 
 cleanup
 adb -s "$REDROID" push "$SCRCPY_SERVER" /data/local/tmp/scrcpy-server.jar >/dev/null
-adb -s "$REDROID" push "$SU1000" /data/local/tmp/su1000 >/dev/null
-adb -s "$REDROID" shell chmod 0755 /data/local/tmp/su1000
+launch=(app_process)
+if [ "$rooted" = true ]; then
+    adb -s "$REDROID" push "$SU1000" /data/local/tmp/su1000 >/dev/null
+    adb -s "$REDROID" shell chmod 0755 /data/local/tmp/su1000
+    launch=(/data/local/tmp/su1000 app_process)
+else
+    echo "adb root unavailable; FLAG_SECURE windows will render black" >&2
+fi
 adb -s "$REDROID" forward "tcp:$SCRCPY_PORT" "localabstract:scrcpy_$SCRCPY_SCID"
 adb -s "$REDROID" shell \
     CLASSPATH=/data/local/tmp/scrcpy-server.jar \
-    /data/local/tmp/su1000 app_process / com.genymobile.scrcpy.Server 4.1 \
+    "${launch[@]}" / com.genymobile.scrcpy.Server 4.1 \
     "scid=$SCRCPY_SCID" log_level=info tunnel_forward=true \
     audio=false send_device_meta=false send_dummy_byte=false \
     video_codec=h264 "video_bit_rate=$VIDEO_BIT_RATE" "max_fps=$MAX_FPS" \

--- a/os-image/ubuntu/22.04-redroid-16.0-gms-h264/remoteview-run.sh
+++ b/os-image/ubuntu/22.04-redroid-16.0-gms-h264/remoteview-run.sh
@@ -9,6 +9,7 @@ REDROID="${REDROID_ADB:-127.0.0.1:5555}"
 VNC_PW="${VNC_PASSWORD:-redroid}"
 RFB_PORT="${RFB_PORT:-5900}"
 SCRCPY_SERVER="${SCRCPY_SERVER:-/usr/local/share/scrcpy/scrcpy-server.jar}"
+SU1000="${SU1000:-/usr/local/share/scrcpy/su1000}"
 SCRCPY_PORT=27183
 SCRCPY_SCID="${SCRCPY_SCID:-4a264fb0}"
 VIDEO_BIT_RATE="${VIDEO_BIT_RATE:-8000000}"
@@ -38,12 +39,25 @@ for _ in $(seq 1 120); do
 done
 [ "$boot_completed" = true ] || { echo "Android boot timed out" >&2; exit 1; }
 
+# scrcpy needs the system uid (1000) to create a FLAG_SECURE mirror display, so
+# FLAG_SECURE app windows (bank/login/pay) render instead of going black; su1000
+# drops root->1000, which needs adbd running as root (also lets cleanup kill the
+# uid-1000 server on restart).
+adb -s "$REDROID" root >/dev/null 2>&1 || true
+for _ in $(seq 1 30); do
+    adb connect "$REDROID" >/dev/null 2>&1 || true
+    [ "$(adb -s "$REDROID" shell id -u 2>/dev/null | tr -d '\r\n ')" = "0" ] && break
+    sleep 1
+done
+
 cleanup
 adb -s "$REDROID" push "$SCRCPY_SERVER" /data/local/tmp/scrcpy-server.jar >/dev/null
+adb -s "$REDROID" push "$SU1000" /data/local/tmp/su1000 >/dev/null
+adb -s "$REDROID" shell chmod 0755 /data/local/tmp/su1000
 adb -s "$REDROID" forward "tcp:$SCRCPY_PORT" "localabstract:scrcpy_$SCRCPY_SCID"
 adb -s "$REDROID" shell \
     CLASSPATH=/data/local/tmp/scrcpy-server.jar \
-    app_process / com.genymobile.scrcpy.Server 4.1 \
+    /data/local/tmp/su1000 app_process / com.genymobile.scrcpy.Server 4.1 \
     "scid=$SCRCPY_SCID" log_level=info tunnel_forward=true \
     audio=false send_device_meta=false send_dummy_byte=false \
     video_codec=h264 "video_bit_rate=$VIDEO_BIT_RATE" "max_fps=$MAX_FPS" \

--- a/os-image/ubuntu/22.04-redroid-16.0-gms-h264/remoteview.Dockerfile
+++ b/os-image/ubuntu/22.04-redroid-16.0-gms-h264/remoteview.Dockerfile
@@ -4,28 +4,30 @@ FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ARG TARGETARCH
-ARG SCRCPY_RFB_REPO=cocoonstack/libvncserver
-ARG SCRCPY_RFB_TAG=dev
+ARG SCRCPY_RFB_REPO=cocoonstack/scrcpy-rfb
+ARG SCRCPY_RFB_TAG=master
 ARG SCRCPY_RFB_COMMIT
-ARG SCRCPY_SERVER_SHA256=deacb991ed2509715160ffdc7907e47b4160eb30d1566217e9047fd5b8850cae
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     adb curl ca-certificates libjpeg-turbo8 zlib1g && \
-    test -n "$SCRCPY_RFB_COMMIT" && \
     case "$TARGETARCH" in amd64|arm64) ;; *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; esac && \
     install -d /usr/local/share/scrcpy /tmp/scrcpy-rfb && \
-    curl -fsSL \
-      https://github.com/Genymobile/scrcpy/releases/download/v4.1/scrcpy-server-v4.1 \
-      -o /usr/local/share/scrcpy/scrcpy-server.jar && \
-    echo "$SCRCPY_SERVER_SHA256  /usr/local/share/scrcpy/scrcpy-server.jar" | sha256sum -c - && \
     BASE="https://github.com/$SCRCPY_RFB_REPO/releases/download/$SCRCPY_RFB_TAG" && \
     ARTIFACT="scrcpy-rfb-linux-$TARGETARCH" && \
-    curl -fsSL "$BASE/build-info.json?commit=$SCRCPY_RFB_COMMIT" -o /tmp/scrcpy-rfb/build-info.json && \
-    grep -Fq "\"commit\": \"$SCRCPY_RFB_COMMIT\"" /tmp/scrcpy-rfb/build-info.json && \
-    curl -fsSL "$BASE/$ARTIFACT?commit=$SCRCPY_RFB_COMMIT" -o "/tmp/scrcpy-rfb/$ARTIFACT" && \
-    curl -fsSL "$BASE/$ARTIFACT.sha256?commit=$SCRCPY_RFB_COMMIT" -o "/tmp/scrcpy-rfb/$ARTIFACT.sha256" && \
-    cd /tmp/scrcpy-rfb && sha256sum -c "$ARTIFACT.sha256" && \
+    curl -fsSL "$BASE/build-info.json" -o /tmp/scrcpy-rfb/build-info.json && \
+    if [ -z "$SCRCPY_RFB_COMMIT" ]; then \
+      SCRCPY_RFB_COMMIT="$(sed -n 's/.*"commit": "\([0-9a-f]\{40\}\)".*/\1/p' /tmp/scrcpy-rfb/build-info.json)"; \
+    fi && \
+    printf '%s' "$SCRCPY_RFB_COMMIT" | grep -Eq '^[0-9a-f]{40}$' && \
+    cd /tmp/scrcpy-rfb && \
+    for f in "$ARTIFACT" scrcpy-server-secure.jar "su1000-linux-$TARGETARCH"; do \
+      curl -fsSL "$BASE/$f?commit=$SCRCPY_RFB_COMMIT" -o "$f" && \
+      curl -fsSL "$BASE/$f.sha256?commit=$SCRCPY_RFB_COMMIT" -o "$f.sha256" && \
+      sha256sum -c "$f.sha256"; \
+    done && \
     install -m 0755 "$ARTIFACT" /usr/local/bin/scrcpy-rfb && \
+    install -m 0644 scrcpy-server-secure.jar /usr/local/share/scrcpy/scrcpy-server.jar && \
+    install -m 0755 "su1000-linux-$TARGETARCH" /usr/local/share/scrcpy/su1000 && \
     cd / && rm -rf /tmp/scrcpy-rfb && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Problem
FLAG_SECURE login/pay pages (Damai's Ali login, banks, WeChat Pay) render **black** in the scrcpy remote view: the mirror display is non-secure and Android blanks secure layers on non-secure outputs. App and network are fine — it's a display-security interaction.

## Fix
- Fetch `scrcpy-server-secure.jar` (patched for a `FLAG_SECURE|AUTO_MIRROR` mirror display) and `su1000-linux-<arch>` from the scrcpy-rfb release instead of downloading the vanilla scrcpy-server. **No new build tooling / no extra image layers** — the same `curl` step, now a small loop.
- `remoteview-run.sh` runs the server as the system uid (1000) via `su1000` after `adb root`; only the platform `android` package (uid 1000) holds `CAPTURE_SECURE_VIDEO_OUTPUT`, which creating a secure display requires (root/shell do not).
- Refresh the stale standalone `remoteview.Dockerfile` (was still pointing at `cocoonstack/libvncserver:dev`) onto `cocoonstack/scrcpy-rfb:master` and the same artifacts.

Depends on cocoonstack/scrcpy-rfb#1 (publishes the two artifacts).

## Validation (arm64, ReDroid 16 GMS / Android 16 on c4a-highmem)
- Dockerfile artifact fetch + sha verification against the scrcpy-rfb `master` release: OK.
- The exact `remoteview-run.sh` from this PR, run against a live VM: auto `adb root` → push su1000 → server launches as **uid 1000** (`/proc` confirmed) → `dumpsys display` shows the scrcpy virtual display `FLAG_SECURE owner android (uid 1000)` → the previously-black **Damai login page renders** in the VNC capture. Input injection and normal content also verified.