### PR TITLE
test: use t.Context() in sqlite maintenance tests

### DIFF
--- a/meta/sqlite/maintenance_test.go
+++ b/meta/sqlite/maintenance_test.go
@@ -126,7 +126,7 @@ func TestBusyCtxDeadline(t *testing.T) {
 	held := make(chan struct{})
 	release := make(chan struct{})
 	go func() {
-		_ = s1.Update(context.Background(), meta.Scope{Write: "vms"}, meta.CommitDurable, func(w meta.Writer) error {
+		_ = s1.Update(t.Context(), meta.Scope{Write: "vms"}, meta.CommitDurable, func(w meta.Writer) error {
 			close(held)
 			<-release
 			return nil
@@ -152,7 +152,7 @@ func TestBusyCtxDeadline(t *testing.T) {
 // concurrent run's stale-tmp cleanup yanks the first run's tmp mid-verify
 // and publishes an empty backup with a nil error.
 func TestBackupConcurrentSameDest(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	dir := t.TempDir()
 	s := newStore(t, dir, "vms")
 	err := s.Update(ctx, meta.Scope{Write: "vms"}, meta.CommitDurable, func(w meta.Writer) error {


### PR DESCRIPTION
Post-#149 sweep of the context rule: the two remaining context.Background() calls in test code (meta/sqlite/maintenance_test.go — the held-writer goroutine in TestBusyCtxDeadline and TestBackupConcurrentSameDest) move to t.Context(), which auto-cancels at the test boundary.

The four production Background() sites were audited and stay: main.go (process root), cliutil.CommandContext (API-boundary fallback, unreachable via ExecuteContext), sqlite checkpointLoop and events notifier (both documented detached-lifetime exceptions).

Gates: go test ./meta/... -count=1 pass, make fmt-check clean.