### PR TITLE
fix(ch): restore clone NICs onto throwaway taps to end the tap-attach races

### DIFF
--- a/hypervisor/cloudhypervisor/clone.go
+++ b/hypervisor/cloudhypervisor/clone.go
@@ -13,9 +13,12 @@ import (
 	"github.com/projecteru2/core/log"
 
 	"github.com/cocoonstack/cocoon/hypervisor"
+	"github.com/cocoonstack/cocoon/network"
 	"github.com/cocoonstack/cocoon/types"
 	"github.com/cocoonstack/cocoon/utils"
 )
+
+const restoreTAPPrefix = "rm"
 
 type cloneResumeOpts struct {
 	vmCfg               *types.VMConfig
@@ -81,9 +84,16 @@ func (ch *CloudHypervisor) cloneAfterExtract(ctx context.Context, vmID string, v
 		return nil, fmt.Errorf("validate post-cidata storage: %w", vErr)
 	}
 
+	// vm.restore attaches the taps named in the snapshot, so concurrent clones of one golden race to attach the source's tap (EBUSY); it cannot attach the clone's real taps either — vm.remove-device releases a tap only after the guest ACKs the eject, so hotSwapNets' add-net would EBUSY on its own tap. Give every restored NIC a clone-unique throwaway tap (auto-created by CH, auto-destroyed once the removed device drops it).
+	netTAPs := make([]string, len(chCfg.Nets))
+	for i := range netTAPs {
+		netTAPs[i] = network.TAPName(restoreTAPPrefix, vmID, i)
+	}
+
 	consoleSock := hypervisor.ConsoleSockPath(runDir)
 	if err = patchCHConfig(chConfigPath, &patchOptions{
 		storageConfigs: patchStorageConfigs,
+		netTAPs:        netTAPs,
 		consoleSock:    consoleSock,
 		vsockSock:      hypervisor.VsockSockPath(runDir),
 		directBoot:     directBoot,

--- a/hypervisor/cloudhypervisor/clone_test.go
+++ b/hypervisor/cloudhypervisor/clone_test.go
@@ -169,6 +169,38 @@ func TestPatchCHConfig_DiskCountMismatch(t *testing.T) {
 	}
 }
 
+func TestPatchCHConfig_RetargetsNetTAPs(t *testing.T) {
+	dir := t.TempDir()
+	cfg := baseCHConfig()
+	cfg["net"] = []any{
+		map[string]any{"id": "_net2", "tap": "btSOURCE00-0", "mac": "96:39:e0:7e:03:6d", "num_queues": 2},
+		map[string]any{"id": "_net3", "tap": "btSOURCE00-1", "mac": "96:39:e0:7e:03:6e", "num_queues": 2},
+	}
+	path := writeCHConfig(t, dir, cfg)
+
+	opts := basePatchOpts()
+	opts.netTAPs = []string{"btCLONE000-0", "rmCLONE000-1"}
+	if err := patchCHConfig(path, opts); err != nil {
+		t.Fatalf("patchCHConfig: %v", err)
+	}
+
+	result := readRawJSON(t, path)
+	nets := result["net"].([]any)
+	for i, want := range opts.netTAPs {
+		n := nets[i].(map[string]any)
+		if n["tap"] != want {
+			t.Errorf("net[%d].tap: got %v, want %v", i, n["tap"], want)
+		}
+	}
+	n0 := nets[0].(map[string]any)
+	if n0["id"] != "_net2" {
+		t.Errorf("net[0].id changed: got %v", n0["id"])
+	}
+	if n0["mac"] != "96:39:e0:7e:03:6d" {
+		t.Errorf("net[0].mac changed: got %v", n0["mac"])
+	}
+}
+
 func TestUpdateCOWPath_OCI(t *testing.T) {
 	configs := []*types.StorageConfig{
 		{Path: "/old/layer.erofs", RO: true, Serial: "layer0", Role: types.StorageRoleLayer},

--- a/hypervisor/cloudhypervisor/patch.go
+++ b/hypervisor/cloudhypervisor/patch.go
@@ -12,6 +12,7 @@ import (
 
 type patchOptions struct {
 	storageConfigs []*types.StorageConfig
+	netTAPs        []string
 	consoleSock    string
 	vsockSock      string
 	directBoot     bool
@@ -61,6 +62,18 @@ func patchCHConfig(path string, opts *patchOptions) error {
 				return fmt.Errorf("patch vsock: %w", patchErr)
 			}
 			raw["vsock"] = patched
+		}
+	}
+
+	if len(opts.netTAPs) > 0 {
+		if netRaw, ok := raw["net"]; ok && rawObjectPresent(netRaw) {
+			patched, patchErr := patchRawArray(netRaw, len(opts.netTAPs), func(i int, elem map[string]json.RawMessage) error {
+				return setField(elem, "tap", opts.netTAPs[i])
+			})
+			if patchErr != nil {
+				return fmt.Errorf("patch nets: %w", patchErr)
+			}
+			raw["net"] = patched
 		}
 	}
 


### PR DESCRIPTION
Fixes #141.

## Root cause (two layers, hardware-verified on the bare-metal testbed)

1. `vm.restore` recreates net devices from the snapshot's `config.json`, whose `tap` field still names the **source VM's tap**. Concurrent clones of one golden all race to attach that single tap name (CH auto-creates it when absent; a non-multiqueue tap accepts exactly one attachment) — one wins, the rest die with `Device or resource busy`. Interface sampling during a B=8 storm shows the source tap name reappearing on the host while no cocoon code creates it. Sequential clones never collide, which is why this only surfaced under concurrency (1/16, 5/32, 6/64 in the report).
2. Retargeting restore at the clone's *real* taps is no fix: `vm.remove-device` releases a tap only after the guest ACKs the PCI eject (which cannot happen while the VM is paused), so the later hot-swap `vm.add-net` EBUSYes on its own tap — 0/8 including sequential clones when tried.

DHCP was ruled out: the failing lane runs on a no-uplink bridge with no DHCP server anywhere, empty CNI ipam, and the failure is host-side at TUNSETIFF time.

## Fix

Patch each restored NIC in `config.json` onto a clone-unique throwaway tap (`rm<vmid8>-<i>`) before `vm.restore` — same patch mechanism already used for disks/console/vsock. CH auto-creates the throwaway at restore (exactly as it auto-created the missing source tap before), `hotSwapNets` replaces it with the real NIC + fresh MAC as before, and the kernel destroys it when the ejected device drops its fd. Surplus NICs on shrinking `--nics` clones get the same treatment.

## Evidence (bare metal, 1c/512M rt:24.04 golden, bridge lane)

| batch | before | after |
|---|---|---|
| seq | ok | ok, 97ms, exec OK |
| 8 | ~1/8 | **8/8** (wall 269ms) |
| 16 | 1/16 | **16/16** (wall 601ms) |
| 32 | 5/32 | **32/32** (wall 1344ms) |
| 64 | 6/64 | **64/64** (wall 2818ms) |

Source-tap reappearances during storms: 0 (50ms interface sampling). Guest-side MAC refresh preserved: two clones show distinct guest NIC MACs matching their cocoon-assigned values.

Hot-path cost: zero new API calls; restore's tap attach does the same syscall work it always did, just on an uncontended name.