### PR TITLE
fix(ch): fail fast when an mmap restore would silently degrade to eager copy

### DIFF
--- a/cmd/vm/commands.go
+++ b/cmd/vm/commands.go
@@ -131,7 +131,7 @@ func Command(h Handler) *cobra.Command {
 		},
 		RunE: h.Restore,
 	}
-	restoreCmd.Flags().String("restore-mode", "", "memory restore mode: copy|ondemand|mmap (CH only; ondemand/mmap require the snapshot file to remain on disk)")
+	restoreCmd.Flags().String("restore-mode", "", "memory restore mode: copy|ondemand|mmap (CH only; ondemand/mmap require the snapshot file to remain on disk; mmap needs a plain private-anon snapshot — no hugepages/shared)")
 	restoreCmd.Flags().String("from-dir", "", "restore from a snapshot directory (must contain snapshot.json) instead of the local snapshot DB; mutually exclusive with positional SNAPSHOT")
 	restoreCmd.Flags().Bool("force", false, "skip the snapshot-belongs-to-VM check (only meaningful with --from-dir; risk of restoring to an unrelated lineage)")
 	cliutil.AddOutputFlag(restoreCmd)
@@ -330,7 +330,7 @@ func addCloneFlags(cmd *cobra.Command) {
 	cmd.Flags().String("network", "", "CNI conflist name (empty = inherit from source VM)")
 	cmd.Flags().String("bridge", "", "use TAP-on-bridge instead of CNI (value is bridge device, e.g. cni0)")
 	cmd.Flags().Bool("no-direct-io", false, "disable O_DIRECT on writable disks (inherit from snapshot if not set)")
-	cmd.Flags().String("restore-mode", "", "memory restore mode: copy|ondemand|mmap (CH only; ondemand/mmap require the snapshot file to remain on disk)")
+	cmd.Flags().String("restore-mode", "", "memory restore mode: copy|ondemand|mmap (CH only; ondemand/mmap require the snapshot file to remain on disk; mmap needs a plain private-anon snapshot — no hugepages/shared)")
 	cmd.Flags().Bool("pull", false, "auto-pull base image if not found locally (for cross-node clone)")
 	cmd.Flags().StringArray("data-disk", nil, "create and hot-add an extra data disk to the clone: size=20G[,name=...][,fstype=ext4|none]; repeatable (CH only)")
 	cmd.Flags().String("from-dir", "", "clone from a snapshot directory (must contain snapshot.json) instead of the local snapshot DB; mutually exclusive with positional SNAPSHOT")

--- a/hypervisor/cloudhypervisor/clone.go
+++ b/hypervisor/cloudhypervisor/clone.go
@@ -44,6 +44,10 @@ func (ch *CloudHypervisor) cloneAfterExtract(ctx context.Context, vmID string, v
 		return nil, fmt.Errorf("parse CH config: %w", err)
 	}
 
+	if err = validateRestoreMode(vmCfg.RestoreMode, chCfg.Memory); err != nil {
+		return nil, err
+	}
+
 	meta, err := ch.conf.LoadAndValidateMeta(runDir)
 	if err != nil {
 		return nil, fmt.Errorf("load snapshot meta: %w", err)

--- a/hypervisor/cloudhypervisor/direct.go
+++ b/hypervisor/cloudhypervisor/direct.go
@@ -23,8 +23,10 @@ func (ch *CloudHypervisor) DirectRestore(ctx context.Context, vmRef string, vmCf
 		VMCfg:            vmCfg,
 		SrcDir:           srcDir,
 		SourceSnapshotID: sourceSnapshotID,
-		Preflight:        ch.preflightRestore,
-		Kill:             ch.killForRestore,
+		Preflight: func(srcDir string, rec *hypervisor.VMRecord) error {
+			return ch.preflightRestore(srcDir, rec, vmCfg.RestoreMode)
+		},
+		Kill: ch.killForRestore,
 		Populate: func(rec *hypervisor.VMRecord, srcDir string) error {
 			return hypervisor.PopulateFromSrc(rec.RunDir, srcDir, cleanSnapshotFiles, func(dstDir, srcDir string) error {
 				return cloneSnapshotFiles(ctx, dstDir, srcDir)

--- a/hypervisor/cloudhypervisor/restore.go
+++ b/hypervisor/cloudhypervisor/restore.go
@@ -20,8 +20,10 @@ func (ch *CloudHypervisor) Restore(ctx context.Context, vmRef string, vmCfg *typ
 		VMCfg:            vmCfg,
 		Snapshot:         snapshot,
 		SourceSnapshotID: sourceSnapshotID,
-		Preflight:        ch.preflightRestore,
-		Kill:             ch.killForRestore,
+		Preflight: func(srcDir string, rec *hypervisor.VMRecord) error {
+			return ch.preflightRestore(srcDir, rec, vmCfg.RestoreMode)
+		},
+		Kill: ch.killForRestore,
 		// Same sweep as DirectRestore's Populate: stale snapshot files from a previous incarnation must not survive the merge.
 		BeforeMerge: func(rec *hypervisor.VMRecord) error {
 			return cleanSnapshotFiles(rec.RunDir)
@@ -33,10 +35,13 @@ func (ch *CloudHypervisor) Restore(ctx context.Context, vmRef string, vmCfg *typ
 	})
 }
 
-func (ch *CloudHypervisor) preflightRestore(srcDir string, rec *hypervisor.VMRecord) error {
+func (ch *CloudHypervisor) preflightRestore(srcDir string, rec *hypervisor.VMRecord, restoreMode string) error {
 	chCfg, err := parseCHConfig(filepath.Join(srcDir, configJSONName))
 	if err != nil {
 		return fmt.Errorf("parse snapshot config: %w", err)
+	}
+	if err := validateRestoreMode(restoreMode, chCfg.Memory); err != nil {
+		return err
 	}
 	if err := ch.conf.PreflightRestore(srcDir, rec, func(dir string, sidecar []*types.StorageConfig) error {
 		return validateSnapshotIntegrityParsed(dir, sidecar, chCfg)
@@ -108,6 +113,14 @@ func (ch *CloudHypervisor) restoreAfterExtract(ctx context.Context, vmID string,
 
 	logger.Infof(ctx, "VM %s restored from snapshot", vmID)
 	return ch.FinalizeRestore(ctx, vmID, vmCfg, rec, pid)
+}
+
+// validateRestoreMode rejects an explicit mmap request that CH would silently downgrade to eager copy: CoW restore needs plain private-anon guest memory.
+func validateRestoreMode(mode string, mem chMemory) error {
+	if mode != "mmap" || (!mem.HugePages && !mem.Shared) {
+		return nil
+	}
+	return fmt.Errorf("restore-mode mmap is incompatible with this snapshot's memory config (hugepages=%t, shared=%t) and CH would silently fall back to eager copy; rebuild the golden without hugepages/shared memory or drop --restore-mode mmap", mem.HugePages, mem.Shared)
 }
 
 // validateRestoreNICs rejects restore when the VM's NIC identity drifted since capture (net resize): vm.restore replays the snapshot's guest MACs verbatim, which would diverge from the live CNI/DB identity.

--- a/hypervisor/cloudhypervisor/restore_test.go
+++ b/hypervisor/cloudhypervisor/restore_test.go
@@ -33,3 +33,27 @@ func TestValidateRestoreNICs(t *testing.T) {
 		t.Fatal("NIC count drift must be rejected")
 	}
 }
+
+func TestValidateRestoreMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    string
+		mem     chMemory
+		wantErr bool
+	}{
+		{"empty mode any mem", "", chMemory{HugePages: true, Shared: true}, false},
+		{"copy any mem", "copy", chMemory{HugePages: true}, false},
+		{"ondemand hugepages", "ondemand", chMemory{HugePages: true}, false},
+		{"mmap plain", "mmap", chMemory{}, false},
+		{"mmap hugepages", "mmap", chMemory{HugePages: true}, true},
+		{"mmap shared", "mmap", chMemory{Shared: true}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRestoreMode(tt.mode, tt.mem)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("got err=%v, wantErr=%v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow-up hardening from the B=64 restore-mode round on the bare-metal testbed (numbers in cocoonstack/sandbox#30).

## Problem

CH's `CopyOnWrite` restore requires plain private-anon guest memory. On snapshots carrying `hugepages` or `shared` memory it logs a warn to its own stderr and **silently falls back to eager copy while reporting success**. cocoon auto-enables hugepages whenever the host has `nr_hugepages > 0`, so a golden built on such a host silently loses the entire CoW win — 43MB/VM + p50 1060ms becomes 331MB/VM + p50 2311ms at B=64 with nothing observable. On a C1M-style fleet this invalidates a whole run.

## Fix

`validateRestoreMode`: an explicit `--restore-mode mmap` against a snapshot whose memory config has `hugepages` or `shared` set is rejected up front, in all three paths (clone, stream restore preflight, direct restore preflight). `copy` and `ondemand` are untouched (ondemand preserves the mapping type and stays compatible).

## Evidence (bare-metal testbed)

- Plain golden + `--restore-mode mmap` clone: OK, exec OK (no regression).
- Host `nr_hugepages=384` → golden captures `"hugepages":true` → `clone --restore-mode mmap`: **rejected** with the new message; default-mode clone of the same golden still OK + exec OK.
- Same-lineage hugepage golden → `vm restore --restore-mode mmap`: **rejected**; default restore OK + exec OK.
- Host state reverted (`nr_hugepages=0`) after the round.

Unit table test covers the validator matrix.