### PR TITLE
perf(clone): skip the adoption index rewrite for pre-reserved clones

### DIFF
--- a/cmd/vm/run.go
+++ b/cmd/vm/run.go
@@ -477,6 +477,7 @@ func prereserveVM(ctx context.Context, hyper hypervisor.Hypervisor, vmID string,
 		unlock()
 		return nil, nil, fmt.Errorf("reserve VM record: %w", err)
 	}
+	vmCfg.PreReserved = true
 	return func() { r.RollbackCreate(ctx, vmID, vmCfg.Name) }, unlock, nil
 }
 

--- a/hypervisor/clone.go
+++ b/hypervisor/clone.go
@@ -14,8 +14,11 @@ import (
 // AfterExtractFn finalizes a cloned VM after snapshot files are in place; sourceSnapshotID flows through for metering lineage.
 type AfterExtractFn func(ctx context.Context, vmID string, vmCfg *types.VMConfig, net types.NetSetup, runDir, logDir string, now time.Time, sourceSnapshotID string) (*types.VM, error)
 
-// CloneSetup is the shared pre-clone sequence: validate CPU, reserve a placeholder, ensure dirs, return a cleanup that rolls back both.
+// CloneSetup is the shared pre-clone sequence: validate CPU, reserve a placeholder, ensure dirs, return a cleanup that rolls back both. A pre-reserved caller already stored an identical placeholder, so adoption skips the redundant index rewrite after a read-only ownership check; any mismatch falls back to the reserving path.
 func (b *Backend) CloneSetup(ctx context.Context, vmID string, vmCfg *types.VMConfig, snapshotConfig *types.SnapshotConfig) (runDir, logDir string, now time.Time, cleanup func(), err error) {
+	if vmCfg.PreReserved && b.ownsPlaceholder(ctx, vmID, vmCfg, snapshotConfig.ImageBlobIDs) {
+		return b.adoptPlaceholder(ctx, vmID, vmCfg)
+	}
 	return b.reservePlaceholder(ctx, vmID, vmCfg, snapshotConfig.ImageBlobIDs)
 }
 

--- a/hypervisor/clone_test.go
+++ b/hypervisor/clone_test.go
@@ -1,0 +1,158 @@
+package hypervisor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cocoonstack/cocoon/lock/flock"
+	meteringcapture "github.com/cocoonstack/cocoon/metering/capture"
+	"github.com/cocoonstack/cocoon/storage"
+	storejson "github.com/cocoonstack/cocoon/storage/json"
+	"github.com/cocoonstack/cocoon/types"
+)
+
+type cloneStubConfig struct {
+	stubBackendConfig
+	root string
+}
+
+func (c cloneStubConfig) VMRunDir(id string) string { return filepath.Join(c.root, "run", id) }
+
+func (c cloneStubConfig) VMLogDir(id string) string { return filepath.Join(c.root, "log", id) }
+
+func (c cloneStubConfig) RunDir() string { return filepath.Join(c.root, "run") }
+
+type countingStore struct {
+	storage.Store[VMIndex]
+	writes atomic.Int32
+}
+
+func (s *countingStore) Update(ctx context.Context, fn func(*VMIndex) error) error {
+	s.writes.Add(1)
+	return s.Store.Update(ctx, fn)
+}
+
+func (s *countingStore) UpdateNoDirSync(ctx context.Context, fn func(*VMIndex) error) error {
+	s.writes.Add(1)
+	return s.Store.UpdateNoDirSync(ctx, fn)
+}
+
+func newCloneTestBackend(t *testing.T) (*Backend, *countingStore) {
+	t.Helper()
+	dir := t.TempDir()
+	locker := flock.New(filepath.Join(dir, "index.lock"))
+	cs := &countingStore{Store: storejson.New[VMIndex](filepath.Join(dir, "index.json"), locker)}
+	return &Backend{
+		Typ:      "test-hv",
+		Conf:     cloneStubConfig{root: dir},
+		DB:       cs,
+		Locker:   locker,
+		Metering: meteringcapture.New(),
+	}, cs
+}
+
+func cloneTestCfg(name string, preReserved bool) *types.VMConfig {
+	return &types.VMConfig{
+		Config:      types.Config{CPU: 1, Memory: 1 << 30, Storage: 10 << 30},
+		Name:        name,
+		PreReserved: preReserved,
+	}
+}
+
+func TestCloneSetup_PreReservedSkipsIndexRewrite(t *testing.T) {
+	b, cs := newCloneTestBackend(t)
+	ctx := t.Context()
+	const id = "vm-prereserved"
+	blobs := map[string]struct{}{"blob1": {}}
+	vmCfg := cloneTestCfg("c1", true)
+
+	if err := b.PrereserveVM(ctx, id, vmCfg, blobs); err != nil {
+		t.Fatalf("PrereserveVM: %v", err)
+	}
+	if got := cs.writes.Load(); got != 1 {
+		t.Fatalf("writes after pre-reserve = %d, want 1", got)
+	}
+
+	runDir, logDir, _, cleanup, err := b.CloneSetup(ctx, id, vmCfg, &types.SnapshotConfig{ImageBlobIDs: blobs})
+	if err != nil {
+		t.Fatalf("CloneSetup: %v", err)
+	}
+	if got := cs.writes.Load(); got != 1 {
+		t.Errorf("writes after CloneSetup = %d, want 1 (adoption must not rewrite the index)", got)
+	}
+	for _, d := range []string{runDir, logDir} {
+		if _, statErr := os.Stat(d); statErr != nil {
+			t.Errorf("dir %s not created: %v", d, statErr)
+		}
+	}
+
+	cleanup()
+	if err := b.DB.With(ctx, func(idx *VMIndex) error {
+		if idx.VMs[id] != nil {
+			t.Error("record survived cleanup")
+		}
+		if _, ok := idx.Names["c1"]; ok {
+			t.Error("name mapping survived cleanup")
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("With: %v", err)
+	}
+	for _, d := range []string{runDir, logDir} {
+		if _, statErr := os.Stat(d); !os.IsNotExist(statErr) {
+			t.Errorf("dir %s survived cleanup", d)
+		}
+	}
+}
+
+func TestCloneSetup_DriftFallsBackToReserve(t *testing.T) {
+	b, cs := newCloneTestBackend(t)
+	ctx := t.Context()
+	const id = "vm-drift"
+	vmCfg := cloneTestCfg("c2", true)
+
+	if err := b.PrereserveVM(ctx, id, vmCfg, map[string]struct{}{"old": {}}); err != nil {
+		t.Fatalf("PrereserveVM: %v", err)
+	}
+
+	newBlobs := map[string]struct{}{"new": {}}
+	if _, _, _, _, err := b.CloneSetup(ctx, id, vmCfg, &types.SnapshotConfig{ImageBlobIDs: newBlobs}); err != nil {
+		t.Fatalf("CloneSetup: %v", err)
+	}
+	if got := cs.writes.Load(); got != 2 {
+		t.Errorf("writes = %d, want 2 (blob drift must take the reserving path)", got)
+	}
+	if err := b.DB.With(ctx, func(idx *VMIndex) error {
+		if _, ok := idx.VMs[id].ImageBlobIDs["new"]; !ok {
+			t.Error("fallback did not refresh blob pins")
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("With: %v", err)
+	}
+}
+
+func TestCloneSetup_NotPreReservedKeepsReservingPath(t *testing.T) {
+	b, cs := newCloneTestBackend(t)
+	ctx := t.Context()
+	const id = "vm-plain"
+	vmCfg := cloneTestCfg("c3", false)
+
+	if _, _, _, _, err := b.CloneSetup(ctx, id, vmCfg, &types.SnapshotConfig{ImageBlobIDs: nil}); err != nil {
+		t.Fatalf("CloneSetup: %v", err)
+	}
+	if got := cs.writes.Load(); got != 1 {
+		t.Errorf("writes = %d, want 1 (non-pre-reserved caller must reserve)", got)
+	}
+	if err := b.DB.With(ctx, func(idx *VMIndex) error {
+		if idx.VMs[id] == nil {
+			t.Error("record missing after reserving CloneSetup")
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("With: %v", err)
+	}
+}

--- a/hypervisor/create.go
+++ b/hypervisor/create.go
@@ -3,6 +3,7 @@ package hypervisor
 import (
 	"context"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/projecteru2/core/log"
@@ -123,6 +124,46 @@ func (b *Backend) CreateSequence(ctx context.Context, id string, spec CreateSpec
 		return nil, fmt.Errorf("finalize VM record: %w", err)
 	}
 	return info, nil
+}
+
+// ownsPlaceholder reports whether id holds the exact placeholder a PrereserveVM by this caller would have written; any drift sends the caller down the reserving path instead.
+func (b *Backend) ownsPlaceholder(ctx context.Context, id string, vmCfg *types.VMConfig, blobIDs map[string]struct{}) bool {
+	owns := false
+	if err := b.DB.With(ctx, func(idx *VMIndex) error {
+		existing := idx.VMs[id]
+		owns = existing != nil &&
+			existing.State == types.VMStateCreating &&
+			existing.Config.Name == vmCfg.Name &&
+			existing.RunDir == b.Conf.VMRunDir(id) &&
+			existing.LogDir == b.Conf.VMLogDir(id) &&
+			maps.Equal(existing.ImageBlobIDs, blobIDs)
+		return nil
+	}); err != nil {
+		return false
+	}
+	return owns
+}
+
+// adoptPlaceholder is reservePlaceholder for a verified pre-reserved record: same validation, dirs, and cleanup, without the redundant index rewrite.
+func (b *Backend) adoptPlaceholder(ctx context.Context, id string, vmCfg *types.VMConfig) (runDir, logDir string, now time.Time, cleanup func(), err error) {
+	if err = ValidateHostCPU(vmCfg.CPU); err != nil {
+		return "", "", time.Time{}, nil, err
+	}
+	now = time.Now()
+	runDir = b.Conf.VMRunDir(id)
+	logDir = b.Conf.VMLogDir(id)
+
+	cleanup = func() {
+		// Record first: dir removal deletes the held ops.lock inode, and a concurrent rm on the recreated file must not find a live placeholder.
+		b.RollbackCreate(ctx, id, vmCfg.Name)
+		_ = RemoveVMDirs(runDir, logDir)
+	}
+
+	if err = utils.EnsureDirs(runDir, logDir); err != nil {
+		cleanup()
+		return "", "", time.Time{}, nil, fmt.Errorf("ensure dirs: %w", err)
+	}
+	return runDir, logDir, now, cleanup, nil
 }
 
 // reservePlaceholder validates host CPU, reserves a "creating" VM record, and ensures its run/log dirs exist; shared by CreateSequence and CloneSetup. On failure it rolls back internally (if needed) and returns a nil cleanup; on success cleanup removes the dirs and rolls back the reservation — the caller decides when to run it.

--- a/types/vm.go
+++ b/types/vm.go
@@ -31,6 +31,7 @@ type VMConfig struct {
 	Name string `json:"name"`
 
 	RestoreMode string         `json:"-"` // memory restore mode: copy|ondemand|mmap (CH only); transient, not persisted
+	PreReserved bool           `json:"-"` // caller already inserted this VM's placeholder via PrereserveVM; transient, not persisted
 	User        string         `json:"-"`
 	Password    string         `json:"-"`
 	DataDisks   []DataDiskSpec `json:"-"` // populated from --data-disk; consumed by Create


### PR DESCRIPTION
Implements #132.

## What

Callers that pre-reserved via `PrereserveVM` set a transient `VMConfig.PreReserved` flag; `CloneSetup` then verifies ownership with a locked read (state, name, dirs, blob-pin set) and skips the adoption `ReserveVM`/`UpdateNoDirSync` rewrite entirely, keeping CPU validation, dir creation, and the rollback cleanup identical. Any drift — or a caller that never pre-reserved — falls back to the existing reserving path unchanged. No store-format or collision-semantics changes.

## Acceptance evidence

- **Mutation counts (unit-verified):** pre-reserved clone setup = pre-reserve + finalize only; the adoption write is gone (`TestCloneSetup_PreReservedSkipsIndexRewrite`). Blob-pin drift falls back and refreshes pins (`TestCloneSetup_DriftFallsBackToReserve`); non-pre-reserved callers keep one reserving write (`TestCloneSetup_NotPreReservedKeepsReservingPath`). Cleanup leaves no record, name mapping, or dirs.
- **Hardware A/B (bare-metal testbed, FC none-lane, 512M golden; same script, stock master then this branch):**

| metric | master-24bd46b | this branch |
|---|---|---|
| seq10 p50 (N=0) | 31ms | 30ms |
| burst16 wall (N=10) | 342ms | 282ms |
| B64 wall (N=0) | 1189ms | 1318ms |
| B64 wall (N=64) | 3874ms | 2906ms |
| B64 wall (N=128) | 4016ms | 3978ms |

Honest read: same-binary run-to-run variance at B64 is ±20% on this host (an earlier same-day baseline measured 4914ms for the N=128 round), so the wall deltas above are within noise — as the issue anticipated ("No fixed percentage improvement is assumed"). The structural win is the removed lock-held write (full-index marshal + main + `.prev` write per clone); the dominant remaining cost is the O(resident-N) whole-file index itself, tracked as the next ledger step (delta/segmented index — cocoonstack/sandbox#30 has the phase decomposition: the index-write segments carry p50 2347ms + 867ms of a 4069ms clone at N≈190 while the actual snapshot load is 14ms). Index sizes ≥1000 measurement deferred to the T2 rig.