### PR TITLE
Whole-repo personal re-read: test-side cleanup and SplitRanges min

### DIFF
--- a/hypervisor/gc_test.go
+++ b/hypervisor/gc_test.go
@@ -32,8 +32,7 @@ func TestGCCollectKeepsLockedVM(t *testing.T) {
 	if err != nil {
 		t.Fatalf("vm lock: %v", err)
 	}
-	l := lk
-	if ok, err := l.TryLock(ctx); err != nil || !ok {
+	if ok, err := lk.TryLock(ctx); err != nil || !ok {
 		t.Fatalf("hold ops lock: ok=%v err=%v", ok, err)
 	}
 	snap := VMGCSnapshot{reasons: map[string]string{id: "stale-creating"}}
@@ -44,7 +43,7 @@ func TestGCCollectKeepsLockedVM(t *testing.T) {
 		t.Fatal("record must survive while the ops lock is held (ownership kept)")
 	}
 
-	if err := l.Unlock(ctx); err != nil {
+	if err := lk.Unlock(ctx); err != nil {
 		t.Fatalf("unlock: %v", err)
 	}
 	if err := b.gcCollect(ctx, []string{id}, snap); err != nil {

--- a/hypervisor/meta_test.go
+++ b/hypervisor/meta_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cocoonstack/cocoon/utils"
 )
 
-// newTestMetaStore opens a meta store over conf's index paths for one backend type.
 var testVMTables = metajson.TableCodec{Specs: []metajson.TableSpec{
 	{Key: "vms", Table: TableRecords},
 	{Key: "names", Table: TableNames},
@@ -24,6 +23,7 @@ var testVMTables = metajson.TableCodec{Specs: []metajson.TableSpec{
 	{Key: "tombstones", Table: tombstone.TableName, Optional: true},
 }}
 
+// newTestMetaStore opens a meta store over the given index paths for one backend type.
 func newTestMetaStore(t *testing.T, typ, indexFile, lockPath string) *metajson.Store {
 	t.Helper()
 	store, err := metajson.Open(metajson.Namespace{Name: VMNamespaceName(typ), FilePath: indexFile, LockPath: lockPath, Codec: testVMTables})

--- a/hypervisor/state_test.go
+++ b/hypervisor/state_test.go
@@ -561,8 +561,6 @@ func (stubBackendConfig) PIDFileName() string                 { return "stub.pid
 func (stubBackendConfig) TerminateGracePeriod() time.Duration { return time.Second }
 func (stubBackendConfig) SocketWaitTimeout() time.Duration    { return time.Second }
 func (stubBackendConfig) EffectivePoolSize() int              { return 1 }
-func (c stubBackendConfig) IndexFile() string                 { return c.indexFile }
-func (c stubBackendConfig) IndexLock() string                 { return c.indexLock }
 func (stubBackendConfig) EnsureDirs() error                   { return nil }
 func (stubBackendConfig) RunDir() string                      { panic("RunDir: not implemented in stub") }
 

--- a/images/gc_test.go
+++ b/images/gc_test.go
@@ -17,14 +17,14 @@ type gcTestEntry struct {
 	Digest string `json:"digest"`
 }
 
-// TestGCCollectSkipsRepublishedBlob pins the loose-GC revalidation: a digest
-// that became referenced after the snapshot (a publish finished and released
-// its lock) must survive Collect.
 var testImageTables = metajson.TableCodec{Specs: []metajson.TableSpec{
 	{Key: "images", Table: TableRecords},
 	{Key: "tombstones", Table: tombstone.TableName, Optional: true},
 }}
 
+// TestGCCollectSkipsRepublishedBlob pins the loose-GC revalidation: a digest
+// that became referenced after the snapshot (a publish finished and released
+// its lock) must survive Collect.
 func TestGCCollectSkipsRepublishedBlob(t *testing.T) {
 	ctx := t.Context()
 	dir := t.TempDir()

--- a/meta/json/multiprocess_test.go
+++ b/meta/json/multiprocess_test.go
@@ -2,6 +2,7 @@ package json
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -47,7 +48,7 @@ func TestMultiProcessCorrectness(t *testing.T) {
 			"META_MP_WORKER="+strconv.Itoa(w),
 			fmt.Sprintf("META_MP_OPS=%d", mpOps),
 		)
-		out := &prefixedBuf{}
+		out := &bytes.Buffer{}
 		cmd.Stdout, cmd.Stderr = out, out
 		if err := cmd.Start(); err != nil {
 			t.Fatalf("start worker %d: %v", w, err)
@@ -105,15 +106,6 @@ func TestMultiProcessWorker(t *testing.T) {
 	}
 }
 
-type prefixedBuf struct{ b []byte }
-
-func (p *prefixedBuf) Write(data []byte) (int, error) {
-	p.b = append(p.b, data...)
-	return len(data), nil
-}
-
-func (p *prefixedBuf) String() string { return string(p.b) }
-
 // TestInverseScopeNoDeadlock is the §9 cross-process gate: mutually-inverse
 // scopes (write alpha read beta vs write beta read alpha) storm concurrently
 // and must never deadlock — the engine's fixed global lock order is the proof.
@@ -132,7 +124,7 @@ func TestInverseScopeNoDeadlock(t *testing.T) {
 			"META_MP_WORKER="+strconv.Itoa(w),
 			"META_MP_SCOPE="+scopes[w%2],
 		)
-		out := &prefixedBuf{}
+		out := &bytes.Buffer{}
 		cmd.Stdout, cmd.Stderr = out, out
 		if err := cmd.Start(); err != nil {
 			t.Fatalf("start worker %d: %v", w, err)

--- a/meta/sqlite/multiprocess_test.go
+++ b/meta/sqlite/multiprocess_test.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -78,7 +79,7 @@ func TestMultiProcessCorrectness(t *testing.T) {
 			"META_MP_WORKER="+strconv.Itoa(w),
 			fmt.Sprintf("META_MP_OPS=%d", mpOps),
 		)
-		out := &procBuf{}
+		out := &bytes.Buffer{}
 		cmd.Stdout, cmd.Stderr = out, out
 		if err := cmd.Start(); err != nil {
 			t.Fatalf("start worker %d: %v", w, err)
@@ -165,7 +166,7 @@ func TestInverseScopeNoDeadlock(t *testing.T) {
 			"META_MP_WORKER="+strconv.Itoa(w),
 			"META_MP_SCOPE="+scopes[w%2],
 		)
-		out := &procBuf{}
+		out := &bytes.Buffer{}
 		cmd.Stdout, cmd.Stderr = out, out
 		if err := cmd.Start(); err != nil {
 			t.Fatalf("start worker %d: %v", w, err)
@@ -310,12 +311,3 @@ func TestKillStormWorker(t *testing.T) {
 		fmt.Printf("ACK %s\n", txn)
 	}
 }
-
-type procBuf struct{ b []byte }
-
-func (p *procBuf) Write(data []byte) (int, error) {
-	p.b = append(p.b, data...)
-	return len(data), nil
-}
-
-func (p *procBuf) String() string { return string(p.b) }

--- a/meta/sqlite/store_test.go
+++ b/meta/sqlite/store_test.go
@@ -4,10 +4,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/cocoonstack/cocoon/utils"
-
 	"github.com/cocoonstack/cocoon/meta"
 	"github.com/cocoonstack/cocoon/meta/contracttest"
+	"github.com/cocoonstack/cocoon/utils"
 )
 
 func newStore(t *testing.T, dir string, nss ...string) *Store {

--- a/network/cni/cni_test.go
+++ b/network/cni/cni_test.go
@@ -42,6 +42,11 @@ const (
 	}`
 )
 
+var testNetTables = metajson.TableCodec{Specs: []metajson.TableSpec{
+	{Key: "networks", Table: TableRecords},
+	{Key: "tombstones", Table: tombstone.TableName, Optional: true},
+}}
+
 func TestLoadConfLists(t *testing.T) {
 	t.Run("empty dir errors", func(t *testing.T) {
 		dir := t.TempDir()
@@ -351,11 +356,6 @@ func TestQuiesceNoRecordsSkipsNetns(t *testing.T) {
 }
 
 // newTestCNIWithStore builds a CNI over a real JSON store and a recordingExec-backed libcni.
-var testNetTables = metajson.TableCodec{Specs: []metajson.TableSpec{
-	{Key: "networks", Table: TableRecords},
-	{Key: "tombstones", Table: tombstone.TableName, Optional: true},
-}}
-
 func newTestCNIWithStore(t *testing.T) (*CNI, *recordingExec) {
 	t.Helper()
 	cl, err := libcni.ConfListFromBytes([]byte(bridgeConflist))

--- a/snapshot/localfile/localfile_test.go
+++ b/snapshot/localfile/localfile_test.go
@@ -28,6 +28,12 @@ import (
 	"github.com/cocoonstack/cocoon/utils"
 )
 
+var testSnapTables = metajson.TableCodec{Specs: []metajson.TableSpec{
+	{Key: "snapshots", Table: TableRecords},
+	{Key: "names", Table: TableNames},
+	{Key: "tombstones", Table: tombstone.TableName, Optional: true},
+}}
+
 func TestNew(t *testing.T) {
 	dir := t.TempDir()
 	lf, err := New(&config.Config{RootDir: dir}, metering.NopRecorder{}, newTestMetaStore(t, &config.Config{RootDir: dir}))
@@ -1513,12 +1519,6 @@ func makeExportableSnapshot(t *testing.T, lf *LocalFile, name string, files map[
 	}
 	return id
 }
-
-var testSnapTables = metajson.TableCodec{Specs: []metajson.TableSpec{
-	{Key: "snapshots", Table: TableRecords},
-	{Key: "names", Table: TableNames},
-	{Key: "tombstones", Table: tombstone.TableName, Optional: true},
-}}
 
 // testSnapNamespace mirrors the composition root's snapshots declaration.
 func testSnapNamespace(conf *config.Config) metajson.Namespace {

--- a/snapshot/localfile/localfile_test.go
+++ b/snapshot/localfile/localfile_test.go
@@ -1356,7 +1356,6 @@ func TestExportToDir_RejectNonEmpty(t *testing.T) {
 	}
 }
 
-// testID generates a random snapshot ID for tests.
 func TestCreateSameIDRetryKeepsExistingSnapshot(t *testing.T) {
 	lf := newTestLF(t)
 	ctx := t.Context()

--- a/snapshot/localfile/meta_shim_test.go
+++ b/snapshot/localfile/meta_shim_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/cocoonstack/cocoon/utils"
 )
 
-// dbUpdate is the test-only whole-index shim: materialize, run fn, write the
-// difference back. Production code never uses it.
 // snapshotIndex mirrors the legacy top-level DB shape for shim-based tests.
 type snapshotIndex struct {
 	Snapshots map[string]*snapshot.SnapshotRecord `json:"snapshots"`
@@ -25,6 +23,8 @@ func (idx *snapshotIndex) Init() {
 	utils.InitNamedIndex(&idx.Snapshots, &idx.Names)
 }
 
+// dbUpdate is the test-only whole-index shim: materialize, run fn, write the
+// difference back. Production code never uses it.
 func (lf *LocalFile) dbUpdate(ctx context.Context, fn func(*snapshotIndex) error) error {
 	return lf.update(ctx, func(t *snapTx) error {
 		before, idx, err := materializeSnapIndex(t)
@@ -54,9 +54,6 @@ func materializeSnapIndex(t *snapTx) (*snapshotIndex, *snapshotIndex, error) {
 	idx.Init()
 	var err error
 	if idx.Snapshots, err = t.All(); err != nil {
-		return nil, nil, err
-	}
-	if err := t.Scan(func(string, *snapshot.SnapshotRecord) error { return nil }); err != nil {
 		return nil, nil, err
 	}
 	for _, rec := range idx.Snapshots {

--- a/utils/batch_test.go
+++ b/utils/batch_test.go
@@ -94,13 +94,7 @@ func TestForEach_Concurrent(t *testing.T) {
 	var cur atomic.Int32
 
 	result := ForEach(t.Context(), []string{"a", "b", "c", "d", "e"}, func(_ context.Context, _ string) error {
-		n := cur.Add(1)
-		for {
-			old := peak.Load()
-			if n <= old || peak.CompareAndSwap(old, n) {
-				break
-			}
-		}
+		raisePeak(&peak, cur.Add(1))
 		time.Sleep(50 * time.Millisecond)
 		cur.Add(-1)
 		return nil
@@ -119,13 +113,7 @@ func TestForEach_WithConcurrencyLimit(t *testing.T) {
 	var cur atomic.Int32
 
 	result := ForEach(t.Context(), []string{"a", "b", "c", "d", "e"}, func(_ context.Context, _ string) error {
-		n := cur.Add(1)
-		for {
-			old := peak.Load()
-			if n <= old || peak.CompareAndSwap(old, n) {
-				break
-			}
-		}
+		raisePeak(&peak, cur.Add(1))
 		time.Sleep(50 * time.Millisecond)
 		cur.Add(-1)
 		return nil
@@ -226,13 +214,7 @@ func TestMap_WithConcurrencyLimit(t *testing.T) {
 	var cur atomic.Int32
 
 	results, err := Map(t.Context(), []int{1, 2, 3, 4, 5}, func(_ context.Context, _, n int) (int, error) {
-		c := cur.Add(1)
-		for {
-			old := peak.Load()
-			if c <= old || peak.CompareAndSwap(old, c) {
-				break
-			}
-		}
+		raisePeak(&peak, cur.Add(1))
 		time.Sleep(50 * time.Millisecond)
 		cur.Add(-1)
 		return n * 10, nil
@@ -260,6 +242,16 @@ func TestMap_IndexPassedCorrectly(t *testing.T) {
 	for i, got := range results {
 		if got != want[i] {
 			t.Errorf("results[%d]: got %q, want %q", i, got, want[i])
+		}
+	}
+}
+
+// raisePeak records n into peak when it is a new maximum.
+func raisePeak(peak *atomic.Int32, n int32) {
+	for {
+		old := peak.Load()
+		if n <= old || peak.CompareAndSwap(old, n) {
+			return
 		}
 	}
 }

--- a/utils/httprange.go
+++ b/utils/httprange.go
@@ -13,11 +13,7 @@ func SplitRanges(size int64, n int) [][2]int64 {
 	chunk := (size + int64(n) - 1) / int64(n)
 	ranges := make([][2]int64, 0, n)
 	for start := int64(0); start < size; start += chunk {
-		end := start + chunk - 1
-		if end >= size {
-			end = size - 1
-		}
-		ranges = append(ranges, [2]int64{start, end})
+		ranges = append(ranges, [2]int64{start, min(start+chunk-1, size-1)})
 	}
 	return ranges
 }


### PR DESCRIPTION
Follow-up to #149/#150: a file-by-file personal re-read of every .go file (production and tests) against the /code style checklist and simplify lenses.

## Changes

- **Test declaration layout**: hoist package-level test table vars (`testNetTables`, `testSnapTables`) to top-of-file.
- **Dead code**: drop `stubBackendConfig.IndexFile/IndexLock` (not in `BackendConfig`), a no-op `t.Scan` in the snapshot meta shim, and a pointless lock-var copy in `gc_test.go`.
- **Dedup**: extract `raisePeak` CAS helper replacing three inlined loops in `utils/batch_test.go`; replace hand-rolled `prefixedBuf`/`procBuf` with `bytes.Buffer` in both multiprocess tests.
- **Comments**: fix godoc adjacency (comments sitting on the wrong declaration) in `meta_test.go`, `gc_test.go`, `images/gc_test.go`, `localfile_test.go`.
- **Imports**: merge `meta/sqlite/store_test.go` to the standard three groups.
- **Prod (1 line)**: `utils.SplitRanges` uses the `min` builtin instead of a hand-rolled clamp.

## Verification

- `make fmt-check` clean; `make lint` 0 issues on both GOOS=linux and GOOS=darwin.
- `go test ./...` all green; focused `-race` runs on `meta/json` and `meta/sqlite` pass.
- Independent adversarial review verdict: CLOSED — every change confirmed behavior-preserving (including CAS semantics, buffer concurrency, and SplitRanges edge cases: size=0, size<n, exact multiples).