### PR TITLE
fix(vm): bound the best-effort reseed after clone/restore

### DIFF
--- a/cmd/vm/reseed.go
+++ b/cmd/vm/reseed.go
@@ -15,9 +15,9 @@ import (
 )
 
 const (
-	reseedEntropyBytes = 32
-	reseedMaxAttempts  = 3
-	reseedRetryDelay   = 2 * time.Second
+	reseedEntropyBytes   = 32
+	reseedMaxAttempts    = 3
+	reseedRetryDelay     = 2 * time.Second
 	reseedAttemptTimeout = 4 * time.Second
 )
 

--- a/cmd/vm/reseed.go
+++ b/cmd/vm/reseed.go
@@ -18,11 +18,6 @@ const (
 	reseedEntropyBytes = 32
 	reseedMaxAttempts  = 3
 	reseedRetryDelay   = 2 * time.Second
-	// reseedAttemptTimeout bounds one dial+reseed. A guest whose vsock is
-	// wedged (e.g. a hypervisor that resets virtio-vsock on restore, leaving
-	// the agent unreachable) can otherwise block the CONNECT reply read or the
-	// reseed frame read forever on a background context — hanging the clone/
-	// restore command that fires this best-effort signal.
 	reseedAttemptTimeout = 4 * time.Second
 )
 

--- a/cmd/vm/reseed.go
+++ b/cmd/vm/reseed.go
@@ -18,6 +18,12 @@ const (
 	reseedEntropyBytes = 32
 	reseedMaxAttempts  = 3
 	reseedRetryDelay   = 2 * time.Second
+	// reseedAttemptTimeout bounds one dial+reseed. A guest whose vsock is
+	// wedged (e.g. a hypervisor that resets virtio-vsock on restore, leaving
+	// the agent unreachable) can otherwise block the CONNECT reply read or the
+	// reseed frame read forever on a background context — hanging the clone/
+	// restore command that fires this best-effort signal.
+	reseedAttemptTimeout = 4 * time.Second
 )
 
 func (h Handler) Reseed(cmd *cobra.Command, args []string) error {
@@ -58,8 +64,10 @@ func reseedVM(ctx context.Context, vm *types.VM, regenMachineID bool) error {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		conn, err := dialHybridVsock(ctx, vm.VsockSocket, hypervisor.VsockAgentPort)
+		attemptCtx, cancel := context.WithTimeout(ctx, reseedAttemptTimeout)
+		conn, err := dialHybridVsock(attemptCtx, vm.VsockSocket, hypervisor.VsockAgentPort)
 		if err != nil {
+			cancel()
 			dialErr = err
 			if attempt < reseedMaxAttempts {
 				select {
@@ -70,8 +78,9 @@ func reseedVM(ctx context.Context, vm *types.VM, regenMachineID bool) error {
 			}
 			continue
 		}
-		err = client.Reseed(ctx, conn, entropy, regenMachineID)
+		err = client.Reseed(attemptCtx, conn, entropy, regenMachineID)
 		conn.Close() //nolint:errcheck,gosec
+		cancel()
 		if err != nil {
 			return fmt.Errorf("reseed: %w", err)
 		}


### PR DESCRIPTION
## What

`vm clone` / `vm restore` fire a best-effort CRNG reseed over the guest's
hybrid-vsock (`reseedAfterResume` → `reseedVM`). The dial (`dialHybridVsock`'s
`CONNECT` reply read) and the reseed frame read both run on the command's
background context with **no deadline**. When the guest vsock is unreachable,
these reads block **forever**, hanging the whole command even though reseed is
documented as best-effort / non-fatal.

This change bounds every dial+reseed attempt with `reseedAttemptTimeout` (4s),
so the signal degrades to a warn within a fixed budget (~16s worst case: 3
attempts + 2 retry delays) instead of wedging the command.

## Repro (before)

On a bare-metal host (FC v1.16.0), `vm clone` from a Firecracker
hibernate-golden hangs indefinitely — the log stops at `VM … cloned from
snapshot` and never prints `VM cloned`; the process sits in `futex_do_wait`
holding the agent vsock connection. `timeout`-ing the process shows it only
unblocks on ctx-cancel.

## After (hardware-verified, .79)

`vm clone` returns `rc=0` in ~16s with:
```
WRN reseed signal failed (agent >= v0.1.6 required): reseed: dial agent: context deadline exceeded; run 'cocoon vm reseed <id>' after fixing
INF VM cloned: <id> (name: rfx-c1)
```
`go vet ./cmd/vm/` clean; `go test ./cmd/vm/ -run Reseed` passes.

## Note — this unmasks a deeper, separate bug (not fixed here)

The reason the guest vsock is unreachable in the repro is that **Firecracker
snapshot-restore (both `vm restore` in-place and `vm clone`) leaves the guest's
virtio-vsock permanently dead on this stack** — `cocoon-agent` (and `silkd`)
stop answering vsock port 1024, and cannot recover (systemd restart +
`listenVsockWithRetry` never re-establishes; a raw `CONNECT 1024` on the
clone's `vsock.uds` returns empty while the source returns `OK …`).
**Cloud Hypervisor restore is unaffected.** Leading hypothesis: the sandbox
custom guest kernel's virtio-vsock does not survive an FC device reset on
restore. That is tracked separately; this PR only stops the CLI from hanging
on it.