### PR TITLE
Whole-repo review round: style walkthrough, simplify pass, and LOC audit

### DIFF
--- a/cmd/images/import.go
+++ b/cmd/images/import.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -180,22 +179,17 @@ func detectLocalImportSource(filePath string) (importSourceKind, error) {
 	}
 	defer func() { _ = f.Close() }()
 
-	var magic [4]byte
-	n, readErr := io.ReadFull(f, magic[:])
-	if readErr != nil && !errors.Is(readErr, io.EOF) && !errors.Is(readErr, io.ErrUnexpectedEOF) {
-		return 0, fmt.Errorf("peek %s: %w", filePath, readErr)
+	head, err := utils.FileHead(f, 4)
+	if err != nil {
+		return 0, fmt.Errorf("peek %s: %w", filePath, err)
 	}
-
-	if n >= 2 && bytes.Equal(magic[:2], utils.GzipMagic) {
+	if bytes.HasPrefix(head, utils.GzipMagic) {
 		return importSourceStream, nil
 	}
-	if n >= 4 && bytes.Equal(magic[:4], utils.Qcow2Magic) {
+	if bytes.HasPrefix(head, utils.Qcow2Magic) {
 		return importSourceQcow2, nil
 	}
 
-	if _, err := f.Seek(0, io.SeekStart); err != nil {
-		return 0, fmt.Errorf("seek %s: %w", filePath, err)
-	}
 	if _, err := tar.NewReader(f).Next(); err != nil {
 		return 0, fmt.Errorf("cannot detect file type for %s (expected qcow2 or tar)", filePath)
 	}

--- a/cmd/others/handler.go
+++ b/cmd/others/handler.go
@@ -53,7 +53,7 @@ func (h Handler) GC(cmd *cobra.Command, _ []string) error {
 		hyper.RegisterGC(o)
 	}
 	netProvider.RegisterGC(o)
-	gc.Register(o, bridge.GCModule(conf.RootDir))
+	gc.Register(o, bridge.GCModule())
 	snapBackend.RegisterGC(o)
 	return o.Run(ctx)
 }

--- a/cmd/storebench/main.go
+++ b/cmd/storebench/main.go
@@ -266,7 +266,8 @@ func argDir(i int) string {
 	}
 	dir, err := os.MkdirTemp("", "storebench-*")
 	if err != nil {
-		panic(err)
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
 	}
 	return dir
 }

--- a/cmd/storebench/main.go
+++ b/cmd/storebench/main.go
@@ -286,8 +286,6 @@ func (c benchConfig) PIDFileName() string                 { return "pid" }
 func (c benchConfig) TerminateGracePeriod() time.Duration { return time.Second }
 func (c benchConfig) SocketWaitTimeout() time.Duration    { return time.Second }
 func (c benchConfig) EffectivePoolSize() int              { return 4 }
-func (c benchConfig) IndexFile() string                   { return filepath.Join(c.dir, "vms.json") }
-func (c benchConfig) IndexLock() string                   { return filepath.Join(c.dir, "vms.lock") }
 func (c benchConfig) EnsureDirs() error                   { return nil }
 func (c benchConfig) RunDir() string                      { return c.dir }
 func (c benchConfig) LogDir() string                      { return c.dir }

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -386,9 +386,12 @@ func providerForVM(conf *config.Config, cniProvider network.Network, bridgeCache
 	return cmdcore.InitNetwork(conf)
 }
 
-// runRoutedLoop runs fn per routed hypervisor, logging each success under logTag (unless JSON), and returns all done ids plus the last error.
-func runRoutedLoop(ctx context.Context, logTag, pastTense string, wantJSON bool, routed map[hypervisor.Hypervisor][]string, fn func(hypervisor.Hypervisor, []string) ([]string, error)) (allDone []string, lastErr error) {
-	logger := log.WithFunc(logTag)
+// batchRoutedCmd runs fn per routed hypervisor, logging each success (unless JSON), then wraps the last error, emits JSON, or logs the empty case.
+func batchRoutedCmd(ctx context.Context, cmd *cobra.Command, name, pastTense string, routed map[hypervisor.Hypervisor][]string, fn func(hypervisor.Hypervisor, []string) ([]string, error)) error {
+	logger := log.WithFunc("cmd.vm." + name)
+	wantJSON := cliutil.WantJSON(cmd)
+	var allDone []string
+	var lastErr error
 	for hyper, refs := range routed {
 		done, err := fn(hyper, refs)
 		if !wantJSON {
@@ -401,11 +404,6 @@ func runRoutedLoop(ctx context.Context, logTag, pastTense string, wantJSON bool,
 			lastErr = err
 		}
 	}
-	return allDone, lastErr
-}
-
-// finishRoutedCmd is the shared tail for routed batch commands: wrap lastErr, emit JSON, or log the empty-case message.
-func finishRoutedCmd(ctx context.Context, cmd *cobra.Command, logTag, name, pastTense string, allDone []string, lastErr error) error {
 	if lastErr != nil {
 		return fmt.Errorf("%s: %w", name, lastErr)
 	}
@@ -413,15 +411,9 @@ func finishRoutedCmd(ctx context.Context, cmd *cobra.Command, logTag, name, past
 		return jsonErr
 	}
 	if len(allDone) == 0 {
-		log.WithFunc(logTag).Infof(ctx, "no VMs %s", pastTense)
+		logger.Infof(ctx, "no VMs %s", pastTense)
 	}
 	return nil
-}
-
-func batchRoutedCmd(ctx context.Context, cmd *cobra.Command, name, pastTense string, routed map[hypervisor.Hypervisor][]string, fn func(hypervisor.Hypervisor, []string) ([]string, error)) error {
-	logTag := "cmd.vm." + name
-	allDone, lastErr := runRoutedLoop(ctx, logTag, pastTense, cliutil.WantJSON(cmd), routed, fn)
-	return finishRoutedCmd(ctx, cmd, logTag, name, pastTense, allDone, lastErr)
 }
 
 // collectAttachedDevices reads fs/vfio devices; errors are logged and dropped so inspect tolerates a flaky vm.info.

--- a/config/config.go
+++ b/config/config.go
@@ -106,7 +106,6 @@ func (c *Config) Validate() error {
 }
 
 // DNSServers parses the DNS string into a slice of server addresses.
-// Returns an error if any entry is not a valid IP address.
 func (c *Config) DNSServers() ([]string, error) {
 	if c.DNS == "" {
 		return nil, nil

--- a/hypervisor/cloudhypervisor/api.go
+++ b/hypervisor/cloudhypervisor/api.go
@@ -69,10 +69,9 @@ type chQueueAffinity struct {
 }
 
 type chBalloon struct {
-	ID                string `json:"id,omitempty"`
-	Size              int64  `json:"size"`
-	DeflateOnOOM      bool   `json:"deflate_on_oom,omitempty"`
-	FreePageReporting bool   `json:"free_page_reporting,omitempty"`
+	Size              int64 `json:"size"`
+	DeflateOnOOM      bool  `json:"deflate_on_oom,omitempty"`
+	FreePageReporting bool  `json:"free_page_reporting,omitempty"`
 }
 
 type chRNG struct {
@@ -105,8 +104,7 @@ type chDevice struct {
 
 // chPciDeviceInfo is the response body from vm.add-fs / vm.add-device / vm.add-disk / vm.add-net (HTTP 200).
 type chPciDeviceInfo struct {
-	ID  string `json:"id"`
-	BDF string `json:"bdf"`
+	ID string `json:"id"`
 }
 
 type chVMInfoResponse struct {

--- a/hypervisor/cloudhypervisor/args.go
+++ b/hypervisor/cloudhypervisor/args.go
@@ -270,10 +270,8 @@ func runtimeFileToCLIArg(c *chRuntimeFile) string {
 		return "file=" + c.File
 	case "socket":
 		return "socket=" + c.Socket
-	case "tty":
-		return "tty"
 	default:
-		return strings.ToLower(c.Mode) // "off", "null", "pty"
+		return strings.ToLower(c.Mode) // "off", "null", "tty", "pty"
 	}
 }
 

--- a/hypervisor/cloudhypervisor/extend.go
+++ b/hypervisor/cloudhypervisor/extend.go
@@ -228,10 +228,7 @@ func (ch *CloudHypervisor) lockedDeviceOp(ctx context.Context, vmRef string) (*h
 		return nil, hypervisor.VMRecord{}, nil, nil, err
 	}
 	// Entrypoint discipline (design §5): device attach is reference-creating.
-	if gErr := ch.EntryGuard(ctx, vmID); gErr != nil {
-		return fail(gErr)
-	}
-	rec, err := ch.LoadRecord(ctx, vmID)
+	rec, err := ch.EntryGuardLoad(ctx, vmID)
 	if err != nil {
 		return fail(err)
 	}

--- a/hypervisor/cloudhypervisor/netresize.go
+++ b/hypervisor/cloudhypervisor/netresize.go
@@ -34,12 +34,9 @@ func (ch *CloudHypervisor) NetResize(ctx context.Context, vmRef string, spec net
 	}
 	defer unlock()
 	// Entrypoint discipline (design §5): a resize must not plumb NICs onto a
-	// VM whose delete was interrupted.
-	if err = ch.EntryGuard(ctx, vmID); err != nil {
-		return netresize.Result{}, err
-	}
-	// Reload under the lock: a resize that won the lock first may have changed the NIC set after this one loaded the record.
-	if rec, err = ch.LoadRecord(ctx, vmID); err != nil {
+	// VM whose delete was interrupted. Reload under the lock: a resize that
+	// won the lock first may have changed the NIC set after this one loaded.
+	if rec, err = ch.EntryGuardLoad(ctx, vmID); err != nil {
 		return netresize.Result{}, err
 	}
 	info, err := getVMInfo(ctx, hc)

--- a/hypervisor/cloudhypervisor/patch.go
+++ b/hypervisor/cloudhypervisor/patch.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/cocoonstack/cocoon/types"
 	"github.com/cocoonstack/cocoon/utils"
@@ -22,13 +21,9 @@ type patchOptions struct {
 
 // patchCHConfig patches specific fields in config.json while preserving all unknown fields that CH adds internally (platform, cpus.topology, etc.).
 func patchCHConfig(path string, opts *patchOptions) error {
-	rawData, err := os.ReadFile(path) //nolint:gosec
-	if err != nil {
-		return fmt.Errorf("read %s: %w", path, err)
-	}
 	var raw map[string]json.RawMessage
-	if e := json.Unmarshal(rawData, &raw); e != nil {
-		return fmt.Errorf("decode raw %s: %w", path, e)
+	if err := utils.ReadJSONFile(path, &raw); err != nil {
+		return err
 	}
 
 	diskCount := rawArrayLen(raw["disks"])

--- a/hypervisor/disks.go
+++ b/hypervisor/disks.go
@@ -75,22 +75,11 @@ func PrepareDataDisks(ctx context.Context, baseDir string, specs []types.DataDis
 		if spec.Size < MinDataDiskSize {
 			return nil, fmt.Errorf("data disk %s: size %d below %d minimum", spec.Name, spec.Size, MinDataDiskSize)
 		}
-		path := filepath.Join(baseDir, DataDiskBaseName(spec.Name))
-		if err := createSparseFile(path, spec.Size); err != nil {
-			return nil, fmt.Errorf("data disk %s: %w", spec.Name, err)
-		}
-		switch spec.FSType {
-		case types.FSTypeExt4:
-			if err := InitCOWFilesystem(ctx, path); err != nil {
-				return nil, fmt.Errorf("data disk %s: mkfs: %w", spec.Name, err)
-			}
-		case types.FSTypeNone:
-			// raw, user formats inside guest
-		default:
+		if spec.FSType != types.FSTypeExt4 && spec.FSType != types.FSTypeNone {
 			return nil, fmt.Errorf("data disk %s: fstype %q not supported", spec.Name, spec.FSType)
 		}
 		out = append(out, &types.StorageConfig{
-			Path:       path,
+			Path:       filepath.Join(baseDir, DataDiskBaseName(spec.Name)),
 			RO:         false,
 			Serial:     spec.Name,
 			Role:       types.StorageRoleData,
@@ -98,6 +87,20 @@ func PrepareDataDisks(ctx context.Context, baseDir string, specs []types.DataDis
 			FSType:     spec.FSType,
 			DirectIO:   spec.DirectIO,
 		})
+	}
+	// Fan out sparse-create + mkfs like copyPairs: on the create path, wall time is the slowest disk, not the sum.
+	if _, err := utils.Map(ctx, specs, func(ctx context.Context, i int, spec types.DataDiskSpec) (struct{}, error) {
+		if err := createSparseFile(out[i].Path, spec.Size); err != nil {
+			return struct{}{}, fmt.Errorf("data disk %s: %w", spec.Name, err)
+		}
+		if spec.FSType == types.FSTypeExt4 {
+			if err := InitCOWFilesystem(ctx, out[i].Path); err != nil {
+				return struct{}{}, fmt.Errorf("data disk %s: mkfs: %w", spec.Name, err)
+			}
+		}
+		return struct{}{}, nil
+	}); err != nil {
+		return nil, err
 	}
 	return out, nil
 }

--- a/hypervisor/firecracker/api.go
+++ b/hypervisor/firecracker/api.go
@@ -75,12 +75,10 @@ type fcSnapshotCreate struct {
 }
 
 type fcSnapshotLoad struct {
-	SnapshotPath        string              `json:"snapshot_path"`
-	MemBackend          fcSnapshotMemBE     `json:"mem_backend"`
-	EnableDiffSnapshots bool                `json:"enable_diff_snapshots,omitempty"`
-	ResumeVM            bool                `json:"resume_vm,omitempty"`
-	NetworkOverrides    []fcNetworkOverride `json:"network_overrides,omitempty"`
-	VsockOverride       *fcVsockOverride    `json:"vsock_override,omitempty"`
+	SnapshotPath     string              `json:"snapshot_path"`
+	MemBackend       fcSnapshotMemBE     `json:"mem_backend"`
+	NetworkOverrides []fcNetworkOverride `json:"network_overrides,omitempty"`
+	VsockOverride    *fcVsockOverride    `json:"vsock_override,omitempty"`
 }
 
 // fcNetworkOverride overrides a network interface from the snapshot with a new TAP device (FC v1.14+, PR #4731).

--- a/hypervisor/restore.go
+++ b/hypervisor/restore.go
@@ -39,11 +39,18 @@ func (b *Backend) ResolveForRestore(ctx context.Context, vmRef string) (string, 
 	if err != nil {
 		return "", nil, err
 	}
-	// Stopped restores too (hibernate resume): the sequence cold-spawns a fresh VMM either way and the kill step tolerates a dead one. Error VMs are allowed through (quarantine sets Error too) — restore rebuilds the run dir, so it is the recovery path start.go redirects a crashed restore to; FailRestore leaves a running-origin failure in Error with no quarantine reason, and rejecting it here would dead-end at vm rm.
-	if rec.State != types.VMStateRunning && rec.State != types.VMStateStopped && rec.State != types.VMStateError {
-		return "", nil, fmt.Errorf("vm %s is %s and cannot be restored", vmID, rec.State)
+	if err := restorableState(vmID, &rec); err != nil {
+		return "", nil, err
 	}
 	return vmID, &rec, nil
+}
+
+// restorableState allows Running, Stopped and Error origins. Stopped restores too (hibernate resume): the sequence cold-spawns a fresh VMM either way and the kill step tolerates a dead one. Error VMs are allowed through (quarantine sets Error too) — restore rebuilds the run dir, so it is the recovery path start.go redirects a crashed restore to; FailRestore leaves a running-origin failure in Error with no quarantine reason, and rejecting it here would dead-end at vm rm.
+func restorableState(vmID string, rec *VMRecord) error {
+	if rec.State != types.VMStateRunning && rec.State != types.VMStateStopped && rec.State != types.VMStateError {
+		return fmt.Errorf("vm %s is %s and cannot be restored", vmID, rec.State)
+	}
+	return nil
 }
 
 func (b *Backend) FinalizeRestore(ctx context.Context, vmID string, vmCfg *types.VMConfig, rec *VMRecord, pid int) (*types.VM, error) {
@@ -91,18 +98,7 @@ func (b *Backend) RestoreSequence(ctx context.Context, vmRef string, spec Restor
 	if preflightErr := spec.Preflight(stagingDir, rec); preflightErr != nil {
 		return nil, fmt.Errorf("snapshot preflight: %w", preflightErr)
 	}
-	oldShape := shapeFromConfig(rec.Config)
-	if killErr := spec.Kill(ctx, vmID, rec); killErr != nil {
-		return nil, killErr
-	}
-	b.emitRestoreComputeStop(ctx, vmID, oldShape, spec.SourceSnapshotID)
-
-	var result *types.VM
-	inner := func() error {
-		// Tombstone before the destructive phase: it survives lost quarantine writes and process death; only FinalizeRestore clears it.
-		if err := markRestoreDirty(rec.RunDir); err != nil {
-			return err
-		}
+	apply := func(rec *VMRecord) error {
 		if spec.BeforeMerge != nil {
 			if err := spec.BeforeMerge(rec); err != nil {
 				// The sweep may already have deleted snapshot files; a stopped origin would otherwise stay startable on mixed state.
@@ -115,16 +111,9 @@ func (b *Backend) RestoreSequence(ctx context.Context, vmRef string, spec Restor
 			b.QuarantineVM(ctx, vmID, "partial snapshot merge")
 			return fmt.Errorf("apply staged snapshot: %w", mergeErr)
 		}
-		var afterErr error
-		result, afterErr = spec.AfterExtract(ctx, vmID, spec.VMCfg, rec)
-		return afterErr
+		return nil
 	}
-	if err := runWrapped(rec, spec.Wrap, inner); err != nil {
-		b.FailRestore(ctx, vmID, rec.State)
-		return nil, err
-	}
-	b.emitRestoreSuccess(ctx, result, oldShape, spec.SourceSnapshotID)
-	return result, nil
+	return b.restoreCore(ctx, vmID, rec, spec.VMCfg, spec.SourceSnapshotID, spec.Kill, spec.Wrap, apply, spec.AfterExtract)
 }
 
 // DirectRestoreSequence restores from a local snapshot directory.
@@ -141,31 +130,49 @@ func (b *Backend) DirectRestoreSequence(ctx context.Context, vmRef string, spec 
 	if preflightErr := spec.Preflight(spec.SrcDir, rec); preflightErr != nil {
 		return nil, fmt.Errorf("snapshot preflight: %w", preflightErr)
 	}
-	oldShape := shapeFromConfig(rec.Config)
-	if killErr := spec.Kill(ctx, vmID, rec); killErr != nil {
-		return nil, killErr
-	}
-	b.emitRestoreComputeStop(ctx, vmID, oldShape, spec.SourceSnapshotID)
-
-	var result *types.VM
-	inner := func() error {
-		if err := markRestoreDirty(rec.RunDir); err != nil {
-			return err
-		}
+	apply := func(rec *VMRecord) error {
 		if populateErr := spec.Populate(rec, spec.SrcDir); populateErr != nil {
 			// Populate cleans then clones with no rollback; a partial run dir must quarantine regardless of origin, like the merge.
 			b.QuarantineVM(ctx, vmID, "partial restore populate")
 			return populateErr
 		}
+		return nil
+	}
+	return b.restoreCore(ctx, vmID, rec, spec.VMCfg, spec.SourceSnapshotID, spec.Kill, spec.Wrap, apply, spec.AfterExtract)
+}
+
+// restoreCore is the shared kill→emit→apply→finalize tail of both restore sequences.
+func (b *Backend) restoreCore(
+	ctx context.Context, vmID string, rec *VMRecord, vmCfg *types.VMConfig, sourceSnapshotID string,
+	kill func(ctx context.Context, vmID string, rec *VMRecord) error,
+	wrap func(*VMRecord, func() error) error,
+	apply func(*VMRecord) error,
+	afterExtract func(ctx context.Context, vmID string, vmCfg *types.VMConfig, rec *VMRecord) (*types.VM, error),
+) (*types.VM, error) {
+	oldShape := shapeFromConfig(rec.Config)
+	if killErr := kill(ctx, vmID, rec); killErr != nil {
+		return nil, killErr
+	}
+	b.emitRestoreComputeStop(ctx, vmID, oldShape, sourceSnapshotID)
+
+	var result *types.VM
+	inner := func() error {
+		// Tombstone before the destructive phase: it survives lost quarantine writes and process death; only FinalizeRestore clears it.
+		if err := markRestoreDirty(rec.RunDir); err != nil {
+			return err
+		}
+		if err := apply(rec); err != nil {
+			return err
+		}
 		var afterErr error
-		result, afterErr = spec.AfterExtract(ctx, vmID, spec.VMCfg, rec)
+		result, afterErr = afterExtract(ctx, vmID, vmCfg, rec)
 		return afterErr
 	}
-	if err := runWrapped(rec, spec.Wrap, inner); err != nil {
+	if err := runWrapped(rec, wrap, inner); err != nil {
 		b.FailRestore(ctx, vmID, rec.State)
 		return nil, err
 	}
-	b.emitRestoreSuccess(ctx, result, oldShape, spec.SourceSnapshotID)
+	b.emitRestoreSuccess(ctx, result, oldShape, sourceSnapshotID)
 	return result, nil
 }
 
@@ -182,13 +189,13 @@ func (b *Backend) prepareRestore(ctx context.Context, vmRef string) (string, *VM
 		unlock()
 		return "", nil, nil, err
 	}
-	if gErr := b.EntryGuard(ctx, vmID); gErr != nil {
-		return fail(gErr)
-	}
-	// Revalidate under the lock: the pre-lock record may predate a concurrent mutating verb, and preflight anchors the external trust set to it.
-	vmID, rec, err := b.ResolveForRestore(ctx, vmID)
+	// Revalidate under the lock (from the guard's own transaction): the pre-lock record may predate a concurrent mutating verb, and preflight anchors the external trust set to it.
+	rec, err := b.EntryGuardLoad(ctx, vmID)
 	if err != nil {
 		return fail(err)
+	}
+	if sErr := restorableState(vmID, &rec); sErr != nil {
+		return fail(sErr)
 	}
 	if vErr := types.ValidateStorageConfigs(rec.StorageConfigs); vErr != nil {
 		return fail(fmt.Errorf("storage invariants violated: %w", vErr))
@@ -196,7 +203,7 @@ func (b *Backend) prepareRestore(ctx context.Context, vmRef string) (string, *VM
 	if vErr := types.ValidateNetworkConfigs(rec.NetworkConfigs); vErr != nil {
 		return fail(fmt.Errorf("network invariants violated: %w", vErr))
 	}
-	return vmID, rec, unlock, nil
+	return vmID, &rec, unlock, nil
 }
 
 // emitRestoreComputeStop closes the compute interval after a confirmed kill; fail-closed on DB error and skip on vanished record so the ledger never gets a phantom entry.

--- a/hypervisor/snapshot.go
+++ b/hypervisor/snapshot.go
@@ -166,10 +166,7 @@ func (b *Backend) prepareSnapshot(ctx context.Context, ref string) (string, VMRe
 		unlock()
 		return "", VMRecord{}, "", nil, err
 	}
-	if gErr := b.EntryGuard(ctx, vmID); gErr != nil {
-		return fail(gErr)
-	}
-	rec, err := b.LoadRecord(ctx, vmID)
+	rec, err := b.EntryGuardLoad(ctx, vmID)
 	if err != nil {
 		return fail(err)
 	}

--- a/hypervisor/start.go
+++ b/hypervisor/start.go
@@ -70,10 +70,7 @@ func (b *Backend) StartSequence(ctx context.Context, id string, spec StartSpec) 
 
 // PrepareStart loads the record, refuses quarantined VMs, verifies not-running, ensures dirs exist.
 func (b *Backend) PrepareStart(ctx context.Context, id string, runtimeFiles []string) (*VMRecord, error) {
-	if err := b.EntryGuard(ctx, id); err != nil {
-		return nil, err
-	}
-	rec, err := b.LoadRecord(ctx, id)
+	rec, err := b.EntryGuardLoad(ctx, id)
 	if err != nil {
 		return nil, err
 	}

--- a/hypervisor/teardown.go
+++ b/hypervisor/teardown.go
@@ -132,14 +132,40 @@ func (b *Backend) recoverVMTombstone(ctx context.Context, id string, teardown Ne
 // roll a leased tombstone back in place; drive a deleting one to completion —
 // including the injected network cleanup — and refuse the operation.
 func (b *Backend) EntryGuard(ctx context.Context, id string) error {
-	err := b.update(ctx, func(t *vmTx) error { return b.guardVMTombstone(ctx, t, id) })
+	_, err := b.entryGuard(ctx, id)
+	return err
+}
+
+// EntryGuardLoad is EntryGuard returning the VM's record from the guard's own
+// transaction, sparing lock-held entry paths a second whole-namespace read.
+func (b *Backend) EntryGuardLoad(ctx context.Context, id string) (VMRecord, error) {
+	rec, err := b.entryGuard(ctx, id)
+	if err != nil {
+		return VMRecord{}, err
+	}
+	if rec == nil {
+		return VMRecord{}, fmt.Errorf("%q not found", id)
+	}
+	return *rec, nil
+}
+
+func (b *Backend) entryGuard(ctx context.Context, id string) (*VMRecord, error) {
+	var rec *VMRecord
+	err := b.update(ctx, func(t *vmTx) error {
+		if err := b.guardVMTombstone(ctx, t, id); err != nil {
+			return err
+		}
+		var getErr error
+		rec, getErr = t.Get(id)
+		return getErr
+	})
 	if !errors.Is(err, ErrTombstoned) {
-		return err
+		return rec, err
 	}
 	if _, rerr := b.recoverVMTombstone(ctx, id, b.NetCleanup); rerr != nil {
-		return fmt.Errorf("vm %s: recover interrupted delete: %w", id, rerr)
+		return nil, fmt.Errorf("vm %s: recover interrupted delete: %w", id, rerr)
 	}
-	return fmt.Errorf("vm %s was partially deleted; recovery finished the removal: %w", id, ErrNotFound)
+	return nil, fmt.Errorf("vm %s was partially deleted; recovery finished the removal: %w", id, ErrNotFound)
 }
 
 // guardVMTombstone refuses tombstoned VMs inside the entrypoint's own

--- a/images/cloudimg/import.go
+++ b/images/cloudimg/import.go
@@ -68,6 +68,11 @@ func importQcow2File(ctx context.Context, conf *Config, store *images.Store[imag
 			filePath, digestHex[:12], verifyHex[:12])
 	}
 
+	return finishQcow2Import(ctx, conf, store, name, tracker, tmpPath, digestHex, logger)
+}
+
+// finishQcow2Import commits the temp blob and logs the completion line shared by every import variant.
+func finishQcow2Import(ctx context.Context, conf *Config, store *images.Store[imageEntry], name string, tracker progress.Tracker, tmpPath, digestHex string, logger *log.Fields) error {
 	if err := commit(ctx, conf, store, name, tracker, tmpPath, digestHex); err != nil {
 		return err
 	}
@@ -101,12 +106,7 @@ func importQcow2Reader(ctx context.Context, conf *Config, store *images.Store[im
 
 	digestHex := hex.EncodeToString(h.Sum(nil))
 	logger.Debugf(ctx, "buffered stream -> sha256:%s", digestHex[:12])
-
-	if err := commit(ctx, conf, store, name, tracker, tmpPath, digestHex); err != nil {
-		return err
-	}
-	logger.Infof(ctx, "import complete: %s -> sha256:%s", name, digestHex)
-	return nil
+	return finishQcow2Import(ctx, conf, store, name, tracker, tmpPath, digestHex, logger)
 }
 
 func importQcow2Concat(ctx context.Context, conf *Config, store *images.Store[imageEntry], name string, tracker progress.Tracker, file ...string) error {
@@ -145,12 +145,7 @@ func importQcow2Concat(ctx context.Context, conf *Config, store *images.Store[im
 
 	digestHex := hex.EncodeToString(h.Sum(nil))
 	logger.Debugf(ctx, "concatenated %d file(s) -> sha256:%s", len(file), digestHex[:12])
-
-	if err := commit(ctx, conf, store, name, tracker, tmpPath, digestHex); err != nil {
-		return err
-	}
-	logger.Infof(ctx, "import complete: %s -> sha256:%s", name, digestHex)
-	return nil
+	return finishQcow2Import(ctx, conf, store, name, tracker, tmpPath, digestHex, logger)
 }
 
 func sniffConcatHead(file []string) error {

--- a/images/oci/pull.go
+++ b/images/oci/pull.go
@@ -31,8 +31,10 @@ func pull(ctx context.Context, conf *Config, store *images.Store[imageEntry], im
 
 	// Heavy work (downloads, EROFS conversion, blob renames) runs outside any transaction under finishImport's per-digest locks; the up-to-date pre-check is racy but benign since the whole flow is idempotent per digest.
 	var upToDate bool
+	var knownBootHexes map[string]struct{}
 	if err := store.View(ctx, func(idx *imageIndex) error {
 		upToDate = isUpToDate(conf, idx, ref, digestHex)
+		knownBootHexes = collectBootHexes(idx)
 		return nil
 	}); err != nil {
 		return err
@@ -40,13 +42,6 @@ func pull(ctx context.Context, conf *Config, store *images.Store[imageEntry], im
 	if upToDate {
 		logger.Debugf(ctx, "Already up to date: %s (digest: sha256:%s)", ref, digestHex)
 		return nil
-	}
-	var knownBootHexes map[string]struct{}
-	if err := store.View(ctx, func(idx *imageIndex) error {
-		knownBootHexes = collectBootHexes(idx)
-		return nil
-	}); err != nil {
-		return err
 	}
 
 	tracker.OnEvent(ociProgress.Event{Phase: ociProgress.PhasePull, Index: -1, Total: len(layers)})

--- a/images/store.go
+++ b/images/store.go
@@ -12,9 +12,8 @@ import (
 	"github.com/cocoonstack/cocoon/meta"
 )
 
-const (
-	TableRecords = "records"
-)
+// TableRecords is the image-namespace records table.
+const TableRecords = "records"
 
 // Store is one image namespace on the shared meta engine, presenting the
 // legacy whole-index closure shape over record primitives: image lookups are

--- a/lock/vmlock/vmlock.go
+++ b/lock/vmlock/vmlock.go
@@ -2,11 +2,10 @@
 package vmlock
 
 import (
-	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/cocoonstack/cocoon/lock/flock"
+	"github.com/cocoonstack/cocoon/utils"
 )
 
 // Path returns the lock file path for vmID under rootDir.
@@ -17,8 +16,8 @@ func Path(rootDir, vmID string) string {
 // New returns vmID's operation lock, creating the lock directory on demand.
 func New(rootDir, vmID string) (*flock.Lock, error) {
 	p := Path(rootDir, vmID)
-	if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
-		return nil, fmt.Errorf("ensure vm lock dir: %w", err)
+	if err := utils.EnsureDirs(filepath.Dir(p)); err != nil {
+		return nil, err
 	}
 	return flock.New(p), nil
 }

--- a/meta/json/multiprocess_test.go
+++ b/meta/json/multiprocess_test.go
@@ -41,7 +41,8 @@ func TestMultiProcessCorrectness(t *testing.T) {
 	cmds := make([]*exec.Cmd, 0, workers)
 	for w := range workers {
 		cmd := exec.Command(os.Args[0], "-test.run=TestMultiProcessWorker$", "-test.count=1") //nolint:gosec
-		cmd.Env = append(os.Environ(),
+		cmd.Env = append(
+			os.Environ(),
 			"META_MP_DIR="+dir,
 			"META_MP_WORKER="+strconv.Itoa(w),
 			fmt.Sprintf("META_MP_OPS=%d", mpOps),
@@ -125,7 +126,8 @@ func TestInverseScopeNoDeadlock(t *testing.T) {
 	cmds := make([]*exec.Cmd, 0, 2*inverseWorkers)
 	for w := range 2 * inverseWorkers {
 		cmd := exec.Command(os.Args[0], "-test.run=TestInverseScopeWorker$", "-test.count=1") //nolint:gosec
-		cmd.Env = append(os.Environ(),
+		cmd.Env = append(
+			os.Environ(),
 			"META_MP_DIR="+dir,
 			"META_MP_WORKER="+strconv.Itoa(w),
 			"META_MP_SCOPE="+scopes[w%2],

--- a/meta/json/store.go
+++ b/meta/json/store.go
@@ -297,11 +297,11 @@ func crash(step string) error {
 	return testCrashStep(step)
 }
 
+var _ meta.Reader = (*txReader)(nil)
+
 type txReader struct {
 	models map[string]*loaded
 }
-
-var _ meta.Reader = (*txReader)(nil)
 
 func (r *txReader) GetRaw(_ context.Context, ns, table, id string) (json.RawMessage, bool, error) {
 	l, ok := r.models[ns]
@@ -324,14 +324,14 @@ func (r *txReader) ScanRaw(_ context.Context, ns, table string, fn func(id strin
 	})
 }
 
+var _ meta.Writer = (*txWriter)(nil)
+
 type txWriter struct {
 	txReader
 	write string
 	model *Model
 	mode  meta.CommitMode
 }
-
-var _ meta.Writer = (*txWriter)(nil)
 
 func (w *txWriter) PutRaw(_ context.Context, ns, table, id string, raw json.RawMessage, relaxedOK bool) error {
 	if err := w.check(ns, relaxedOK); err != nil {

--- a/meta/sqlite/multiprocess_test.go
+++ b/meta/sqlite/multiprocess_test.go
@@ -72,7 +72,8 @@ func TestMultiProcessCorrectness(t *testing.T) {
 	cmds := make([]*exec.Cmd, 0, workers)
 	for w := range workers {
 		cmd := exec.Command(os.Args[0], "-test.run=TestMultiProcessWorker$", "-test.count=1") //nolint:gosec
-		cmd.Env = append(os.Environ(),
+		cmd.Env = append(
+			os.Environ(),
 			"META_MP_DIR="+dir,
 			"META_MP_WORKER="+strconv.Itoa(w),
 			fmt.Sprintf("META_MP_OPS=%d", mpOps),
@@ -158,7 +159,8 @@ func TestInverseScopeNoDeadlock(t *testing.T) {
 	cmds := make([]*exec.Cmd, 0, 2*inverseWorkers)
 	for w := range 2 * inverseWorkers {
 		cmd := exec.Command(os.Args[0], "-test.run=TestInverseScopeWorker$", "-test.count=1") //nolint:gosec
-		cmd.Env = append(os.Environ(),
+		cmd.Env = append(
+			os.Environ(),
 			"META_MP_DIR="+dir,
 			"META_MP_WORKER="+strconv.Itoa(w),
 			"META_MP_SCOPE="+scopes[w%2],

--- a/meta/sqlite/store.go
+++ b/meta/sqlite/store.go
@@ -290,6 +290,15 @@ func (s *Store) verifyIdentity() error {
 	return nil
 }
 
+// RefuseManifest fails when a conversion manifest sits beside dbPath, meaning an offline conversion is unfinished.
+func RefuseManifest(dbPath string) error {
+	manifest := filepath.Join(filepath.Dir(dbPath), ManifestName)
+	if utils.FileExists(manifest) {
+		return fmt.Errorf("%s exists: a conversion is in flight, run `cocoon meta convert` to finish it", manifest)
+	}
+	return nil
+}
+
 func tableName(ns, table string) string {
 	return quoteIdent(ns + "__" + table)
 }
@@ -410,6 +419,11 @@ func mapErr(err error) error {
 	}
 }
 
+var (
+	_ meta.Reader = (*txHandle)(nil)
+	_ meta.Writer = (*txHandle)(nil)
+)
+
 // txHandle implements Reader/Writer over one transaction; values are
 // detached by construction (every read allocates from row scans).
 type txHandle struct {
@@ -420,11 +434,6 @@ type txHandle struct {
 	write string
 	mode  meta.CommitMode
 }
-
-var (
-	_ meta.Reader = (*txHandle)(nil)
-	_ meta.Writer = (*txHandle)(nil)
-)
 
 func (h *txHandle) GetRaw(ctx context.Context, ns, table, id string) (json.RawMessage, bool, error) {
 	if err := h.checkRead(ns); err != nil {
@@ -516,14 +525,6 @@ func (h *txHandle) checkWrite(ns string, relaxedOK bool) error {
 	}
 	if h.mode == meta.CommitRelaxed && !relaxedOK {
 		return fmt.Errorf("write %s: %w", ns, meta.ErrDurabilityContract)
-	}
-	return nil
-}
-
-func RefuseManifest(dbPath string) error {
-	manifest := filepath.Join(filepath.Dir(dbPath), ManifestName)
-	if utils.FileExists(manifest) {
-		return fmt.Errorf("%s exists: a conversion is in flight, run `cocoon meta convert` to finish it", manifest)
 	}
 	return nil
 }

--- a/meta/tombstone/tombstone.go
+++ b/meta/tombstone/tombstone.go
@@ -150,15 +150,6 @@ func (t *Table) fenced(ctx context.Context, w meta.Writer, id, leaseID string) (
 	return rec, nil
 }
 
-// MarshalCleanup encodes a namespace-defined cleanup payload.
-func MarshalCleanup(v any) (json.RawMessage, error) {
-	raw, err := json.Marshal(v)
-	if err != nil {
-		return nil, fmt.Errorf("encode cleanup payload: %w", err)
-	}
-	return raw, nil
-}
-
 // PendingIDs lists every tombstoned id (the recovery sweep's work list).
 func (t *Table) PendingIDs(ctx context.Context, r meta.Reader) ([]string, error) {
 	var ids []string
@@ -209,4 +200,13 @@ func (t *Table) Resume(ctx context.Context, w meta.Writer, id string) (rec *Reco
 		return rec, taken.LeaseID, t.Rollback(ctx, w, id, taken.LeaseID)
 	}
 	return rec, taken.LeaseID, nil
+}
+
+// MarshalCleanup encodes a namespace-defined cleanup payload.
+func MarshalCleanup(v any) (json.RawMessage, error) {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("encode cleanup payload: %w", err)
+	}
+	return raw, nil
 }

--- a/network/bridge/bridge_linux.go
+++ b/network/bridge/bridge_linux.go
@@ -181,7 +181,7 @@ func (b *Bridge) List(_ context.Context) ([]*types.Network, error) {
 
 // RegisterGC reclaims orphan bt* TAP devices.
 func (b *Bridge) RegisterGC(orch *gc.Orchestrator) {
-	gc.Register(orch, GCModule(b.conf.RootDir))
+	gc.Register(orch, GCModule())
 }
 
 // CleanupTAPs removes bridge TAP devices per VM ID; safe without a Bridge instance.

--- a/network/bridge/gc_linux.go
+++ b/network/bridge/gc_linux.go
@@ -23,7 +23,7 @@ type bridgeSnapshot struct {
 }
 
 // GCModule returns a GC module reclaiming orphan bt* TAP devices; it needs no Bridge instance.
-func GCModule(_ string) gc.Module[bridgeSnapshot] {
+func GCModule() gc.Module[bridgeSnapshot] {
 	return gc.Module[bridgeSnapshot]{
 		Name: typ,
 		ReadDB: func(_ context.Context) (bridgeSnapshot, error) {

--- a/network/bridge/gc_other.go
+++ b/network/bridge/gc_other.go
@@ -12,7 +12,7 @@ import (
 type bridgeSnapshot struct{}
 
 // GCModule returns a no-op GC module on non-Linux — bridge TAPs don't exist.
-func GCModule(rootDir string) gc.Module[bridgeSnapshot] {
+func GCModule() gc.Module[bridgeSnapshot] {
 	return gc.Module[bridgeSnapshot]{
 		Name: "bridge",
 		ReadDB: func(_ context.Context) (bridgeSnapshot, error) {

--- a/snapshot/localfile/gc.go
+++ b/snapshot/localfile/gc.go
@@ -11,7 +11,6 @@ import (
 	"slices"
 	"time"
 
-	gofrsflock "github.com/gofrs/flock"
 	"github.com/projecteru2/core/log"
 
 	"github.com/cocoonstack/cocoon/gc"
@@ -139,15 +138,12 @@ func gcModule(lf *LocalFile, policy EvictionPolicy) gc.Module[snapshotGCSnapshot
 					break
 				}
 				// Exclusive lease: an active clone/restore/export holds it shared; skip and retry next cycle.
-				fl := gofrsflock.New(conf.LeasePath(id))
-				locked, lockErr := fl.TryLock()
+				fl, ok, lockErr := lf.tryExclusiveLease(id)
 				if lockErr != nil {
-					_ = fl.Close()
-					errs = append(errs, fmt.Errorf("lease snapshot %s: %w", id, lockErr))
+					errs = append(errs, lockErr)
 					continue
 				}
-				if !locked {
-					_ = fl.Close()
+				if !ok {
 					logger.Warnf(ctx, "skip %s: leased by an active reader", id)
 					continue
 				}

--- a/snapshot/localfile/import.go
+++ b/snapshot/localfile/import.go
@@ -34,8 +34,8 @@ func (lf *LocalFile) Import(ctx context.Context, r io.Reader, name, description 
 	}
 	defer release()
 
-	if err = os.MkdirAll(dataDir, 0o750); err != nil {
-		return "", fmt.Errorf("create data dir: %w", err)
+	if err = utils.EnsureDirs(dataDir); err != nil {
+		return "", err
 	}
 	defer func() {
 		if err != nil {

--- a/snapshot/localfile/localfile.go
+++ b/snapshot/localfile/localfile.go
@@ -136,8 +136,8 @@ func (lf *LocalFile) Create(ctx context.Context, cfg *types.SnapshotConfig, stre
 		}
 	}()
 
-	if err = os.MkdirAll(dataDir, 0o750); err != nil {
-		return "", fmt.Errorf("create data dir: %w", err)
+	if err = utils.EnsureDirs(dataDir); err != nil {
+		return "", err
 	}
 	if err = utils.ExtractTar(dataDir, stream); err != nil {
 		return "", fmt.Errorf("extract snapshot data: %w", err)
@@ -258,16 +258,28 @@ func (lf *LocalFile) RegisterGC(orch *gc.Orchestrator) {
 	gc.Register(orch, gcModule(lf, lf.gcPolicy))
 }
 
-// acquireBuildLease exclusively leases id while its data dir is being built (Create/Import), so rm/GC cannot resolve-and-delete the half-written dir.
-func (lf *LocalFile) acquireBuildLease(id string) (func(), error) {
-	fl := gofrsflock.New(lf.conf.LeasePath(id))
+// tryExclusiveLease TryLocks id's lease file; ok=false means an active holder. The caller owns fl.Close() when ok.
+func (lf *LocalFile) tryExclusiveLease(id string) (fl *gofrsflock.Flock, ok bool, err error) {
+	fl = gofrsflock.New(lf.conf.LeasePath(id))
 	locked, err := fl.TryLock()
 	if err != nil {
 		_ = fl.Close()
-		return nil, fmt.Errorf("lease snapshot %s: %w", id, err)
+		return nil, false, fmt.Errorf("lease snapshot %s: %w", id, err)
 	}
 	if !locked {
 		_ = fl.Close()
+		return nil, false, nil
+	}
+	return fl, true, nil
+}
+
+// acquireBuildLease exclusively leases id while its data dir is being built (Create/Import), so rm/GC cannot resolve-and-delete the half-written dir.
+func (lf *LocalFile) acquireBuildLease(id string) (func(), error) {
+	fl, ok, err := lf.tryExclusiveLease(id)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
 		return nil, fmt.Errorf("snapshot %s is in use", id)
 	}
 	return func() { _ = fl.Close() }, nil
@@ -290,14 +302,11 @@ func (lf *LocalFile) acquireReadLease(ctx context.Context, id string) (func(), e
 
 // deleteOne is idempotent under concurrent rm; the rival's emit is skipped so the ledger keeps exactly one stop per snapshot.
 func (lf *LocalFile) deleteOne(ctx context.Context, id string) error {
-	fl := gofrsflock.New(lf.conf.LeasePath(id))
-	locked, err := fl.TryLock()
+	fl, ok, err := lf.tryExclusiveLease(id)
 	if err != nil {
-		_ = fl.Close()
-		return fmt.Errorf("lease snapshot %s: %w", id, err)
+		return err
 	}
-	if !locked {
-		_ = fl.Close()
+	if !ok {
 		return fmt.Errorf("snapshot %s is in use by an active clone/restore/export", id)
 	}
 	defer fl.Close() //nolint:errcheck

--- a/snapshot/localfile/teardown.go
+++ b/snapshot/localfile/teardown.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 
-	gofrsflock "github.com/gofrs/flock"
 	"github.com/projecteru2/core/log"
 
 	"github.com/cocoonstack/cocoon/meta/tombstone"
@@ -107,12 +106,11 @@ func (lf *LocalFile) finishSnapTeardown(ctx context.Context, id, leaseID string,
 // recoverSnapTombstone drives id's tombstone under a freshly acquired
 // exclusive lease: leased rolls back, deleting rolls forward.
 func (lf *LocalFile) recoverSnapTombstone(ctx context.Context, id string) error {
-	fl := gofrsflock.New(lf.conf.LeasePath(id))
-	locked, err := fl.TryLock()
+	fl, ok, err := lf.tryExclusiveLease(id)
 	if err != nil {
-		return fmt.Errorf("lease snapshot %s: %w", id, err)
+		return err
 	}
-	if !locked {
+	if !ok {
 		return nil // an active holder will meet the tombstone at its own entrypoint
 	}
 	defer fl.Close() //nolint:errcheck

--- a/utils/http.go
+++ b/utils/http.go
@@ -122,16 +122,27 @@ func IsRetryable(err error) bool {
 	return true
 }
 
-// DoAPIWithRetry wraps DoAPI in DoWithRetry; successCodes[0] is primary, codes[1:] are also accepted (silent nil-body).
+// DoAPIWithRetry wraps DoAPIOnce in DoWithRetry; successCodes[0] is primary, codes[1:] are also accepted (silent nil-body).
 func DoAPIWithRetry(ctx context.Context, hc *http.Client, method, url string, body []byte, successCodes ...int) ([]byte, error) {
 	return DoWithRetry(ctx, func() ([]byte, error) {
-		return doAPI(ctx, hc, method, url, body, successCodes...)
+		return DoAPIOnce(ctx, hc, method, url, body, successCodes...)
 	})
 }
 
-// DoAPIOnce sends a single non-retried request; use for non-idempotent endpoints where retry would surface as duplicate/conflict (e.g. vm.add-fs, snapshot/create).
+// DoAPIOnce sends a single non-retried request with successCodes defaulting to 204 (codes[1:] are tolerated alts, nil body); use for non-idempotent endpoints where retry would surface as duplicate/conflict (e.g. vm.add-fs, snapshot/create).
 func DoAPIOnce(ctx context.Context, hc *http.Client, method, url string, body []byte, successCodes ...int) ([]byte, error) {
-	return doAPI(ctx, hc, method, url, body, successCodes...)
+	primary := http.StatusNoContent
+	if len(successCodes) > 0 {
+		primary = successCodes[0]
+	}
+	resp, apiErr := DoAPI(ctx, hc, method, url, body, primary)
+	if apiErr == nil {
+		return resp, nil
+	}
+	if ae, ok := errors.AsType[*APIError](apiErr); ok && len(successCodes) > 1 && slices.Contains(successCodes[1:], ae.Code) {
+		return nil, nil
+	}
+	return nil, apiErr
 }
 
 // DoJSONOnce marshals payload and sends it via DoAPIOnce; kind names the payload in the marshal error.
@@ -150,20 +161,4 @@ func DoJSONWithRetry[T any](ctx context.Context, hc *http.Client, method, url, k
 		return nil, fmt.Errorf("marshal %s: %w", kind, err)
 	}
 	return DoAPIWithRetry(ctx, hc, method, url, body, successCodes...)
-}
-
-// doAPI is DoAPI with successCodes defaulting to 204; codes[1:] are tolerated alts (return nil body).
-func doAPI(ctx context.Context, hc *http.Client, method, url string, body []byte, successCodes ...int) ([]byte, error) {
-	primary := http.StatusNoContent
-	if len(successCodes) > 0 {
-		primary = successCodes[0]
-	}
-	resp, apiErr := DoAPI(ctx, hc, method, url, body, primary)
-	if apiErr == nil {
-		return resp, nil
-	}
-	if ae, ok := errors.AsType[*APIError](apiErr); ok && len(successCodes) > 1 && slices.Contains(successCodes[1:], ae.Code) {
-		return nil, nil
-	}
-	return nil, apiErr
 }

--- a/utils/reflink_linux.go
+++ b/utils/reflink_linux.go
@@ -24,9 +24,7 @@ func tryFiclone(dst, src string, sync SyncMode) error {
 		if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, dstFile.Fd(), ficlone, srcFile.Fd()); errno != 0 {
 			return fmt.Errorf("ficlone: %w", errno)
 		}
-		// FICLONE only shares extents; honor the caller's durability request
-		// like SparseCopy does, or a Sync export is silently non-durable on
-		// the CoW filesystems where the fast path succeeds.
+		// FICLONE only shares extents — still honor Sync, or the fast path silently drops durability.
 		if sync == Sync {
 			if err := dstFile.Sync(); err != nil {
 				return fmt.Errorf("sync dst: %w", err)


### PR DESCRIPTION
Whole-repo quality round against the #118 closeout baseline (a590838): a full per-file style walkthrough, a four-lens simplify pass, and a production-LOC justify audit. Net -16 prod lines (before the fmt commit).

## review: whole-repo /code pass (4ff680e)

- compile-time interface checks moved above their implementing types (meta/json txReader/txWriter, meta/sqlite txHandle)
- MarshalCleanup moved out of the tombstone.Table method block; RefuseManifest hoisted above private utilities with godoc
- bare single-entry const in images/store.go
- storebench argDir: panic replaced with stderr+exit
- comment budget: dropped one restating godoc line (DNSServers), compressed the tryFiclone WHY to one line

## simplify: reuse / simplification / efficiency (38ae906)

Reuse:
- localfile: four TryLock+close-on-fail lease blocks folded into tryExclusiveLease — this incidentally fixes a latent fd leak in recoverSnapTombstone, whose old inline block never closed the flock fd on the TryLock-error and already-held paths
- detectLocalImportSource uses utils.FileHead; patchCHConfig uses utils.ReadJSONFile; EnsureDirs replaces raw MkdirAll at three sites; cloudimg import shares one finishQcow2Import tail

Simplification:
- utils/http: doAPI folded into DoAPIOnce (wrapper removed)
- cmd/vm: single-caller runRoutedLoop/finishRoutedCmd inlined into batchRoutedCmd
- hypervisor: restoreCore extracts the kill/emit/apply/finalize tail shared by RestoreSequence and DirectRestoreSequence
- dead fields dropped (fcSnapshotLoad.EnableDiffSnapshots/ResumeVM, chBalloon.ID, chPciDeviceInfo.BDF), dead tty CLI case, dead bridge GCModule param

Efficiency (claim path):
- EntryGuardLoad returns the record from the guard's own transaction — one whole-namespace read instead of two on start/snapshot/restore/netresize/device-attach
- oci pull: two back-to-back store.View calls merged into one
- PrepareDataDisks fans out sparse-create+mkfs via utils.Map (same treatment as copyPairs); note: under simultaneous multi-disk failure the reported disk is first-error-wins rather than lowest-index, matching the existing copyPairs semantics

## fmt: gofumpt -extra convergence (6deb1ad)

make fmt-check failed because gofumpt -extra oscillated on benchConfig's aligned method block; the over-wide lines were the dead IndexFile/IndexLock methods (not part of BackendConfig, no callers) — removed, plus -extra formatting on two multiprocess test files left over from #147/#148.

## LOC audit (report-only)

- prod 26,427 (effective 22,082), comments 5.7%; +5,270 prod since the baseline, 91.5% of it the meta P0-P3 project (#147/#148), the rest incident-backed fixes and benched perf work; review-labeled commits are net negative (-151)
- 22-mechanism provenance ledger (design doc / named incident / review-caught bug): all EARNED, empty cut-list; unreachable-defense scan returned zero findings
- known test gaps recorded for a later round: sweepStaleCloneLocks, orchestrator-level recover-before-discovery, sqlite checkpointLoop goroutine

## Gates

- golangci-lint: 0 issues on GOOS=linux and GOOS=darwin; make fmt-check clean
- go test ./... all packages pass; independent adversarial re-review of the full diff additionally ran go test -race over hypervisor/snapshot/utils/meta/lock and go vet, all clean, and confirmed behavior preservation at every converted call site