### PR TITLE
daemon: optional resident supervisor for cocoon-managed VMs (#152 P0+P1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Lightweight MicroVM engine with dual hypervisor backends: [Cloud Hypervisor](htt
 - **Data disks & runtime attach** — extra virtio-blk disks at create/clone time; hot-plug vhost-user-fs shares, VFIO PCI devices, and external raw disks (CH)
 - **Windows guests** — UEFI + Hyper-V enlightenments via the cocoonstack CH/firmware forks
 - **Firecracker backend** — `--fc` for ~125ms boots and <5 MiB per-VM overhead (OCI images only)
-- **Zero-daemon architecture** — one hypervisor process per VM; modular lock-safe GC with snapshot LRU eviction
+- **Daemon-optional architecture** — one hypervisor process per VM, every command standalone; `cocoon daemon` optionally adopts running VMs to converge crashes as they happen; modular lock-safe GC with snapshot LRU eviction
 - **Switchable metadata engine** — json files by default, opt-in sqlite (`meta_backend: sqlite`) for concurrent-create scale; crash-resumable offline conversion both ways (`cocoon meta convert`)
 
 ## Quick Start
@@ -39,7 +39,7 @@ cocoon vm clone base --name fresh
 cocoon vm rm --force my-vm fresh
 ```
 
-Full walkthroughs: [Installation](docs/install.md) · [CLI reference](docs/cli.md) · [Images](docs/images.md) · [VM lifecycle](docs/vm.md) · [Networking](docs/networking.md) · [Snapshots & clone](docs/snapshots.md) · [Device attach](docs/devices.md) · [Windows](docs/windows.md) · [Firecracker](docs/firecracker.md) · [GC](docs/gc.md) · [OS images](docs/os-image.md) · [Known issues](docs/known-issues.md)
+Full walkthroughs: [Installation](docs/install.md) · [CLI reference](docs/cli.md) · [Images](docs/images.md) · [VM lifecycle](docs/vm.md) · [Networking](docs/networking.md) · [Snapshots & clone](docs/snapshots.md) · [Device attach](docs/devices.md) · [Windows](docs/windows.md) · [Firecracker](docs/firecracker.md) · [GC](docs/gc.md) · [Daemon](docs/daemon.md) · [OS images](docs/os-image.md) · [Known issues](docs/known-issues.md)
 
 ## Development
 

--- a/cmd/core/gc.go
+++ b/cmd/core/gc.go
@@ -9,8 +9,7 @@ import (
 	"github.com/cocoonstack/cocoon/snapshot/localfile"
 )
 
-// NewGCOrchestrator registers every collector: image, hypervisor (both backends,
-// so a sweep protects blobs pinned by either), network and snapshot.
+// NewGCOrchestrator registers every collector; both hypervisor backends join so a sweep protects blobs pinned by either.
 func NewGCOrchestrator(ctx context.Context, conf *config.Config, snapOpts ...localfile.Option) (*gc.Orchestrator, error) {
 	backends, err := InitImageBackends(ctx, conf)
 	if err != nil {

--- a/cmd/core/gc.go
+++ b/cmd/core/gc.go
@@ -1,0 +1,43 @@
+package core
+
+import (
+	"context"
+
+	"github.com/cocoonstack/cocoon/config"
+	"github.com/cocoonstack/cocoon/gc"
+	"github.com/cocoonstack/cocoon/network/bridge"
+	"github.com/cocoonstack/cocoon/snapshot/localfile"
+)
+
+// NewGCOrchestrator registers every collector: image, hypervisor (both backends,
+// so a sweep protects blobs pinned by either), network and snapshot.
+func NewGCOrchestrator(ctx context.Context, conf *config.Config, snapOpts ...localfile.Option) (*gc.Orchestrator, error) {
+	backends, err := InitImageBackends(ctx, conf)
+	if err != nil {
+		return nil, err
+	}
+	netProvider, err := InitNetwork(conf)
+	if err != nil {
+		return nil, err
+	}
+	snapBackend, err := InitSnapshot(ctx, conf, snapOpts...)
+	if err != nil {
+		return nil, err
+	}
+	hypers, err := InitAllHypervisors(ctx, conf)
+	if err != nil {
+		return nil, err
+	}
+
+	o := gc.New()
+	for _, b := range backends {
+		b.RegisterGC(o)
+	}
+	for _, hyper := range hypers {
+		hyper.RegisterGC(o)
+	}
+	netProvider.RegisterGC(o)
+	gc.Register(o, bridge.GCModule())
+	snapBackend.RegisterGC(o)
+	return o, nil
+}

--- a/cmd/core/init.go
+++ b/cmd/core/init.go
@@ -31,6 +31,7 @@ var hypervisorFactories = []hypervisorFactory{
 func wireHypervisor[H interface {
 	hypervisor.Hypervisor
 	SetNetCleanup(hypervisor.NetTeardown)
+	SetNetLifecycle(hypervisor.NetLifecycle)
 }](newFn func(*config.Config, metering.Recorder, meta.Store) (H, error)) func(context.Context, *config.Config) (hypervisor.Hypervisor, error) {
 	return func(ctx context.Context, c *config.Config) (hypervisor.Hypervisor, error) {
 		store, err := MetaStore(c)
@@ -42,6 +43,7 @@ func wireHypervisor[H interface {
 			return nil, err
 		}
 		h.SetNetCleanup(netCleanup(c))
+		h.SetNetLifecycle(NewNetProviders(c).Lifecycle())
 		return h, nil
 	}
 }

--- a/cmd/core/init.go
+++ b/cmd/core/init.go
@@ -30,8 +30,7 @@ var hypervisorFactories = []hypervisorFactory{
 // wireHypervisor builds a backend factory over the shared store and recorder.
 func wireHypervisor[H interface {
 	hypervisor.Hypervisor
-	SetNetCleanup(hypervisor.NetTeardown)
-	SetNetLifecycle(hypervisor.NetLifecycle)
+	SetNetwork(hypervisor.VMNetwork)
 }](newFn func(*config.Config, metering.Recorder, meta.Store) (H, error)) func(context.Context, *config.Config) (hypervisor.Hypervisor, error) {
 	return func(ctx context.Context, c *config.Config) (hypervisor.Hypervisor, error) {
 		store, err := MetaStore(c)
@@ -42,23 +41,8 @@ func wireHypervisor[H interface {
 		if err != nil {
 			return nil, err
 		}
-		h.SetNetCleanup(netCleanup(c))
-		h.SetNetLifecycle(NewNetProviders(c).Lifecycle())
+		h.SetNetwork(NetworkSeam(c))
 		return h, nil
-	}
-}
-
-// netCleanup runs inside the delete protocol under the VM lock; a partial CNI failure leaves the tombstone for retry/GC to resume.
-func netCleanup(c *config.Config) hypervisor.NetTeardown {
-	return func(ctx context.Context, vmID string) error {
-		bridgenet.CleanupTAPs([]string{vmID})
-		netProvider, initErr := InitNetwork(c)
-		if initErr != nil {
-			// Lazy CNI; OK to skip for bridge-only setups.
-			return nil
-		}
-		_, err := netProvider.Delete(ctx, []string{vmID})
-		return err
 	}
 }
 

--- a/cmd/core/network.go
+++ b/cmd/core/network.go
@@ -1,0 +1,103 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/projecteru2/core/log"
+
+	"github.com/cocoonstack/cocoon/config"
+	"github.com/cocoonstack/cocoon/hypervisor"
+	"github.com/cocoonstack/cocoon/network"
+	"github.com/cocoonstack/cocoon/types"
+)
+
+// NetProviders resolves and caches the network provider each VM's record names;
+// one instance is shared across concurrent VM operations.
+type NetProviders struct {
+	conf *config.Config
+
+	mu     sync.Mutex
+	cni    network.Network
+	bridge map[string]network.Network
+}
+
+func NewNetProviders(conf *config.Config) *NetProviders {
+	return &NetProviders{conf: conf, bridge: map[string]network.Network{}}
+}
+
+// ForVM picks the provider from the VM's persisted network state.
+func (n *NetProviders) ForVM(vm *types.VM) (network.Network, error) {
+	if vm == nil {
+		return nil, fmt.Errorf("no VM record")
+	}
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if vm.ResolvedNetBackend() != types.BackendBridge {
+		return n.cniLocked()
+	}
+	dev := vm.ResolvedNetBridgeDev()
+	if dev == "" {
+		return nil, fmt.Errorf("bridge backend but no bridge device persisted")
+	}
+	if cached, ok := n.bridge[dev]; ok {
+		return cached, nil
+	}
+	p, err := InitBridgeNetwork(n.conf, dev)
+	if err != nil {
+		return nil, err
+	}
+	n.bridge[dev] = p
+	return p, nil
+}
+
+// Lifecycle is the locked network convergence the hypervisor runs on start and stop.
+func (n *NetProviders) Lifecycle() hypervisor.NetLifecycle {
+	return hypervisor.NetLifecycle{Recover: n.recoverNetwork, Quiesce: n.quiesceNetwork}
+}
+
+func (n *NetProviders) cniLocked() (network.Network, error) {
+	if n.cni == nil {
+		p, err := InitNetwork(n.conf)
+		if err != nil {
+			return nil, err
+		}
+		n.cni = p
+	}
+	return n.cni, nil
+}
+
+// recoverNetwork verifies the VM's plumbing, rebuilding it when missing and lifting the
+// stop-time quiesce otherwise. Its error aborts the launch: booting a VM whose
+// host networking is half-built strands it with no way to reach the network.
+func (n *NetProviders) recoverNetwork(ctx context.Context, vm *types.VM) error {
+	backend := vm.ResolvedNetBackend()
+	if backend == "" || (backend == types.BackendBridge && len(vm.NetworkConfigs) == 0) {
+		return nil
+	}
+	p, err := n.ForVM(vm)
+	if err != nil {
+		return err
+	}
+	if p.Verify(ctx, vm.ID, vm.NetworkConfigs) == nil {
+		return p.Unquiesce(ctx, vm.ID)
+	}
+	log.WithFunc("core.NetProviders.recoverNetwork").Warnf(ctx, "network missing for VM %s, recovering", vm.ID)
+	if _, prepErr := p.Prepare(ctx, vm.ID, &vm.Config); prepErr != nil {
+		return fmt.Errorf("prepare netns: %w", prepErr)
+	}
+	if len(vm.NetworkConfigs) == 0 {
+		return nil
+	}
+	_, err = p.Add(ctx, vm.ID, &vm.Config, network.AddRecover(vm.NetworkConfigs)...)
+	return err
+}
+
+func (n *NetProviders) quiesceNetwork(ctx context.Context, vm *types.VM) error {
+	p, err := n.ForVM(vm)
+	if err != nil {
+		return err
+	}
+	return p.Quiesce(ctx, vm.ID)
+}

--- a/cmd/core/network.go
+++ b/cmd/core/network.go
@@ -21,8 +21,7 @@ var (
 
 var _ hypervisor.VMNetwork = (*NetProviders)(nil)
 
-// NetProviders resolves and caches the network provider each VM's record names;
-// one instance is shared across concurrent VM operations.
+// NetProviders resolves and caches the network provider each VM's record names.
 type NetProviders struct {
 	conf *config.Config
 
@@ -31,8 +30,7 @@ type NetProviders struct {
 	bridge map[string]network.Network
 }
 
-// NetworkSeam returns the process-wide host-networking seam, so both hypervisor
-// backends share one provider cache rather than building one each.
+// NetworkSeam returns the process-wide seam, so both backends share one provider cache.
 func NetworkSeam(conf *config.Config) *NetProviders {
 	netOnce.Do(func() { netSeam = NewNetProviders(conf) })
 	return netSeam
@@ -44,9 +42,6 @@ func NewNetProviders(conf *config.Config) *NetProviders {
 
 // ForVM picks the provider from the VM's persisted network state.
 func (n *NetProviders) ForVM(vm *types.VM) (network.Network, error) {
-	if vm == nil {
-		return nil, fmt.Errorf("no VM record")
-	}
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	if vm.ResolvedNetBackend() != types.BackendBridge {
@@ -78,9 +73,7 @@ func (n *NetProviders) cniLocked() (network.Network, error) {
 	return n.cni, nil
 }
 
-// Recover verifies the VM's plumbing, rebuilding it when missing and lifting the
-// stop-time quiesce otherwise. Its error aborts the launch: booting a VM whose
-// host networking is half-built strands it with no way to reach the network.
+// Recover verifies, rebuilds or un-quiesces the VM's plumbing; its error aborts the launch, since half-built networking strands the guest.
 func (n *NetProviders) Recover(ctx context.Context, vm *types.VM) error {
 	backend := vm.ResolvedNetBackend()
 	if backend == "" || (backend == types.BackendBridge && len(vm.NetworkConfigs) == 0) {

--- a/cmd/core/network.go
+++ b/cmd/core/network.go
@@ -10,8 +10,16 @@ import (
 	"github.com/cocoonstack/cocoon/config"
 	"github.com/cocoonstack/cocoon/hypervisor"
 	"github.com/cocoonstack/cocoon/network"
+	bridgenet "github.com/cocoonstack/cocoon/network/bridge"
 	"github.com/cocoonstack/cocoon/types"
 )
+
+var (
+	netOnce sync.Once
+	netSeam *NetProviders
+)
+
+var _ hypervisor.VMNetwork = (*NetProviders)(nil)
 
 // NetProviders resolves and caches the network provider each VM's record names;
 // one instance is shared across concurrent VM operations.
@@ -21,6 +29,13 @@ type NetProviders struct {
 	mu     sync.Mutex
 	cni    network.Network
 	bridge map[string]network.Network
+}
+
+// NetworkSeam returns the process-wide host-networking seam, so both hypervisor
+// backends share one provider cache rather than building one each.
+func NetworkSeam(conf *config.Config) *NetProviders {
+	netOnce.Do(func() { netSeam = NewNetProviders(conf) })
+	return netSeam
 }
 
 func NewNetProviders(conf *config.Config) *NetProviders {
@@ -52,11 +67,6 @@ func (n *NetProviders) ForVM(vm *types.VM) (network.Network, error) {
 	return p, nil
 }
 
-// Lifecycle is the locked network convergence the hypervisor runs on start and stop.
-func (n *NetProviders) Lifecycle() hypervisor.NetLifecycle {
-	return hypervisor.NetLifecycle{Recover: n.recoverNetwork, Quiesce: n.quiesceNetwork}
-}
-
 func (n *NetProviders) cniLocked() (network.Network, error) {
 	if n.cni == nil {
 		p, err := InitNetwork(n.conf)
@@ -68,10 +78,10 @@ func (n *NetProviders) cniLocked() (network.Network, error) {
 	return n.cni, nil
 }
 
-// recoverNetwork verifies the VM's plumbing, rebuilding it when missing and lifting the
+// Recover verifies the VM's plumbing, rebuilding it when missing and lifting the
 // stop-time quiesce otherwise. Its error aborts the launch: booting a VM whose
 // host networking is half-built strands it with no way to reach the network.
-func (n *NetProviders) recoverNetwork(ctx context.Context, vm *types.VM) error {
+func (n *NetProviders) Recover(ctx context.Context, vm *types.VM) error {
 	backend := vm.ResolvedNetBackend()
 	if backend == "" || (backend == types.BackendBridge && len(vm.NetworkConfigs) == 0) {
 		return nil
@@ -83,7 +93,7 @@ func (n *NetProviders) recoverNetwork(ctx context.Context, vm *types.VM) error {
 	if p.Verify(ctx, vm.ID, vm.NetworkConfigs) == nil {
 		return p.Unquiesce(ctx, vm.ID)
 	}
-	log.WithFunc("core.NetProviders.recoverNetwork").Warnf(ctx, "network missing for VM %s, recovering", vm.ID)
+	log.WithFunc("core.NetProviders.Recover").Warnf(ctx, "network missing for VM %s, recovering", vm.ID)
 	if _, prepErr := p.Prepare(ctx, vm.ID, &vm.Config); prepErr != nil {
 		return fmt.Errorf("prepare netns: %w", prepErr)
 	}
@@ -94,10 +104,31 @@ func (n *NetProviders) recoverNetwork(ctx context.Context, vm *types.VM) error {
 	return err
 }
 
-func (n *NetProviders) quiesceNetwork(ctx context.Context, vm *types.VM) error {
+// Quiesce brings a stopped VM's host NICs down.
+func (n *NetProviders) Quiesce(ctx context.Context, vm *types.VM) error {
 	p, err := n.ForVM(vm)
 	if err != nil {
 		return err
 	}
 	return p.Quiesce(ctx, vm.ID)
+}
+
+// Cleanup releases a VM's networking inside the delete protocol; a partial CNI
+// failure leaves the tombstone for retry or GC to resume.
+func (n *NetProviders) Cleanup(ctx context.Context, vmID string) error {
+	bridgenet.CleanupTAPs([]string{vmID})
+	p, err := n.cniOnly()
+	if err != nil {
+		// Lazy CNI; OK to skip for bridge-only setups.
+		return nil
+	}
+	_, err = p.Delete(ctx, []string{vmID})
+	return err
+}
+
+// cniOnly resolves the CNI provider without a VM record, for the ID-only teardown path.
+func (n *NetProviders) cniOnly() (network.Network, error) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.cniLocked()
 }

--- a/cmd/daemon/commands.go
+++ b/cmd/daemon/commands.go
@@ -14,7 +14,7 @@ func Command(h Handler) *cobra.Command {
 		RunE:  h.Run,
 	}
 	cmd.Flags().Duration("reconcile-interval", cocoond.DefaultReconcileInterval, "full reconcile pass cadence")
-	cmd.Flags().Duration("gc-interval", 0, "periodic gc cadence; 0 leaves gc a CLI verb")
+	cmd.Flags().Duration("gc-interval", 0, "sweep on this cadence in a background goroutine; 0 (default) leaves gc a CLI verb")
 	cmd.Flags().String("api-socket", "", "read-only API socket path (default: <run-dir>/cocoond.sock)")
 	cmd.Flags().Bool("no-api", false, "disable the read-only API")
 	cmd.Flags().Uint32("api-socket-mode", cocoond.DefaultAPISockMode, "read-only API socket permission bits")

--- a/cmd/daemon/commands.go
+++ b/cmd/daemon/commands.go
@@ -1,0 +1,22 @@
+package daemon
+
+import (
+	"github.com/spf13/cobra"
+
+	cocoond "github.com/cocoonstack/cocoon/daemon"
+)
+
+// Command builds the resident supervisor command.
+func Command(h Handler) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "daemon",
+		Short: "Supervise cocoon-managed VMs: adopt live VMMs, converge exits, retry pending network quiesce",
+		RunE:  h.Run,
+	}
+	cmd.Flags().Duration("reconcile-interval", cocoond.DefaultReconcileInterval, "full reconcile pass cadence")
+	cmd.Flags().Duration("gc-interval", 0, "periodic gc cadence; 0 leaves gc a CLI verb")
+	cmd.Flags().String("api-socket", "", "read-only API socket path (default: <run-dir>/cocoond.sock)")
+	cmd.Flags().Bool("no-api", false, "disable the read-only API")
+	cmd.Flags().Uint32("api-socket-mode", cocoond.DefaultAPISockMode, "read-only API socket permission bits")
+	return cmd
+}

--- a/cmd/daemon/handler.go
+++ b/cmd/daemon/handler.go
@@ -1,0 +1,96 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
+	"github.com/cocoonstack/cocoon/config"
+	cocoond "github.com/cocoonstack/cocoon/daemon"
+)
+
+// apiSockName is the read-only API socket's default name under the run dir.
+const apiSockName = "cocoond.sock"
+
+// Handler runs the resident supervisor.
+type Handler struct {
+	cmdcore.BaseHandler
+}
+
+func (h Handler) Run(cmd *cobra.Command, _ []string) error {
+	ctx, conf, err := h.Init(cmd)
+	if err != nil {
+		return err
+	}
+	store, err := cmdcore.MetaStore(conf)
+	if err != nil {
+		return err
+	}
+	hypers, err := cmdcore.InitAllHypervisors(ctx, conf)
+	if err != nil {
+		return err
+	}
+	supervisors := make([]cocoond.Supervisor, 0, len(hypers))
+	for _, hyper := range hypers {
+		s, ok := hyper.(cocoond.Supervisor)
+		if !ok {
+			return fmt.Errorf("hypervisor %s cannot be supervised", hyper.Type())
+		}
+		supervisors = append(supervisors, s)
+	}
+	dconf, err := daemonConfig(cmd, conf)
+	if err != nil {
+		return err
+	}
+	d, err := cocoond.New(dconf, store, supervisors)
+	if err != nil {
+		return err
+	}
+	return d.Run(ctx)
+}
+
+func daemonConfig(cmd *cobra.Command, conf *config.Config) (cocoond.Config, error) {
+	interval, _ := cmd.Flags().GetDuration("reconcile-interval")
+	if interval < 0 {
+		return cocoond.Config{}, fmt.Errorf("--reconcile-interval must be >= 0, got %s", interval)
+	}
+	gcInterval, _ := cmd.Flags().GetDuration("gc-interval")
+	if gcInterval < 0 {
+		return cocoond.Config{}, fmt.Errorf("--gc-interval must be >= 0, got %s", gcInterval)
+	}
+	sockMode, _ := cmd.Flags().GetUint32("api-socket-mode")
+
+	addr, _ := cmd.Flags().GetString("api-socket")
+	if noAPI, _ := cmd.Flags().GetBool("no-api"); noAPI {
+		addr = ""
+	} else if addr == "" {
+		addr = filepath.Join(conf.RunDir, apiSockName)
+	}
+
+	return cocoond.Config{
+		RootDir:           conf.RootDir,
+		ReconcileInterval: interval,
+		GCInterval:        gcInterval,
+		GC:                gcRunner(conf, gcInterval),
+		APIAddr:           addr,
+		APISockMode:       sockMode,
+	}, nil
+}
+
+// gcRunner builds the orchestrator per run so a sweep always reads fresh state; nil keeps GC a CLI verb.
+func gcRunner(conf *config.Config, interval time.Duration) func(context.Context) error {
+	if interval <= 0 {
+		return nil
+	}
+	return func(ctx context.Context) error {
+		o, err := cmdcore.NewGCOrchestrator(ctx, conf)
+		if err != nil {
+			return err
+		}
+		return o.Run(ctx)
+	}
+}

--- a/cmd/daemon/handler.go
+++ b/cmd/daemon/handler.go
@@ -80,7 +80,7 @@ func daemonConfig(cmd *cobra.Command, conf *config.Config) (cocoond.Config, erro
 	}, nil
 }
 
-// gcRunner builds the orchestrator per run so a sweep always reads fresh state; nil keeps GC a CLI verb.
+// gcRunner builds the orchestrator per run so each sweep reads fresh state.
 func gcRunner(conf *config.Config, interval time.Duration) func(context.Context) error {
 	if interval <= 0 {
 		return nil

--- a/cmd/daemon/handler.go
+++ b/cmd/daemon/handler.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"path/filepath"
@@ -13,7 +14,6 @@ import (
 	cocoond "github.com/cocoonstack/cocoon/daemon"
 )
 
-// apiSockName is the read-only API socket's default name under the run dir.
 const apiSockName = "cocoond.sock"
 
 // Handler runs the resident supervisor.
@@ -65,10 +65,9 @@ func daemonConfig(cmd *cobra.Command, conf *config.Config) (cocoond.Config, erro
 	sockMode, _ := cmd.Flags().GetUint32("api-socket-mode")
 
 	addr, _ := cmd.Flags().GetString("api-socket")
+	addr = cmp.Or(addr, filepath.Join(conf.RunDir, apiSockName))
 	if noAPI, _ := cmd.Flags().GetBool("no-api"); noAPI {
 		addr = ""
-	} else if addr == "" {
-		addr = filepath.Join(conf.RunDir, apiSockName)
 	}
 
 	return cocoond.Config{

--- a/cmd/others/handler.go
+++ b/cmd/others/handler.go
@@ -7,8 +7,6 @@ import (
 	"github.com/spf13/cobra"
 
 	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
-	"github.com/cocoonstack/cocoon/gc"
-	"github.com/cocoonstack/cocoon/network/bridge"
 	"github.com/cocoonstack/cocoon/snapshot/localfile"
 	"github.com/cocoonstack/cocoon/version"
 )
@@ -27,34 +25,10 @@ func (h Handler) GC(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	backends, err := cmdcore.InitImageBackends(ctx, conf)
+	o, err := cmdcore.NewGCOrchestrator(ctx, conf, localfile.WithGCPolicy(policy))
 	if err != nil {
 		return err
 	}
-	netProvider, err := cmdcore.InitNetwork(conf)
-	if err != nil {
-		return err
-	}
-	snapBackend, err := cmdcore.InitSnapshot(ctx, conf, localfile.WithGCPolicy(policy))
-	if err != nil {
-		return err
-	}
-
-	o := gc.New()
-	for _, b := range backends {
-		b.RegisterGC(o)
-	}
-	// Register ALL hypervisor backends so GC protects blobs from both CH and FC VMs.
-	hypers, hyperErr := cmdcore.InitAllHypervisors(ctx, conf)
-	if hyperErr != nil {
-		return hyperErr
-	}
-	for _, hyper := range hypers {
-		hyper.RegisterGC(o)
-	}
-	netProvider.RegisterGC(o)
-	gc.Register(o, bridge.GCModule())
-	snapBackend.RegisterGC(o)
 	return o.Run(ctx)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cocoonstack/cocoon/cmd/cliutil"
 	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
+	cmddaemon "github.com/cocoonstack/cocoon/cmd/daemon"
 	cmdimages "github.com/cocoonstack/cocoon/cmd/images"
 	cmdmeta "github.com/cocoonstack/cocoon/cmd/meta"
 	cmdothers "github.com/cocoonstack/cocoon/cmd/others"
@@ -88,6 +89,7 @@ func newRootCmd() *cobra.Command {
 	cmd.AddCommand(cmdvm.Command(cmdvm.Handler{BaseHandler: base}))
 	cmd.AddCommand(cmdsnapshot.Command(cmdsnapshot.Handler{BaseHandler: base}))
 	cmd.AddCommand(cmdmeta.Command(cmdmeta.Handler{BaseHandler: base}))
+	cmd.AddCommand(cmddaemon.Command(cmddaemon.Handler{BaseHandler: base}))
 	for _, c := range cmdothers.Commands(cmdothers.Handler{BaseHandler: base}) {
 		cmd.AddCommand(c)
 	}

--- a/cmd/vm/hibernate.go
+++ b/cmd/vm/hibernate.go
@@ -54,7 +54,6 @@ func (h Handler) Hibernate(cmd *cobra.Command, args []string) error {
 	}); err != nil {
 		return err
 	}
-	h.quiesceNetwork(ctx, conf, hyper, []string{vm.ID})
 	logger.Infof(ctx, "VM hibernated; snapshot %s (resume: cocoon vm restore %s %s)", snapID, vmRef, cmp.Or(name, snapID))
 	return nil
 }

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cocoonstack/cocoon/extend/fs"
 	"github.com/cocoonstack/cocoon/extend/vfio"
 	"github.com/cocoonstack/cocoon/hypervisor"
-	"github.com/cocoonstack/cocoon/network"
+
 	"github.com/cocoonstack/cocoon/types"
 )
 
@@ -56,10 +56,6 @@ func (h Handler) Start(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	for hyper, refs := range routed {
-		h.recoverNetwork(ctx, conf, hyper, refs)
-	}
-
 	return batchRoutedCmd(ctx, cmd, "start", "started", routed, func(hyper hypervisor.Hypervisor, refs []string) ([]string, error) {
 		return hyper.Start(ctx, refs)
 	})
@@ -82,7 +78,7 @@ func (h Handler) Stop(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	return batchRoutedCmd(ctx, cmd, "stop", "stopped", routed, func(hyper hypervisor.Hypervisor, refs []string) ([]string, error) {
-		return h.stopAndQuiesce(ctx, conf, hyper, refs)
+		return hyper.Stop(ctx, refs)
 	})
 }
 
@@ -203,148 +199,9 @@ func (h Handler) RM(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if force {
-		for hyper, refs := range routed {
-			_, _ = h.stopAndQuiesce(ctx, conf, hyper, refs)
-		}
-	}
-
 	return batchRoutedCmd(ctx, cmd, "rm", "deleted", routed, func(hyper hypervisor.Hypervisor, refs []string) ([]string, error) {
 		return hyper.Delete(ctx, refs, force)
 	})
-}
-
-func (h Handler) recoverNetwork(ctx context.Context, conf *config.Config, hyper hypervisor.Hypervisor, refs []string) {
-	logger := log.WithFunc("cmd.vm.recoverNetwork")
-
-	// Lazy CNI; OK to skip for bridge-only setups.
-	var cniProvider network.Network
-	if p, err := cmdcore.InitNetwork(conf); err == nil {
-		cniProvider = p
-	}
-
-	bridgeProviders := map[string]network.Network{}
-
-	// Single List → byID map avoids one Inspect-per-ref under DB lock.
-	all, err := hyper.List(ctx)
-	if err != nil {
-		logger.Warnf(ctx, "list VMs for recovery: %v", err)
-		return
-	}
-	byID := make(map[string]*types.VM, len(all))
-	for _, vm := range all {
-		byID[vm.ID] = vm
-	}
-
-	for _, ref := range refs {
-		vm := byID[ref]
-		if vm == nil {
-			continue
-		}
-		// A corrupt record (null NIC entry) must not grow fresh plumbing here; start will refuse it with a typed error.
-		if err := types.ValidateNetworkConfigs(vm.NetworkConfigs); err != nil {
-			logger.Warnf(ctx, "skip network recovery for VM %s: %v", vm.ID, err)
-			continue
-		}
-		backend := vm.ResolvedNetBackend()
-		if backend == "" {
-			continue
-		}
-		if backend == types.BackendBridge && len(vm.NetworkConfigs) == 0 {
-			continue
-		}
-		netProvider, provErr := providerForVM(conf, cniProvider, bridgeProviders, vm)
-		if provErr != nil {
-			logger.Warnf(ctx, "skip recovery for VM %s: %v", vm.ID, provErr)
-			continue
-		}
-		recoverOne := func(vm *types.VM) {
-			if netProvider.Verify(ctx, vm.ID, vm.NetworkConfigs) == nil {
-				if err := netProvider.Unquiesce(ctx, vm.ID); err != nil {
-					logger.Warnf(ctx, "unquiesce network for VM %s: %v", vm.ID, err)
-				}
-				return
-			}
-			logger.Warnf(ctx, "network missing for VM %s, recovering", vm.ID)
-			if _, prepErr := netProvider.Prepare(ctx, vm.ID, &vm.Config); prepErr != nil {
-				logger.Warnf(ctx, "prepare netns for VM %s: %v (start will fail)", vm.ID, prepErr)
-				return
-			}
-			if len(vm.NetworkConfigs) == 0 {
-				return
-			}
-			if _, recoverErr := netProvider.Add(ctx, vm.ID, &vm.Config, network.AddRecover(vm.NetworkConfigs)...); recoverErr != nil {
-				logger.Warnf(ctx, "recover network for VM %s: %v (start will fail)", vm.ID, recoverErr)
-			}
-		}
-		// Ops lock serializes verify-and-rebuild: two concurrent starts would both see missing plumbing, double-ADD, and the loser's rollback DEL would tear down the winner's network.
-		locker, ok := hyper.(hypervisor.Reserver)
-		if !ok {
-			recoverOne(vm)
-			continue
-		}
-		unlock, lockErr := locker.LockVMOps(ctx, vm.ID)
-		if lockErr != nil {
-			logger.Warnf(ctx, "skip network recovery for VM %s: ops lock: %v", vm.ID, lockErr)
-			continue
-		}
-		// Entry discipline before healing: an interrupted delete must finish
-		// and refuse, never get its network rebuilt (§9).
-		if g, ok := hyper.(hypervisor.EntryGuarded); ok {
-			if gErr := g.EntryGuard(ctx, vm.ID); gErr != nil {
-				logger.Warnf(ctx, "skip network recovery for VM %s: %v", vm.ID, gErr)
-				unlock()
-				continue
-			}
-		}
-		// Recheck under the lock from the fresh record: the pre-lock List snapshot may predate a completed rm or net resize.
-		if fresh, inspectErr := hyper.Inspect(ctx, vm.ID); inspectErr == nil {
-			recoverOne(fresh)
-		}
-		unlock()
-	}
-}
-
-func (h Handler) stopAndQuiesce(ctx context.Context, conf *config.Config, hyper hypervisor.Hypervisor, refs []string) ([]string, error) {
-	stopped, err := hyper.Stop(ctx, refs)
-	h.quiesceNetwork(ctx, conf, hyper, stopped)
-	return stopped, err
-}
-
-// quiesceNetwork brings each stopped VM's host NICs down — Stop's counterpart to Start's recoverNetwork — so an idle TAP's TC redirect can't storm softirqs. Best-effort: a quiesce failure never blocks the stop.
-func (h Handler) quiesceNetwork(ctx context.Context, conf *config.Config, hyper hypervisor.Hypervisor, ids []string) {
-	if len(ids) == 0 {
-		return
-	}
-	logger := log.WithFunc("cmd.vm.quiesceNetwork")
-
-	var cniProvider network.Network
-	if p, err := cmdcore.InitNetwork(conf); err == nil {
-		cniProvider = p
-	}
-	bridgeProviders := map[string]network.Network{}
-
-	for _, id := range ids {
-		vm, err := hyper.Inspect(ctx, id)
-		if err != nil {
-			logger.Warnf(ctx, "inspect VM %s for quiesce: %v", id, err)
-			continue
-		}
-		if vm == nil {
-			continue
-		}
-		if vm.ResolvedNetBackend() == "" || len(vm.NetworkConfigs) == 0 {
-			continue
-		}
-		netProvider, provErr := providerForVM(conf, cniProvider, bridgeProviders, vm)
-		if provErr != nil {
-			logger.Warnf(ctx, "skip quiesce for VM %s: %v", id, provErr)
-			continue
-		}
-		if err := netProvider.Quiesce(ctx, id); err != nil {
-			logger.Warnf(ctx, "quiesce network for VM %s: %v", id, err)
-		}
-	}
 }
 
 // applyStopFlags maps --force (-1 = immediate kill; #82: FC guests without i8042 never answer CtrlAltDel) and --timeout onto the stop window; rm has no --timeout flag, that read no-ops.
@@ -357,33 +214,6 @@ func applyStopFlags(conf *config.Config, cmd *cobra.Command) {
 	case timeout > 0:
 		conf.StopTimeoutSeconds = timeout
 	}
-}
-
-// providerForVM picks the provider from VM state. cniProvider may be nil; bridgeCache must be non-nil.
-func providerForVM(conf *config.Config, cniProvider network.Network, bridgeCache map[string]network.Network, vm *types.VM) (network.Network, error) {
-	if vm == nil {
-		return nil, fmt.Errorf("no VM record")
-	}
-	if vm.ResolvedNetBackend() == types.BackendBridge {
-		dev := vm.ResolvedNetBridgeDev()
-		if dev == "" {
-			return nil, fmt.Errorf("bridge backend but no bridge device persisted")
-		}
-		if cached, ok := bridgeCache[dev]; ok {
-			return cached, nil
-		}
-		p, err := cmdcore.InitBridgeNetwork(conf, dev)
-		if err != nil {
-			return nil, err
-		}
-		bridgeCache[dev] = p
-		return p, nil
-	}
-	// "cni" or empty (backward compat).
-	if cniProvider != nil {
-		return cniProvider, nil
-	}
-	return cmdcore.InitNetwork(conf)
 }
 
 // batchRoutedCmd runs fn per routed hypervisor, logging each success (unless JSON), then wraps the last error, emits JSON, or logs the empty case.

--- a/cmd/vm/netresize.go
+++ b/cmd/vm/netresize.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cocoonstack/cocoon/cmd/cliutil"
+	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
 	"github.com/cocoonstack/cocoon/config"
 	"github.com/cocoonstack/cocoon/extend/netresize"
 	"github.com/cocoonstack/cocoon/network"
@@ -52,5 +53,5 @@ func plumbingForVM(conf *config.Config, vm *types.VM) (network.Network, error) {
 	if backend == types.BackendCNI && vm.ResolvedNetnsPath() == "" {
 		return nil, fmt.Errorf("cni backend but no netns; resize would target host netns")
 	}
-	return providerForVM(conf, nil, map[string]network.Network{}, vm)
+	return cmdcore.NewNetProviders(conf).ForVM(vm)
 }

--- a/cmd/vm/run.go
+++ b/cmd/vm/run.go
@@ -159,10 +159,6 @@ func (h Handler) Restore(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("find VM %s: %w", vmRef, err)
 	}
-	// Start's network self-heal, needed here for hibernate resume after a host reboot.
-	if vm, inspectErr := hyper.Inspect(ctx, vmRef); inspectErr == nil && vm.State != types.VMStateRunning {
-		h.recoverNetwork(ctx, conf, hyper, []string{vm.ID})
-	}
 	snapBackend, err := cmdcore.InitSnapshot(ctx, conf)
 	if err != nil {
 		return err
@@ -230,9 +226,6 @@ func (h Handler) restoreFromDir(ctx context.Context, cmd *cobra.Command, conf *c
 	vm, err := hyper.Inspect(ctx, vmRef)
 	if err != nil {
 		return fmt.Errorf("inspect VM: %w", err)
-	}
-	if vm.State != types.VMStateRunning {
-		h.recoverNetwork(ctx, conf, hyper, []string{vm.ID})
 	}
 	if _, owned := vm.SnapshotIDs[cfg.ID]; !owned {
 		force, _ := cmd.Flags().GetBool("force")

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -32,9 +32,12 @@ type vmsResponse struct {
 	VMs []VMStatus `json:"vms"`
 }
 
-// healthResponse reports whether a full pass succeeded inside the freshness window.
+// healthResponse reports whether the loop is running, and how many VMs the last
+// pass could not converge. Degraded VMs do not make it unready: restarting the
+// daemon does not fix a VM nobody can converge, and a restart loop is worse.
 type healthResponse struct {
 	OK       bool      `json:"ok"`
+	Degraded int       `json:"degraded"`
 	LastPass time.Time `json:"last_pass"`
 	VMs      int       `json:"vms"`
 }
@@ -92,17 +95,17 @@ func (d *Daemon) routes() http.Handler {
 }
 
 func (d *Daemon) handleHealth(w http.ResponseWriter, _ *http.Request) {
-	all, healthy, lastPass := d.state.snapshot()
-	ok := healthy && !lastPass.IsZero() && time.Since(lastPass) < healthStaleFactor*d.conf.ReconcileInterval
+	all, h := d.state.snapshot()
+	ok := h.ok && !h.lastPass.IsZero() && time.Since(h.lastPass) < healthStaleFactor*d.conf.ReconcileInterval
 	status := http.StatusOK
 	if !ok {
 		status = http.StatusServiceUnavailable
 	}
-	writeJSON(w, status, healthResponse{OK: ok, LastPass: lastPass, VMs: len(all)})
+	writeJSON(w, status, healthResponse{OK: ok, Degraded: h.degraded, LastPass: h.lastPass, VMs: len(all)})
 }
 
 func (d *Daemon) handleVMs(w http.ResponseWriter, _ *http.Request) {
-	all, _, _ := d.state.snapshot()
+	all, _ := d.state.snapshot()
 	writeJSON(w, http.StatusOK, vmsResponse{VMs: all})
 }
 
@@ -117,7 +120,7 @@ func (d *Daemon) handleEvents(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-cache")
 	rc := http.NewResponseController(w)
 
-	all, _, _ := d.state.snapshot()
+	all, _ := d.state.snapshot()
 	if err := writeSSE(w, rc, "sync", vmsResponse{VMs: all}); err != nil {
 		return
 	}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -32,9 +32,7 @@ type vmsResponse struct {
 	VMs []VMStatus `json:"vms"`
 }
 
-// healthResponse reports whether the loop is running, and how many VMs the last
-// pass could not converge. Degraded VMs do not make it unready: restarting the
-// daemon does not fix a VM nobody can converge, and a restart loop is worse.
+// healthResponse: degraded VMs do not flip readiness — a daemon restart cannot fix a VM nobody can converge.
 type healthResponse struct {
 	OK       bool      `json:"ok"`
 	Degraded int       `json:"degraded"`
@@ -109,9 +107,7 @@ func (d *Daemon) handleVMs(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, vmsResponse{VMs: all})
 }
 
-// handleEvents streams changes after an opening snapshot. It replays nothing: a
-// reconnecting client compares per-VM generations against the new snapshot to
-// find transitions it missed.
+// handleEvents streams changes after an opening snapshot; it replays nothing, so a reconnecting client diffs per-VM generations against the fresh snapshot.
 func (d *Daemon) handleEvents(w http.ResponseWriter, r *http.Request) {
 	events, release := d.state.subscribe()
 	defer release()

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1,0 +1,151 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/projecteru2/core/log"
+)
+
+const (
+	apiReadHeaderTimeout = 5 * time.Second
+	apiShutdownTimeout   = 2 * time.Second
+
+	// healthStaleFactor bounds how many reconcile intervals may elapse before /healthz reports unready.
+	healthStaleFactor = 3
+
+	// DefaultAPISockMode keeps the socket group-accessible; filesystem permissions are the authorization boundary.
+	DefaultAPISockMode = 0o660
+	apiDirMode         = 0o750
+)
+
+// vmsResponse is the /v1/vms body and the stream's opening snapshot.
+type vmsResponse struct {
+	VMs []VMStatus `json:"vms"`
+}
+
+// healthResponse reports whether a full pass succeeded inside the freshness window.
+type healthResponse struct {
+	OK       bool      `json:"ok"`
+	LastPass time.Time `json:"last_pass"`
+	VMs      int       `json:"vms"`
+}
+
+// serveAPI starts the read-only unix-socket API and returns its shutdown hook.
+func (d *Daemon) serveAPI(ctx context.Context) (func(), error) {
+	ln, err := d.listen()
+	if err != nil {
+		return nil, err
+	}
+	srv := &http.Server{Handler: d.routes(), ReadHeaderTimeout: apiReadHeaderTimeout}
+	go func() {
+		if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.WithFunc("daemon.serveAPI").Error(ctx, err, "api server")
+		}
+	}()
+	log.WithFunc("daemon.serveAPI").Infof(ctx, "read-only api on %s", d.conf.APIAddr)
+	return func() {
+		shutCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), apiShutdownTimeout)
+		defer cancel()
+		_ = srv.Shutdown(shutCtx)
+		_ = os.Remove(d.conf.APIAddr)
+	}, nil
+}
+
+// listen binds the unix socket, clearing a socket the previous instance left behind — the daemon lock proves no peer owns it.
+func (d *Daemon) listen() (net.Listener, error) {
+	if err := os.MkdirAll(filepath.Dir(d.conf.APIAddr), apiDirMode); err != nil {
+		return nil, err
+	}
+	if err := os.Remove(d.conf.APIAddr); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return nil, err
+	}
+	ln, err := net.Listen("unix", d.conf.APIAddr)
+	if err != nil {
+		return nil, err
+	}
+	mode := fs.FileMode(d.conf.APISockMode)
+	if mode == 0 {
+		mode = DefaultAPISockMode
+	}
+	if err := os.Chmod(d.conf.APIAddr, mode); err != nil {
+		_ = ln.Close()
+		return nil, err
+	}
+	return ln, nil
+}
+
+func (d *Daemon) routes() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /healthz", d.handleHealth)
+	mux.HandleFunc("GET /v1/vms", d.handleVMs)
+	mux.HandleFunc("GET /v1/events", d.handleEvents)
+	return mux
+}
+
+func (d *Daemon) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	all, healthy, lastPass := d.state.snapshot()
+	ok := healthy && !lastPass.IsZero() && time.Since(lastPass) < healthStaleFactor*d.conf.ReconcileInterval
+	status := http.StatusOK
+	if !ok {
+		status = http.StatusServiceUnavailable
+	}
+	writeJSON(w, status, healthResponse{OK: ok, LastPass: lastPass, VMs: len(all)})
+}
+
+func (d *Daemon) handleVMs(w http.ResponseWriter, _ *http.Request) {
+	all, _, _ := d.state.snapshot()
+	writeJSON(w, http.StatusOK, vmsResponse{VMs: all})
+}
+
+// handleEvents streams changes after an opening snapshot. It replays nothing: a
+// reconnecting client compares per-VM generations against the new snapshot to
+// find transitions it missed.
+func (d *Daemon) handleEvents(w http.ResponseWriter, r *http.Request) {
+	events, release := d.state.subscribe()
+	defer release()
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	rc := http.NewResponseController(w)
+
+	all, _, _ := d.state.snapshot()
+	if err := writeSSE(w, rc, "sync", vmsResponse{VMs: all}); err != nil {
+		return
+	}
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case ev := <-events:
+			if err := writeSSE(w, rc, "change", ev); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func writeSSE(w http.ResponseWriter, rc *http.ResponseController, event string, payload any) error {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, data); err != nil {
+		return err
+	}
+	return rc.Flush()
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}

--- a/daemon/cache.go
+++ b/daemon/cache.go
@@ -1,6 +1,8 @@
 package daemon
 
 import (
+	"maps"
+	"slices"
 	"sync"
 	"time"
 
@@ -111,10 +113,7 @@ func (c *cache) publish(all []VMStatus, healthy bool, at time.Time) {
 	}
 	c.byKey, c.order = next, all
 	c.healthy, c.lastPass = healthy, at
-	subs := make([]chan changeEvent, 0, len(c.subs))
-	for _, ch := range c.subs {
-		subs = append(subs, ch)
-	}
+	subs := slices.Collect(maps.Values(c.subs))
 	c.mu.Unlock()
 
 	for _, ev := range events {

--- a/daemon/cache.go
+++ b/daemon/cache.go
@@ -66,12 +66,20 @@ type changeEvent struct {
 	Status VMStatus   `json:"vm"`
 }
 
+// health is one pass's outcome: whether it ran at all, and how many VMs it could not converge.
+type health struct {
+	ok       bool
+	degraded int
+	lastPass time.Time
+}
+
 // cache holds the last published pass and fans its diff out to stream subscribers.
 type cache struct {
 	mu       sync.RWMutex
 	byKey    map[watchKey]VMStatus
 	order    []VMStatus
 	healthy  bool
+	degraded int
 	lastPass time.Time
 
 	nextSub int
@@ -89,7 +97,7 @@ func (c *cache) size() int {
 }
 
 // publish replaces the snapshot and emits the diff against the previous pass.
-func (c *cache) publish(all []VMStatus, healthy bool, at time.Time) {
+func (c *cache) publish(all []VMStatus, healthy bool, degraded int, at time.Time) {
 	next := make(map[watchKey]VMStatus, len(all))
 	for _, st := range all {
 		next[watchKey{backend: st.Backend, vmID: st.ID}] = st
@@ -112,7 +120,7 @@ func (c *cache) publish(all []VMStatus, healthy bool, at time.Time) {
 		}
 	}
 	c.byKey, c.order = next, all
-	c.healthy, c.lastPass = healthy, at
+	c.healthy, c.degraded, c.lastPass = healthy, degraded, at
 	subs := slices.Collect(maps.Values(c.subs))
 	c.mu.Unlock()
 
@@ -126,10 +134,10 @@ func (c *cache) publish(all []VMStatus, healthy bool, at time.Time) {
 	}
 }
 
-func (c *cache) snapshot() ([]VMStatus, bool, time.Time) {
+func (c *cache) snapshot() ([]VMStatus, health) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.order, c.healthy, c.lastPass
+	return c.order, health{ok: c.healthy, degraded: c.degraded, lastPass: c.lastPass}
 }
 
 // subscribe returns the change stream plus its release; the caller must drain it or lose events.

--- a/daemon/cache.go
+++ b/daemon/cache.go
@@ -1,0 +1,151 @@
+package daemon
+
+import (
+	"sync"
+	"time"
+
+	"github.com/cocoonstack/cocoon/hypervisor"
+	"github.com/cocoonstack/cocoon/types"
+)
+
+const (
+	changeAdded    changeKind = "ADDED"
+	changeModified changeKind = "MODIFIED"
+	changeDeleted  changeKind = "DELETED"
+
+	// subQueue bounds one subscriber's backlog; the stream is a hint, so a slow reader loses events rather than stalling the pass.
+	subQueue = 128
+)
+
+// changeKind labels a status stream event.
+type changeKind string
+
+// VMStatus is one supervised VM as of the last reconcile pass.
+type VMStatus struct {
+	Backend              string                 `json:"backend"`
+	ID                   string                 `json:"id"`
+	Name                 string                 `json:"name,omitempty"`
+	State                types.VMState          `json:"state"`
+	TransitionGeneration uint64                 `json:"transition_generation"`
+	LastTransitionReason types.TransitionReason `json:"last_transition_reason,omitempty"`
+	LastTransitionAt     *time.Time             `json:"last_transition_at,omitempty"`
+	Live                 bool                   `json:"live"`
+	WatchedPID           int                    `json:"watched_pid,omitempty"`
+	QuiescePending       bool                   `json:"quiesce_pending,omitempty"`
+	VerifiedAt           time.Time              `json:"verified_at"`
+}
+
+func newVMStatus(backend string, rec *hypervisor.VMRecord, live bool, watchedPID int, at time.Time) VMStatus {
+	return VMStatus{
+		Backend:              backend,
+		ID:                   rec.ID,
+		Name:                 rec.Config.Name,
+		State:                rec.State,
+		TransitionGeneration: rec.TransitionGeneration,
+		LastTransitionReason: rec.LastTransitionReason,
+		LastTransitionAt:     rec.LastTransitionAt,
+		Live:                 live,
+		WatchedPID:           watchedPID,
+		QuiescePending:       rec.QuiescePending,
+		VerifiedAt:           at,
+	}
+}
+
+// changed reports whether a consumer would act differently on the two views.
+func (s VMStatus) changed(other VMStatus) bool {
+	return s.State != other.State ||
+		s.TransitionGeneration != other.TransitionGeneration ||
+		s.LastTransitionReason != other.LastTransitionReason ||
+		s.Live != other.Live ||
+		s.QuiescePending != other.QuiescePending
+}
+
+// changeEvent is one status stream item.
+type changeEvent struct {
+	Kind   changeKind `json:"type"`
+	Status VMStatus   `json:"vm"`
+}
+
+// cache holds the last published pass and fans its diff out to stream subscribers.
+type cache struct {
+	mu       sync.RWMutex
+	byKey    map[watchKey]VMStatus
+	order    []VMStatus
+	healthy  bool
+	lastPass time.Time
+
+	nextSub int
+	subs    map[int]chan changeEvent
+}
+
+func newCache() *cache {
+	return &cache{byKey: map[watchKey]VMStatus{}, subs: map[int]chan changeEvent{}}
+}
+
+func (c *cache) size() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.order)
+}
+
+// publish replaces the snapshot and emits the diff against the previous pass.
+func (c *cache) publish(all []VMStatus, healthy bool, at time.Time) {
+	next := make(map[watchKey]VMStatus, len(all))
+	for _, st := range all {
+		next[watchKey{backend: st.Backend, vmID: st.ID}] = st
+	}
+
+	c.mu.Lock()
+	var events []changeEvent
+	for key, st := range next {
+		prev, ok := c.byKey[key]
+		switch {
+		case !ok:
+			events = append(events, changeEvent{Kind: changeAdded, Status: st})
+		case st.changed(prev):
+			events = append(events, changeEvent{Kind: changeModified, Status: st})
+		}
+	}
+	for key, prev := range c.byKey {
+		if _, ok := next[key]; !ok {
+			events = append(events, changeEvent{Kind: changeDeleted, Status: prev})
+		}
+	}
+	c.byKey, c.order = next, all
+	c.healthy, c.lastPass = healthy, at
+	subs := make([]chan changeEvent, 0, len(c.subs))
+	for _, ch := range c.subs {
+		subs = append(subs, ch)
+	}
+	c.mu.Unlock()
+
+	for _, ev := range events {
+		for _, ch := range subs {
+			select {
+			case ch <- ev:
+			default:
+			}
+		}
+	}
+}
+
+func (c *cache) snapshot() ([]VMStatus, bool, time.Time) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.order, c.healthy, c.lastPass
+}
+
+// subscribe returns the change stream plus its release; the caller must drain it or lose events.
+func (c *cache) subscribe() (<-chan changeEvent, func()) {
+	ch := make(chan changeEvent, subQueue)
+	c.mu.Lock()
+	id := c.nextSub
+	c.nextSub++
+	c.subs[id] = ch
+	c.mu.Unlock()
+	return ch, func() {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		delete(c.subs, id)
+	}
+}

--- a/daemon/cache.go
+++ b/daemon/cache.go
@@ -17,7 +17,6 @@ const (
 	subQueue = 128
 )
 
-// changeKind labels a status stream event.
 type changeKind string
 
 // VMStatus is one supervised VM as of the last reconcile pass.
@@ -60,7 +59,6 @@ func (s VMStatus) changed(other VMStatus) bool {
 		s.QuiescePending != other.QuiescePending
 }
 
-// changeEvent is one status stream item.
 type changeEvent struct {
 	Kind   changeKind `json:"type"`
 	Status VMStatus   `json:"vm"`

--- a/daemon/cache.go
+++ b/daemon/cache.go
@@ -90,12 +90,6 @@ func newCache() *cache {
 	return &cache{byKey: map[watchKey]VMStatus{}, subs: map[int]chan changeEvent{}}
 }
 
-func (c *cache) size() int {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return len(c.order)
-}
-
 // publish replaces the snapshot and emits the diff against the previous pass.
 func (c *cache) publish(all []VMStatus, healthy bool, degraded int, at time.Time) {
 	next := make(map[watchKey]VMStatus, len(all))

--- a/daemon/cache_test.go
+++ b/daemon/cache_test.go
@@ -31,12 +31,12 @@ func TestCachePublishesAddedThenModified(t *testing.T) {
 	events, release := c.subscribe()
 	defer release()
 
-	c.publish([]VMStatus{statusOf("vm1", types.VMStateRunning, 1, true)}, true, time.Now())
+	c.publish([]VMStatus{statusOf("vm1", types.VMStateRunning, 1, true)}, true, 0, time.Now())
 	if got := collect(t, events); len(got) != 1 || got[0].Kind != changeAdded {
 		t.Fatalf("got %+v, want one ADDED", got)
 	}
 
-	c.publish([]VMStatus{statusOf("vm1", types.VMStateStopped, 2, false)}, true, time.Now())
+	c.publish([]VMStatus{statusOf("vm1", types.VMStateStopped, 2, false)}, true, 0, time.Now())
 	got := collect(t, events)
 	if len(got) != 1 || got[0].Kind != changeModified {
 		t.Fatalf("got %+v, want one MODIFIED", got)
@@ -49,11 +49,11 @@ func TestCachePublishesAddedThenModified(t *testing.T) {
 func TestCacheEmitsNothingForAnUnchangedPass(t *testing.T) {
 	c := newCache()
 	st := statusOf("vm1", types.VMStateRunning, 1, true)
-	c.publish([]VMStatus{st}, true, time.Now())
+	c.publish([]VMStatus{st}, true, 0, time.Now())
 	events, release := c.subscribe()
 	defer release()
 
-	c.publish([]VMStatus{st}, true, time.Now())
+	c.publish([]VMStatus{st}, true, 0, time.Now())
 	if got := collect(t, events); len(got) != 0 {
 		t.Errorf("got %+v, want no events when nothing a consumer acts on changed", got)
 	}
@@ -61,11 +61,11 @@ func TestCacheEmitsNothingForAnUnchangedPass(t *testing.T) {
 
 func TestCachePublishesDeleted(t *testing.T) {
 	c := newCache()
-	c.publish([]VMStatus{statusOf("vm1", types.VMStateRunning, 1, true)}, true, time.Now())
+	c.publish([]VMStatus{statusOf("vm1", types.VMStateRunning, 1, true)}, true, 0, time.Now())
 	events, release := c.subscribe()
 	defer release()
 
-	c.publish(nil, true, time.Now())
+	c.publish(nil, true, 0, time.Now())
 	got := collect(t, events)
 	if len(got) != 1 || got[0].Kind != changeDeleted || got[0].Status.ID != "vm1" {
 		t.Fatalf("got %+v, want one DELETED for vm1", got)
@@ -75,17 +75,20 @@ func TestCachePublishesDeleted(t *testing.T) {
 func TestCacheSnapshotCarriesHealth(t *testing.T) {
 	c := newCache()
 	at := time.Now()
-	c.publish([]VMStatus{statusOf("vm1", types.VMStateRunning, 1, true)}, false, at)
+	c.publish([]VMStatus{statusOf("vm1", types.VMStateRunning, 1, true)}, false, 2, at)
 
-	all, healthy, lastPass := c.snapshot()
+	all, h := c.snapshot()
 	if len(all) != 1 {
 		t.Fatalf("got %d statuses, want 1", len(all))
 	}
-	if healthy {
+	if h.ok {
 		t.Error("a pass that failed a backend scan reported healthy")
 	}
-	if !lastPass.Equal(at) {
-		t.Errorf("got last pass %v, want %v", lastPass, at)
+	if h.degraded != 2 {
+		t.Errorf("got degraded %d, want 2", h.degraded)
+	}
+	if !h.lastPass.Equal(at) {
+		t.Errorf("got last pass %v, want %v", h.lastPass, at)
 	}
 }
 
@@ -95,7 +98,7 @@ func TestCacheReleaseStopsDelivery(t *testing.T) {
 	events, release := c.subscribe()
 	release()
 
-	c.publish([]VMStatus{statusOf("vm1", types.VMStateRunning, 1, true)}, true, time.Now())
+	c.publish([]VMStatus{statusOf("vm1", types.VMStateRunning, 1, true)}, true, 0, time.Now())
 	if got := collect(t, events); len(got) != 0 {
 		t.Errorf("got %+v, want nothing after release", got)
 	}

--- a/daemon/cache_test.go
+++ b/daemon/cache_test.go
@@ -1,0 +1,102 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cocoonstack/cocoon/hypervisor"
+	"github.com/cocoonstack/cocoon/types"
+)
+
+func statusOf(id string, state types.VMState, gen uint64, live bool) VMStatus {
+	rec := &hypervisor.VMRecord{VM: types.VM{ID: id, State: state, TransitionGeneration: gen}}
+	return newVMStatus("fake-hv", rec, live, 0, time.Now())
+}
+
+func collect(t *testing.T, ch <-chan changeEvent) []changeEvent {
+	t.Helper()
+	var got []changeEvent
+	for {
+		select {
+		case ev := <-ch:
+			got = append(got, ev)
+		default:
+			return got
+		}
+	}
+}
+
+func TestCachePublishesAddedThenModified(t *testing.T) {
+	c := newCache()
+	events, release := c.subscribe()
+	defer release()
+
+	c.publish([]VMStatus{statusOf("vm1", types.VMStateRunning, 1, true)}, true, time.Now())
+	if got := collect(t, events); len(got) != 1 || got[0].Kind != changeAdded {
+		t.Fatalf("got %+v, want one ADDED", got)
+	}
+
+	c.publish([]VMStatus{statusOf("vm1", types.VMStateStopped, 2, false)}, true, time.Now())
+	got := collect(t, events)
+	if len(got) != 1 || got[0].Kind != changeModified {
+		t.Fatalf("got %+v, want one MODIFIED", got)
+	}
+	if got[0].Status.TransitionGeneration != 2 {
+		t.Errorf("got generation %d, want 2", got[0].Status.TransitionGeneration)
+	}
+}
+
+func TestCacheEmitsNothingForAnUnchangedPass(t *testing.T) {
+	c := newCache()
+	st := statusOf("vm1", types.VMStateRunning, 1, true)
+	c.publish([]VMStatus{st}, true, time.Now())
+	events, release := c.subscribe()
+	defer release()
+
+	c.publish([]VMStatus{st}, true, time.Now())
+	if got := collect(t, events); len(got) != 0 {
+		t.Errorf("got %+v, want no events when nothing a consumer acts on changed", got)
+	}
+}
+
+func TestCachePublishesDeleted(t *testing.T) {
+	c := newCache()
+	c.publish([]VMStatus{statusOf("vm1", types.VMStateRunning, 1, true)}, true, time.Now())
+	events, release := c.subscribe()
+	defer release()
+
+	c.publish(nil, true, time.Now())
+	got := collect(t, events)
+	if len(got) != 1 || got[0].Kind != changeDeleted || got[0].Status.ID != "vm1" {
+		t.Fatalf("got %+v, want one DELETED for vm1", got)
+	}
+}
+
+func TestCacheSnapshotCarriesHealth(t *testing.T) {
+	c := newCache()
+	at := time.Now()
+	c.publish([]VMStatus{statusOf("vm1", types.VMStateRunning, 1, true)}, false, at)
+
+	all, healthy, lastPass := c.snapshot()
+	if len(all) != 1 {
+		t.Fatalf("got %d statuses, want 1", len(all))
+	}
+	if healthy {
+		t.Error("a pass that failed a backend scan reported healthy")
+	}
+	if !lastPass.Equal(at) {
+		t.Errorf("got last pass %v, want %v", lastPass, at)
+	}
+}
+
+// A released subscription must not keep receiving, and must not block later passes.
+func TestCacheReleaseStopsDelivery(t *testing.T) {
+	c := newCache()
+	events, release := c.subscribe()
+	release()
+
+	c.publish([]VMStatus{statusOf("vm1", types.VMStateRunning, 1, true)}, true, time.Now())
+	if got := collect(t, events); len(got) != 0 {
+		t.Errorf("got %+v, want nothing after release", got)
+	}
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1,0 +1,231 @@
+// Package daemon is the resident supervisor for VMs the cocoon CLI created: it
+// adopts their VMM processes, observes exits, and converges metadata and host
+// networking without becoming a dependency of any CLI verb.
+package daemon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync/atomic"
+	"time"
+
+	"github.com/projecteru2/core/log"
+
+	"github.com/cocoonstack/cocoon/hypervisor"
+	"github.com/cocoonstack/cocoon/lock/flock"
+	"github.com/cocoonstack/cocoon/meta"
+	"github.com/cocoonstack/cocoon/utils"
+)
+
+const (
+	// DefaultReconcileInterval floors how often a full pass runs; meta events drive faster ones.
+	DefaultReconcileInterval = 5 * time.Second
+
+	// wakeDebounce coalesces event bursts into one pass: the json engine's View
+	// holds a cross-process namespace lock, so an unthrottled daemon would stall
+	// every concurrent CLI invocation.
+	wakeDebounce = 200 * time.Millisecond
+
+	lockFileName = "daemon.lock"
+)
+
+// ErrAlreadyRunning reports another daemon instance holding the single-instance lock.
+var ErrAlreadyRunning = errors.New("another cocoon daemon is already running")
+
+// Supervisor is the hypervisor-backend surface supervision runs through.
+type Supervisor interface {
+	Type() string
+	ScanSupervision(ctx context.Context) (hypervisor.SupervisionScan, error)
+	ObserveVMM(ctx context.Context, rec *hypervisor.VMRecord) (utils.ProcRef, error)
+	TryLockVMOps(ctx context.Context, vmID string) (func(), bool, error)
+	PeekRecord(ctx context.Context, vmID string) (*hypervisor.VMRecord, error)
+	ConvergeDead(ctx context.Context, vmID string, gen uint64, observedAt time.Time) error
+	QuiesceIfPending(ctx context.Context, vmID string) error
+	ReconcileToRunning(ctx context.Context, vmID string)
+	CollectStaleCreate(ctx context.Context, vmID string, rec *hypervisor.VMRecord) error
+}
+
+// Config carries the daemon's runtime knobs and injected collaborators.
+type Config struct {
+	RootDir           string
+	ReconcileInterval time.Duration
+	// GCInterval enables the periodic GC run; zero leaves GC to the CLI.
+	GCInterval time.Duration
+	GC         func(context.Context) error
+	// APIAddr is the read-only API's unix socket path; empty disables it.
+	APIAddr     string
+	APISockMode uint32
+}
+
+// Daemon supervises every configured backend from one process.
+type Daemon struct {
+	conf      Config
+	store     meta.Store
+	backends  map[string]Supervisor
+	order     []Supervisor
+	watcher   *procWatcher
+	gcRunning atomic.Bool
+	state     *cache
+}
+
+// New builds a daemon over already-wired backends; store is the shared meta store the CLI also writes.
+func New(conf Config, store meta.Store, backends []Supervisor) (*Daemon, error) {
+	if conf.RootDir == "" {
+		return nil, fmt.Errorf("root dir must not be empty")
+	}
+	if len(backends) == 0 {
+		return nil, fmt.Errorf("no hypervisor backends to supervise")
+	}
+	if conf.ReconcileInterval <= 0 {
+		conf.ReconcileInterval = DefaultReconcileInterval
+	}
+	byType := make(map[string]Supervisor, len(backends))
+	for _, b := range backends {
+		byType[b.Type()] = b
+	}
+	return &Daemon{
+		conf:     conf,
+		store:    store,
+		backends: byType,
+		order:    backends,
+		watcher:  newProcWatcher(),
+		state:    newCache(),
+	}, nil
+}
+
+// Run supervises until ctx is canceled; it returns ErrAlreadyRunning when another instance holds the lock.
+func (d *Daemon) Run(ctx context.Context) error {
+	logger := log.WithFunc("daemon.Run")
+	unlock, err := d.lockInstance(ctx)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	if err := d.watcher.start(ctx); err != nil {
+		return fmt.Errorf("start process watcher: %w", err)
+	}
+	defer d.watcher.close()
+
+	if d.conf.APIAddr != "" {
+		stopAPI, err := d.serveAPI(ctx)
+		if err != nil {
+			return fmt.Errorf("serve api: %w", err)
+		}
+		defer stopAPI()
+	}
+
+	events, release := d.subscribe(ctx)
+	defer func() {
+		if release != nil {
+			release()
+		}
+	}()
+
+	ticker := time.NewTicker(d.conf.ReconcileInterval)
+	defer ticker.Stop()
+	gcTick := d.gcTicker()
+	defer gcTick.Stop()
+
+	logger.Infof(ctx, "supervising %d backend(s), reconcile every %s", len(d.order), d.conf.ReconcileInterval)
+	d.reconcile(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			// The meta layer never closes a subscriber channel, so a dead
+			// subscription is invisible: the ticker is the correctness floor and
+			// also the resubscribe cadence.
+			if events == nil {
+				events, release = d.subscribe(ctx)
+			}
+			d.reconcile(ctx)
+		case <-events:
+			if !d.settle(ctx) {
+				return nil
+			}
+			drain(events)
+			d.reconcile(ctx)
+		case ev := <-d.watcher.exits:
+			d.handleExit(ctx, ev)
+		case <-gcTick.C:
+			d.runGC(ctx)
+		}
+	}
+}
+
+func (d *Daemon) lockInstance(ctx context.Context) (func(), error) {
+	dir := filepath.Join(d.conf.RootDir, "locks")
+	if err := utils.EnsureDirs(dir); err != nil {
+		return nil, err
+	}
+	l := flock.New(filepath.Join(dir, lockFileName))
+	ok, err := l.TryLock(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("acquire daemon lock: %w", err)
+	}
+	if !ok {
+		return nil, ErrAlreadyRunning
+	}
+	return func() { _ = l.Unlock(ctx) }, nil
+}
+
+// subscribe returns a coalesced meta change signal; a nil channel degrades to ticker-only reconciliation.
+func (d *Daemon) subscribe(ctx context.Context) (<-chan struct{}, func()) {
+	ch, release, err := d.store.Events(ctx)
+	if err != nil {
+		log.WithFunc("daemon.subscribe").Warnf(ctx, "meta events unavailable, reconciling on the ticker only: %v", err)
+		return nil, nil
+	}
+	return ch, release
+}
+
+// settle waits out the debounce window; false means the daemon is shutting down.
+func (d *Daemon) settle(ctx context.Context) bool {
+	timer := time.NewTimer(wakeDebounce)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+func (d *Daemon) gcTicker() *time.Ticker {
+	if d.conf.GCInterval <= 0 || d.conf.GC == nil {
+		// A stopped ticker's channel never fires, so the select arm stays inert.
+		t := time.NewTicker(time.Hour)
+		t.Stop()
+		return t
+	}
+	return time.NewTicker(d.conf.GCInterval)
+}
+
+// runGC starts a collection unless one is still in flight; it runs off the
+// supervision loop so a slow sweep cannot delay convergence.
+func (d *Daemon) runGC(ctx context.Context) {
+	if !d.gcRunning.CompareAndSwap(false, true) {
+		log.WithFunc("daemon.runGC").Warn(ctx, "skip gc: previous run still active")
+		return
+	}
+	go func() {
+		defer d.gcRunning.Store(false)
+		if err := d.conf.GC(ctx); err != nil {
+			log.WithFunc("daemon.runGC").Error(ctx, err, "gc run")
+		}
+	}()
+}
+
+func drain(ch <-chan struct{}) {
+	for {
+		select {
+		case <-ch:
+		default:
+			return
+		}
+	}
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1,6 +1,4 @@
-// Package daemon is the resident supervisor for VMs the cocoon CLI created: it adopts their
-// VMM processes, observes exits, and converges metadata and host networking — optionally, so no
-// CLI verb depends on it.
+// Package daemon is the optional resident supervisor: it adopts the CLI's VMM processes, observes exits, and converges metadata and host networking.
 package daemon
 
 import (
@@ -60,12 +58,6 @@ type Daemon struct {
 
 // New builds a daemon over already-wired backends; store is the shared meta store the CLI also writes.
 func New(conf Config, store meta.Store, backends []Supervisor) (*Daemon, error) {
-	if conf.RootDir == "" {
-		return nil, fmt.Errorf("root dir must not be empty")
-	}
-	if len(backends) == 0 {
-		return nil, fmt.Errorf("no hypervisor backends to supervise")
-	}
 	if conf.ReconcileInterval <= 0 {
 		conf.ReconcileInterval = DefaultReconcileInterval
 	}
@@ -179,8 +171,7 @@ func (d *Daemon) settle(ctx context.Context) bool {
 	}
 }
 
-// gcTick returns the periodic-GC channel and its stop. GC is off unless an
-// interval is configured; a nil channel never fires, so the select arm goes inert.
+// gcTick returns the periodic-GC channel and its stop; with GC off (the default) the nil channel keeps the select arm inert.
 func (d *Daemon) gcTick() (<-chan time.Time, func()) {
 	if d.conf.GCInterval <= 0 || d.conf.GC == nil {
 		return nil, func() {}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -98,9 +98,9 @@ func New(conf Config, store meta.Store, backends []Supervisor) (*Daemon, error) 
 // Run supervises until ctx is canceled; it returns ErrAlreadyRunning when another instance holds the lock.
 func (d *Daemon) Run(ctx context.Context) error {
 	logger := log.WithFunc("daemon.Run")
-	unlock, err := d.lockInstance(ctx)
-	if err != nil {
-		return err
+	unlock, lockErr := d.lockInstance(ctx)
+	if lockErr != nil {
+		return lockErr
 	}
 	defer unlock()
 
@@ -110,14 +110,17 @@ func (d *Daemon) Run(ctx context.Context) error {
 	defer d.watcher.close()
 
 	if d.conf.APIAddr != "" {
-		stopAPI, err := d.serveAPI(ctx)
-		if err != nil {
-			return fmt.Errorf("serve api: %w", err)
+		stopAPI, apiErr := d.serveAPI(ctx)
+		if apiErr != nil {
+			return fmt.Errorf("serve api: %w", apiErr)
 		}
 		defer stopAPI()
 	}
 
-	events, release := d.subscribe(ctx)
+	events, release, subErr := d.subscribe(ctx)
+	if subErr != nil {
+		logger.Warnf(ctx, "meta change events unavailable, reconciling on the ticker only: %v", subErr)
+	}
 	defer func() {
 		if release != nil {
 			release()
@@ -138,9 +141,13 @@ func (d *Daemon) Run(ctx context.Context) error {
 		case <-ticker.C:
 			// The meta layer never closes a subscriber channel, so a dead
 			// subscription is invisible: the ticker is the correctness floor and
-			// also the resubscribe cadence.
+			// also the resubscribe cadence. Retries stay silent — only the first
+			// failure and the recovery are worth a line.
 			if events == nil {
-				events, release = d.subscribe(ctx)
+				if ch, rel, retryErr := d.subscribe(ctx); retryErr == nil {
+					events, release = ch, rel
+					logger.Info(ctx, "meta change events restored")
+				}
 			}
 			d.reconcile(ctx)
 		case <-events:
@@ -173,14 +180,9 @@ func (d *Daemon) lockInstance(ctx context.Context) (func(), error) {
 	return func() { _ = l.Unlock(ctx) }, nil
 }
 
-// subscribe returns a coalesced meta change signal; a nil channel degrades to ticker-only reconciliation.
-func (d *Daemon) subscribe(ctx context.Context) (<-chan struct{}, func()) {
-	ch, release, err := d.store.Events(ctx)
-	if err != nil {
-		log.WithFunc("daemon.subscribe").Warnf(ctx, "meta events unavailable, reconciling on the ticker only: %v", err)
-		return nil, nil
-	}
-	return ch, release
+// subscribe returns a coalesced meta change signal; on error the caller degrades to ticker-only reconciliation.
+func (d *Daemon) subscribe(ctx context.Context) (<-chan struct{}, func(), error) {
+	return d.store.Events(ctx)
 }
 
 // settle waits out the debounce window; false means the daemon is shutting down.

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -153,6 +153,8 @@ func (d *Daemon) Run(ctx context.Context) error {
 			d.reconcile(ctx)
 		case ev := <-d.watcher.exits:
 			d.handleExit(ctx, ev)
+			// The convergence just written wakes this daemon's own subscription; its pass already ran.
+			drain(events)
 		case <-gcTick.C:
 			d.runGC(ctx)
 		}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -32,18 +32,8 @@ const (
 // ErrAlreadyRunning reports another daemon instance holding the single-instance lock.
 var ErrAlreadyRunning = errors.New("another cocoon daemon is already running")
 
-// Supervisor is the hypervisor-backend surface supervision runs through.
-type Supervisor interface {
-	Type() string
-	ScanSupervision(ctx context.Context) (hypervisor.SupervisionScan, error)
-	ObserveVMM(ctx context.Context, rec *hypervisor.VMRecord) (utils.ProcRef, error)
-	TryLockVMOps(ctx context.Context, vmID string) (func(), bool, error)
-	PeekRecord(ctx context.Context, vmID string) (*hypervisor.VMRecord, error)
-	ConvergeDead(ctx context.Context, vmID string, gen uint64, observedAt time.Time) error
-	QuiesceIfPending(ctx context.Context, vmID string) error
-	ReconcileToRunning(ctx context.Context, vmID string)
-	CollectStaleCreate(ctx context.Context, vmID string, rec *hypervisor.VMRecord) error
-}
+// Supervisor is the backend surface supervision drives.
+type Supervisor = hypervisor.Supervisable
 
 // Config carries the daemon's runtime knobs and injected collaborators.
 type Config struct {
@@ -115,7 +105,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 		defer stopAPI()
 	}
 
-	events, release, subErr := d.subscribe(ctx)
+	events, release, subErr := d.store.Events(ctx)
 	if subErr != nil {
 		logger.Warnf(ctx, "meta change events unavailable, reconciling on the ticker only: %v", subErr)
 	}
@@ -139,7 +129,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 		case <-ticker.C:
 			// A dead subscription is invisible — the meta layer never closes a subscriber channel — so the ticker doubles as the resubscribe cadence.
 			if events == nil {
-				if ch, rel, retryErr := d.subscribe(ctx); retryErr == nil {
+				if ch, rel, retryErr := d.store.Events(ctx); retryErr == nil {
 					events, release = ch, rel
 					logger.Info(ctx, "meta change events restored")
 				}
@@ -175,11 +165,6 @@ func (d *Daemon) lockInstance(ctx context.Context) (func(), error) {
 		return nil, ErrAlreadyRunning
 	}
 	return func() { _ = l.Unlock(ctx) }, nil
-}
-
-// subscribe returns a coalesced meta change signal; on error the caller degrades to ticker-only reconciliation.
-func (d *Daemon) subscribe(ctx context.Context) (<-chan struct{}, func(), error) {
-	return d.store.Events(ctx)
 }
 
 // settle waits out the debounce window; false means the daemon is shutting down.

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -39,7 +39,7 @@ type Supervisor = hypervisor.Supervisable
 type Config struct {
 	RootDir           string
 	ReconcileInterval time.Duration
-	// GCInterval enables the periodic GC run; zero leaves GC to the CLI.
+	// GCInterval enables the periodic GC run; zero (the default) leaves GC a CLI verb.
 	GCInterval time.Duration
 	GC         func(context.Context) error
 	// APIAddr is the read-only API's unix socket path; empty disables it.
@@ -117,8 +117,8 @@ func (d *Daemon) Run(ctx context.Context) error {
 
 	ticker := time.NewTicker(d.conf.ReconcileInterval)
 	defer ticker.Stop()
-	gcTick := d.gcTicker()
-	defer gcTick.Stop()
+	gcTick, stopGC := d.gcTick()
+	defer stopGC()
 
 	logger.Infof(ctx, "supervising %d backend(s), reconcile every %s", len(d.order), d.conf.ReconcileInterval)
 	d.reconcile(ctx)
@@ -145,7 +145,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 			d.handleExit(ctx, ev)
 			// The convergence just written wakes this daemon's own subscription; its pass already ran.
 			drain(events)
-		case <-gcTick.C:
+		case <-gcTick:
 			d.runGC(ctx)
 		}
 	}
@@ -179,14 +179,14 @@ func (d *Daemon) settle(ctx context.Context) bool {
 	}
 }
 
-func (d *Daemon) gcTicker() *time.Ticker {
+// gcTick returns the periodic-GC channel and its stop. GC is off unless an
+// interval is configured; a nil channel never fires, so the select arm goes inert.
+func (d *Daemon) gcTick() (<-chan time.Time, func()) {
 	if d.conf.GCInterval <= 0 || d.conf.GC == nil {
-		// A stopped ticker's channel never fires, so the select arm stays inert.
-		t := time.NewTicker(time.Hour)
-		t.Stop()
-		return t
+		return nil, func() {}
 	}
-	return time.NewTicker(d.conf.GCInterval)
+	t := time.NewTicker(d.conf.GCInterval)
+	return t.C, t.Stop
 }
 
 // runGC starts a collection off the supervision loop, unless one is still in flight.

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1,6 +1,6 @@
-// Package daemon is the resident supervisor for VMs the cocoon CLI created: it
-// adopts their VMM processes, observes exits, and converges metadata and host
-// networking without becoming a dependency of any CLI verb.
+// Package daemon is the resident supervisor for VMs the cocoon CLI created: it adopts their
+// VMM processes, observes exits, and converges metadata and host networking — optionally, so no
+// CLI verb depends on it.
 package daemon
 
 import (
@@ -23,9 +23,7 @@ const (
 	// DefaultReconcileInterval floors how often a full pass runs; meta events drive faster ones.
 	DefaultReconcileInterval = 5 * time.Second
 
-	// wakeDebounce coalesces event bursts into one pass: the json engine's View
-	// holds a cross-process namespace lock, so an unthrottled daemon would stall
-	// every concurrent CLI invocation.
+	// wakeDebounce coalesces event bursts: the json engine's View holds a cross-process namespace lock, so unthrottled passes stall every concurrent CLI invocation.
 	wakeDebounce = 200 * time.Millisecond
 
 	lockFileName = "daemon.lock"
@@ -139,10 +137,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			// The meta layer never closes a subscriber channel, so a dead
-			// subscription is invisible: the ticker is the correctness floor and
-			// also the resubscribe cadence. Retries stay silent — only the first
-			// failure and the recovery are worth a line.
+			// A dead subscription is invisible — the meta layer never closes a subscriber channel — so the ticker doubles as the resubscribe cadence.
 			if events == nil {
 				if ch, rel, retryErr := d.subscribe(ctx); retryErr == nil {
 					events, release = ch, rel
@@ -207,8 +202,7 @@ func (d *Daemon) gcTicker() *time.Ticker {
 	return time.NewTicker(d.conf.GCInterval)
 }
 
-// runGC starts a collection unless one is still in flight; it runs off the
-// supervision loop so a slow sweep cannot delay convergence.
+// runGC starts a collection off the supervision loop, unless one is still in flight.
 func (d *Daemon) runGC(ctx context.Context) {
 	if !d.gcRunning.CompareAndSwap(false, true) {
 		log.WithFunc("daemon.runGC").Warn(ctx, "skip gc: previous run still active")

--- a/daemon/reconcile.go
+++ b/daemon/reconcile.go
@@ -15,31 +15,35 @@ import (
 // reconcile runs one idempotent pass over every backend and republishes the API snapshot.
 func (d *Daemon) reconcile(ctx context.Context) {
 	all := make([]VMStatus, 0, d.state.size())
-	healthy := true
+	healthy, degraded := true, 0
 	for _, b := range d.order {
-		st, err := d.reconcileBackend(ctx, b)
+		st, failed, err := d.reconcileBackend(ctx, b)
+		// Only a scan failure is unhealthy: 503 means "restarting me might help",
+		// and restarting fixes a store the daemon cannot read. Per-VM failures are
+		// reported as degraded instead — one VM nobody can converge must not put a
+		// working daemon into a restart loop.
 		if err != nil {
 			healthy = false
 		}
+		degraded += failed
 		all = append(all, st...)
 	}
-	d.state.publish(all, healthy, time.Now())
+	d.state.publish(all, healthy, degraded, time.Now())
 }
 
-// reconcileBackend returns the backend's statuses plus the first failure the pass
-// hit. A busy ops lock is not a failure — it is the normal way supervision yields
-// to a command — but anything else means the pass did not fully succeed, which is
-// what /healthz reports.
-func (d *Daemon) reconcileBackend(ctx context.Context, b Supervisor) ([]VMStatus, error) {
+// reconcileBackend returns the backend's statuses, how many VMs the pass could
+// not converge, and any scan failure. A busy ops lock is not a failure — it is
+// the normal way supervision yields to a command.
+func (d *Daemon) reconcileBackend(ctx context.Context, b Supervisor) ([]VMStatus, int, error) {
 	scan, err := b.ScanSupervision(ctx)
 	if err != nil {
 		log.WithFunc("daemon.reconcileBackend").Errorf(ctx, err, "scan %s", b.Type())
-		return nil, err
+		return nil, 0, err
 	}
 	now := time.Now()
 	seen := make(map[string]struct{}, len(scan.Records))
 	out := make([]VMStatus, 0, len(scan.Records))
-	var failed error
+	failed := 0
 	for _, rec := range scan.Records {
 		seen[rec.ID] = struct{}{}
 		key := watchKey{backend: b.Type(), vmID: rec.ID}
@@ -50,11 +54,13 @@ func (d *Daemon) reconcileBackend(ctx context.Context, b Supervisor) ([]VMStatus
 		} else {
 			live, vmErr = d.reconcileVM(ctx, b, key, rec, scan.Procs)
 		}
-		failed = cmpErr(failed, vmErr)
+		if vmErr != nil {
+			failed++
+		}
 		out = append(out, newVMStatus(b.Type(), rec, live, d.watcher.pidOf(key), now))
 	}
 	d.watcher.dropAbsent(b.Type(), seen)
-	return out, failed
+	return out, failed, nil
 }
 
 // reconcileVM applies the supervision rules to one record and reports whether a VMM generation is live.
@@ -237,12 +243,4 @@ func (d *Daemon) tryLock(ctx context.Context, b Supervisor, vmID string) (func()
 		return nil, false, err
 	}
 	return unlock, ok, nil
-}
-
-// cmpErr keeps the first failure of a pass; later ones are already logged where they happened.
-func cmpErr(first, next error) error {
-	if first != nil {
-		return first
-	}
-	return next
 }

--- a/daemon/reconcile.go
+++ b/daemon/reconcile.go
@@ -14,14 +14,11 @@ import (
 
 // reconcile runs one idempotent pass over every backend and republishes the API snapshot.
 func (d *Daemon) reconcile(ctx context.Context) {
-	all := make([]VMStatus, 0, d.state.size())
+	var all []VMStatus
 	healthy, degraded := true, 0
 	for _, b := range d.order {
 		st, failed, err := d.reconcileBackend(ctx, b)
-		// Only a scan failure is unhealthy: 503 means "restarting me might help",
-		// and restarting fixes a store the daemon cannot read. Per-VM failures are
-		// reported as degraded instead — one VM nobody can converge must not put a
-		// working daemon into a restart loop.
+		// Only a scan failure is unhealthy: a restart fixes an unreadable store, not a VM nobody can converge.
 		if err != nil {
 			healthy = false
 		}
@@ -31,9 +28,7 @@ func (d *Daemon) reconcile(ctx context.Context) {
 	d.state.publish(all, healthy, degraded, time.Now())
 }
 
-// reconcileBackend returns the backend's statuses, how many VMs the pass could
-// not converge, and any scan failure. A busy ops lock is not a failure — it is
-// the normal way supervision yields to a command.
+// reconcileBackend returns the backend's statuses, how many VMs the pass could not converge, and any scan failure; a busy ops lock is not a failure.
 func (d *Daemon) reconcileBackend(ctx context.Context, b Supervisor) ([]VMStatus, int, error) {
 	scan, err := b.ScanSupervision(ctx)
 	if err != nil {
@@ -103,9 +98,9 @@ func (d *Daemon) adoptLive(ctx context.Context, b Supervisor, key watchKey, rec 
 	if again, obsErr := b.ObserveVMM(ctx, fresh); obsErr != nil || again != proc {
 		return obsErr
 	}
-	gen := b.ReconcileToRunning(ctx, key.vmID)
-	if gen == 0 {
-		return nil
+	gen, err := b.ReconcileToRunning(ctx, key.vmID)
+	if err != nil || gen == 0 {
+		return err
 	}
 	log.WithFunc("daemon.adoptLive").Warnf(ctx, "adopted live VM %s whose record read %s", key.vmID, fresh.State)
 	d.watcher.ensure(key, proc, gen)
@@ -127,8 +122,9 @@ func (d *Daemon) convergeDead(ctx context.Context, b Supervisor, key watchKey, r
 	if err != nil || fresh == nil {
 		return err
 	}
-	if !d.confirmDead(ctx, b, fresh) {
-		return nil
+	dead, err := d.confirmDead(ctx, b, fresh)
+	if !dead {
+		return err
 	}
 	logger := log.WithFunc("daemon.convergeDead")
 	exited := hypervisor.NeedsDeadConvergence(fresh)
@@ -162,11 +158,7 @@ func (d *Daemon) collectOwnerless(ctx context.Context, b Supervisor, rec *hyperv
 	return nil
 }
 
-// resumeDelete finishes a delete a previous worker left mid-protocol. Supervision
-// starts deletes of its own when it collects an ownerless placeholder, so it must
-// also resume them: a crash or a transient teardown failure after the deleting
-// mark would otherwise strand the record and its name reservation until someone
-// runs gc by hand.
+// resumeDelete finishes a delete a previous worker left mid-protocol; supervision starts deletes of its own, and an unfinished one strands the record and its name until a manual gc.
 func (d *Daemon) resumeDelete(ctx context.Context, b Supervisor, vmID string) error {
 	unlock, ok, err := d.tryLock(ctx, b, vmID)
 	if !ok {
@@ -204,9 +196,6 @@ func (d *Daemon) handleExit(ctx context.Context, ev exitEvent) {
 // convergeExit runs the locked half of handleExit; the pass that follows must not be inside the lock it takes.
 func (d *Daemon) convergeExit(ctx context.Context, ev exitEvent) bool {
 	b := d.backends[ev.key.backend]
-	if b == nil {
-		return false
-	}
 	unlock, ok, _ := d.tryLock(ctx, b, ev.key.vmID)
 	if !ok {
 		return false
@@ -217,7 +206,7 @@ func (d *Daemon) convergeExit(ctx context.Context, ev exitEvent) bool {
 		return false
 	}
 	// A newer transition owns the record; this event may not date or label it.
-	if rec.TransitionGeneration != ev.gen || !d.confirmDead(ctx, b, rec) {
+	if dead, _ := d.confirmDead(ctx, b, rec); rec.TransitionGeneration != ev.gen || !dead {
 		return false
 	}
 	logger := log.WithFunc("daemon.handleExit")
@@ -229,10 +218,13 @@ func (d *Daemon) convergeExit(ctx context.Context, ev exitEvent) bool {
 	return true
 }
 
-// confirmDead re-observes under the ops lock; a live or inconclusive result defers the work to a later pass.
-func (d *Daemon) confirmDead(ctx context.Context, b Supervisor, rec *hypervisor.VMRecord) bool {
+// confirmDead re-observes under the ops lock; live and inconclusive both defer the work, but only inconclusive is a failure worth counting.
+func (d *Daemon) confirmDead(ctx context.Context, b Supervisor, rec *hypervisor.VMRecord) (bool, error) {
 	_, err := b.ObserveVMM(ctx, rec)
-	return errors.Is(err, hypervisor.ErrNotRunning)
+	if errors.Is(err, hypervisor.ErrNotRunning) {
+		return true, nil
+	}
+	return false, err
 }
 
 // tryLock reports ok=false for a busy lock and for a lock error alike; only the error is worth logging, and only it makes the pass unhealthy.

--- a/daemon/reconcile.go
+++ b/daemon/reconcile.go
@@ -41,7 +41,7 @@ func (d *Daemon) reconcileBackend(ctx context.Context, b Supervisor) ([]VMStatus
 		key := watchKey{backend: b.Type(), vmID: rec.ID}
 		live := false
 		if _, tombstoned := scan.Tombstoned[rec.ID]; !tombstoned {
-			live = d.reconcileVM(ctx, b, key, rec)
+			live = d.reconcileVM(ctx, b, key, rec, scan.Procs)
 		}
 		out = append(out, newVMStatus(b.Type(), rec, live, d.watcher.pidOf(key), now))
 	}
@@ -50,13 +50,13 @@ func (d *Daemon) reconcileBackend(ctx context.Context, b Supervisor) ([]VMStatus
 }
 
 // reconcileVM applies the supervision rules to one record and reports whether a VMM generation is live.
-func (d *Daemon) reconcileVM(ctx context.Context, b Supervisor, key watchKey, rec *hypervisor.VMRecord) bool {
+func (d *Daemon) reconcileVM(ctx context.Context, b Supervisor, key watchKey, rec *hypervisor.VMRecord, procs utils.ProcScan) bool {
 	// A creating placeholder is never promoted: a clone launches its VMM before the record is complete.
 	if rec.State == types.VMStateCreating {
 		d.collectOwnerless(ctx, b, rec)
 		return false
 	}
-	proc, err := b.ObserveVMM(ctx, rec)
+	proc, err := b.ObserveVMMIn(ctx, rec, procs)
 	switch {
 	case err == nil:
 		d.adoptLive(ctx, b, key, rec, proc)
@@ -89,18 +89,15 @@ func (d *Daemon) adoptLive(ctx context.Context, b Supervisor, key watchKey, rec 
 	if err != nil || fresh == nil || fresh.Quarantine != "" {
 		return
 	}
-	if fresh.State == types.VMStateRunning || fresh.State == types.VMStateCreating {
-		return
-	}
 	if again, obsErr := b.ObserveVMM(ctx, fresh); obsErr != nil || again != proc {
 		return
 	}
-	b.ReconcileToRunning(ctx, key.vmID)
-	log.WithFunc("daemon.adoptLive").Warnf(ctx, "adopted live VM %s whose record read %s", key.vmID, fresh.State)
-	// Re-read: the repair bumped the generation the watch must fence against.
-	if after, err := b.PeekRecord(ctx, key.vmID); err == nil && after != nil {
-		d.watcher.ensure(key, proc, after.TransitionGeneration)
+	gen := b.ReconcileToRunning(ctx, key.vmID)
+	if gen == 0 {
+		return
 	}
+	log.WithFunc("daemon.adoptLive").Warnf(ctx, "adopted live VM %s whose record read %s", key.vmID, fresh.State)
+	d.watcher.ensure(key, proc, gen)
 }
 
 // convergeDead lands the stop transition, or retries a quiesce the last stop could not finish.
@@ -122,18 +119,13 @@ func (d *Daemon) convergeDead(ctx context.Context, b Supervisor, key watchKey, r
 		return
 	}
 	logger := log.WithFunc("daemon.convergeDead")
-	if hypervisor.NeedsDeadConvergence(fresh) {
-		if err := b.ConvergeDead(ctx, key.vmID, fresh.TransitionGeneration, time.Now()); err != nil {
-			logger.Errorf(ctx, err, "converge %s", key.vmID)
-			return
-		}
-		logger.Warnf(ctx, "VM %s exited outside a cocoon stop", key.vmID)
+	exited := hypervisor.NeedsDeadConvergence(fresh)
+	if err := b.ConvergeDead(ctx, key.vmID, fresh.TransitionGeneration, time.Now()); err != nil {
+		logger.Errorf(ctx, err, "converge %s", key.vmID)
 		return
 	}
-	if fresh.QuiescePending {
-		if err := b.QuiesceIfPending(ctx, key.vmID); err != nil {
-			logger.Errorf(ctx, err, "retry quiesce %s", key.vmID)
-		}
+	if exited {
+		logger.Warnf(ctx, "VM %s exited outside a cocoon stop", key.vmID)
 	}
 }
 

--- a/daemon/reconcile.go
+++ b/daemon/reconcile.go
@@ -20,13 +20,16 @@ func (d *Daemon) reconcile(ctx context.Context) {
 		st, err := d.reconcileBackend(ctx, b)
 		if err != nil {
 			healthy = false
-			continue
 		}
 		all = append(all, st...)
 	}
 	d.state.publish(all, healthy, time.Now())
 }
 
+// reconcileBackend returns the backend's statuses plus the first failure the pass
+// hit. A busy ops lock is not a failure — it is the normal way supervision yields
+// to a command — but anything else means the pass did not fully succeed, which is
+// what /healthz reports.
 func (d *Daemon) reconcileBackend(ctx context.Context, b Supervisor) ([]VMStatus, error) {
 	scan, err := b.ScanSupervision(ctx)
 	if err != nil {
@@ -36,116 +39,143 @@ func (d *Daemon) reconcileBackend(ctx context.Context, b Supervisor) ([]VMStatus
 	now := time.Now()
 	seen := make(map[string]struct{}, len(scan.Records))
 	out := make([]VMStatus, 0, len(scan.Records))
+	var failed error
 	for _, rec := range scan.Records {
 		seen[rec.ID] = struct{}{}
 		key := watchKey{backend: b.Type(), vmID: rec.ID}
 		live := false
-		if _, tombstoned := scan.Tombstoned[rec.ID]; !tombstoned {
-			live = d.reconcileVM(ctx, b, key, rec, scan.Procs)
+		var vmErr error
+		if _, tombstoned := scan.Tombstoned[rec.ID]; tombstoned {
+			vmErr = d.resumeDelete(ctx, b, rec.ID)
+		} else {
+			live, vmErr = d.reconcileVM(ctx, b, key, rec, scan.Procs)
 		}
+		failed = cmpErr(failed, vmErr)
 		out = append(out, newVMStatus(b.Type(), rec, live, d.watcher.pidOf(key), now))
 	}
 	d.watcher.dropAbsent(b.Type(), seen)
-	return out, nil
+	return out, failed
 }
 
 // reconcileVM applies the supervision rules to one record and reports whether a VMM generation is live.
-func (d *Daemon) reconcileVM(ctx context.Context, b Supervisor, key watchKey, rec *hypervisor.VMRecord, procs utils.ProcScan) bool {
+func (d *Daemon) reconcileVM(ctx context.Context, b Supervisor, key watchKey, rec *hypervisor.VMRecord, procs utils.ProcScan) (bool, error) {
 	// A creating placeholder is never promoted: a clone launches its VMM before the record is complete.
 	if rec.State == types.VMStateCreating {
-		d.collectOwnerless(ctx, b, rec)
-		return false
+		return false, d.collectOwnerless(ctx, b, rec)
 	}
 	proc, err := b.ObserveVMMIn(ctx, rec, procs)
 	switch {
 	case err == nil:
-		d.adoptLive(ctx, b, key, rec, proc)
-		return true
+		return true, d.adoptLive(ctx, b, key, rec, proc)
 	case errors.Is(err, hypervisor.ErrNotRunning):
-		d.convergeDead(ctx, b, key, rec)
-		return false
+		return false, d.convergeDead(ctx, b, key, rec)
 	default:
 		// Fail closed: an inconclusive probe must never be read as an exit.
 		log.WithFunc("daemon.reconcileVM").Warnf(ctx, "liveness inconclusive for %s/%s: %v", key.backend, key.vmID, err)
-		return false
+		return false, err
 	}
 }
 
 // adoptLive watches the exact live generation, repairing a record that drifted out of Running first.
-func (d *Daemon) adoptLive(ctx context.Context, b Supervisor, key watchKey, rec *hypervisor.VMRecord, proc utils.ProcRef) {
+func (d *Daemon) adoptLive(ctx context.Context, b Supervisor, key watchKey, rec *hypervisor.VMRecord, proc utils.ProcRef) error {
 	if rec.State == types.VMStateRunning {
 		d.watcher.ensure(key, proc, rec.TransitionGeneration)
-		return
+		return nil
 	}
 	if rec.Quarantine != "" {
-		return
+		return nil
 	}
-	unlock, ok := d.tryLock(ctx, b, key.vmID)
+	unlock, ok, err := d.tryLock(ctx, b, key.vmID)
 	if !ok {
-		return
+		return err
 	}
 	defer unlock()
 	fresh, err := b.PeekRecord(ctx, key.vmID)
 	if err != nil || fresh == nil || fresh.Quarantine != "" {
-		return
+		return err
 	}
 	if again, obsErr := b.ObserveVMM(ctx, fresh); obsErr != nil || again != proc {
-		return
+		return obsErr
 	}
 	gen := b.ReconcileToRunning(ctx, key.vmID)
 	if gen == 0 {
-		return
+		return nil
 	}
 	log.WithFunc("daemon.adoptLive").Warnf(ctx, "adopted live VM %s whose record read %s", key.vmID, fresh.State)
 	d.watcher.ensure(key, proc, gen)
+	return nil
 }
 
 // convergeDead lands the stop transition, or retries a quiesce the last stop could not finish.
-func (d *Daemon) convergeDead(ctx context.Context, b Supervisor, key watchKey, rec *hypervisor.VMRecord) {
+func (d *Daemon) convergeDead(ctx context.Context, b Supervisor, key watchKey, rec *hypervisor.VMRecord) error {
 	d.watcher.drop(key)
 	if !hypervisor.NeedsDeadConvergence(rec) && !rec.QuiescePending {
-		return
+		return nil
 	}
-	unlock, ok := d.tryLock(ctx, b, key.vmID)
+	unlock, ok, err := d.tryLock(ctx, b, key.vmID)
 	if !ok {
-		return
+		return err
 	}
 	defer unlock()
 	fresh, err := b.PeekRecord(ctx, key.vmID)
 	if err != nil || fresh == nil {
-		return
+		return err
 	}
 	if !d.confirmDead(ctx, b, fresh) {
-		return
+		return nil
 	}
 	logger := log.WithFunc("daemon.convergeDead")
 	exited := hypervisor.NeedsDeadConvergence(fresh)
 	if err := b.ConvergeDead(ctx, key.vmID, fresh.TransitionGeneration, time.Now()); err != nil {
 		logger.Errorf(ctx, err, "converge %s", key.vmID)
-		return
+		return err
 	}
 	if exited {
 		logger.Warnf(ctx, "VM %s exited outside a cocoon stop", key.vmID)
 	}
+	return nil
 }
 
 // collectOwnerless reclaims a creating placeholder whose owner died; a free ops lock is the proof, since create and clone hold it from prereserve through the final record commit.
-func (d *Daemon) collectOwnerless(ctx context.Context, b Supervisor, rec *hypervisor.VMRecord) {
-	unlock, ok := d.tryLock(ctx, b, rec.ID)
+func (d *Daemon) collectOwnerless(ctx context.Context, b Supervisor, rec *hypervisor.VMRecord) error {
+	unlock, ok, err := d.tryLock(ctx, b, rec.ID)
 	if !ok {
-		return
+		return err
 	}
 	defer unlock()
 	fresh, err := b.PeekRecord(ctx, rec.ID)
 	if err != nil || fresh == nil || fresh.State != types.VMStateCreating {
-		return
+		return err
 	}
 	logger := log.WithFunc("daemon.collectOwnerless")
 	if err := b.CollectStaleCreate(ctx, rec.ID, fresh); err != nil {
 		logger.Errorf(ctx, err, "collect ownerless create %s", rec.ID)
-		return
+		return err
 	}
 	logger.Warnf(ctx, "collected ownerless creating VM %s", rec.ID)
+	return nil
+}
+
+// resumeDelete finishes a delete a previous worker left mid-protocol. Supervision
+// starts deletes of its own when it collects an ownerless placeholder, so it must
+// also resume them: a crash or a transient teardown failure after the deleting
+// mark would otherwise strand the record and its name reservation until someone
+// runs gc by hand.
+func (d *Daemon) resumeDelete(ctx context.Context, b Supervisor, vmID string) error {
+	unlock, ok, err := d.tryLock(ctx, b, vmID)
+	if !ok {
+		return err
+	}
+	defer unlock()
+	done, err := b.RecoverTombstone(ctx, vmID)
+	if err != nil {
+		log.WithFunc("daemon.resumeDelete").Errorf(ctx, err, "resume interrupted delete of %s", vmID)
+		return err
+	}
+	if done {
+		log.WithFunc("daemon.resumeDelete").Warnf(ctx, "finished an interrupted delete of VM %s", vmID)
+	}
+	return nil
 }
 
 // handleExit converges the generation the watcher saw exit, dating the stop from that observation, then republishes for stream consumers.
@@ -171,7 +201,7 @@ func (d *Daemon) convergeExit(ctx context.Context, ev exitEvent) bool {
 	if b == nil {
 		return false
 	}
-	unlock, ok := d.tryLock(ctx, b, ev.key.vmID)
+	unlock, ok, _ := d.tryLock(ctx, b, ev.key.vmID)
 	if !ok {
 		return false
 	}
@@ -199,12 +229,20 @@ func (d *Daemon) confirmDead(ctx context.Context, b Supervisor, rec *hypervisor.
 	return errors.Is(err, hypervisor.ErrNotRunning)
 }
 
-// tryLock reports ok=false for a busy lock and for a lock error alike; both retry next pass, only the error is logged.
-func (d *Daemon) tryLock(ctx context.Context, b Supervisor, vmID string) (func(), bool) {
+// tryLock reports ok=false for a busy lock and for a lock error alike; only the error is worth logging, and only it makes the pass unhealthy.
+func (d *Daemon) tryLock(ctx context.Context, b Supervisor, vmID string) (func(), bool, error) {
 	unlock, ok, err := b.TryLockVMOps(ctx, vmID)
 	if err != nil {
 		log.WithFunc("daemon.tryLock").Errorf(ctx, err, "ops lock for %s", vmID)
-		return nil, false
+		return nil, false, err
 	}
-	return unlock, ok
+	return unlock, ok, nil
+}
+
+// cmpErr keeps the first failure of a pass; later ones are already logged where they happened.
+func cmpErr(first, next error) error {
+	if first != nil {
+		return first
+	}
+	return next
 }

--- a/daemon/reconcile.go
+++ b/daemon/reconcile.go
@@ -137,10 +137,7 @@ func (d *Daemon) convergeDead(ctx context.Context, b Supervisor, key watchKey, r
 	}
 }
 
-// collectOwnerless reclaims a creating placeholder whose owner died. A free ops
-// lock is the proof: create and clone hold it from prereserve through the final
-// record commit, so an unlocked placeholder has no live owner and its name
-// reservation must not wait out the GC grace.
+// collectOwnerless reclaims a creating placeholder whose owner died; a free ops lock is the proof, since create and clone hold it from prereserve through the final record commit.
 func (d *Daemon) collectOwnerless(ctx context.Context, b Supervisor, rec *hypervisor.VMRecord) {
 	unlock, ok := d.tryLock(ctx, b, rec.ID)
 	if !ok {
@@ -159,9 +156,7 @@ func (d *Daemon) collectOwnerless(ctx context.Context, b Supervisor, rec *hyperv
 	logger.Warnf(ctx, "collected ownerless creating VM %s", rec.ID)
 }
 
-// handleExit converges the one generation the watcher saw exit, dating the stop
-// from the observation rather than from detection, then republishes so a stream
-// consumer learns of the crash without waiting for the ticker.
+// handleExit converges the generation the watcher saw exit, dating the stop from that observation, then republishes for stream consumers.
 func (d *Daemon) handleExit(ctx context.Context, ev exitEvent) {
 	converged := d.convergeExit(ctx, ev)
 	for {
@@ -212,8 +207,7 @@ func (d *Daemon) confirmDead(ctx context.Context, b Supervisor, rec *hypervisor.
 	return errors.Is(err, hypervisor.ErrNotRunning)
 }
 
-// tryLock reports ok=false for both a busy lock (an operation owns the VM) and a
-// lock error; both retry on the next pass, only the error is logged.
+// tryLock reports ok=false for a busy lock and for a lock error alike; both retry next pass, only the error is logged.
 func (d *Daemon) tryLock(ctx context.Context, b Supervisor, vmID string) (func(), bool) {
 	unlock, ok, err := b.TryLockVMOps(ctx, vmID)
 	if err != nil {

--- a/daemon/reconcile.go
+++ b/daemon/reconcile.go
@@ -1,0 +1,224 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/projecteru2/core/log"
+
+	"github.com/cocoonstack/cocoon/hypervisor"
+	"github.com/cocoonstack/cocoon/types"
+	"github.com/cocoonstack/cocoon/utils"
+)
+
+// reconcile runs one idempotent pass over every backend and republishes the API snapshot.
+func (d *Daemon) reconcile(ctx context.Context) {
+	all := make([]VMStatus, 0, d.state.size())
+	healthy := true
+	for _, b := range d.order {
+		st, err := d.reconcileBackend(ctx, b)
+		if err != nil {
+			healthy = false
+			continue
+		}
+		all = append(all, st...)
+	}
+	d.state.publish(all, healthy, time.Now())
+}
+
+func (d *Daemon) reconcileBackend(ctx context.Context, b Supervisor) ([]VMStatus, error) {
+	scan, err := b.ScanSupervision(ctx)
+	if err != nil {
+		log.WithFunc("daemon.reconcileBackend").Errorf(ctx, err, "scan %s", b.Type())
+		return nil, err
+	}
+	now := time.Now()
+	seen := make(map[string]struct{}, len(scan.Records))
+	out := make([]VMStatus, 0, len(scan.Records))
+	for _, rec := range scan.Records {
+		seen[rec.ID] = struct{}{}
+		key := watchKey{backend: b.Type(), vmID: rec.ID}
+		live := false
+		if _, tombstoned := scan.Tombstoned[rec.ID]; !tombstoned {
+			live = d.reconcileVM(ctx, b, key, rec)
+		}
+		out = append(out, newVMStatus(b.Type(), rec, live, d.watcher.pidOf(key), now))
+	}
+	d.watcher.dropAbsent(b.Type(), seen)
+	return out, nil
+}
+
+// reconcileVM applies the supervision rules to one record and reports whether a VMM generation is live.
+func (d *Daemon) reconcileVM(ctx context.Context, b Supervisor, key watchKey, rec *hypervisor.VMRecord) bool {
+	// A creating placeholder is never promoted: a clone launches its VMM before the record is complete.
+	if rec.State == types.VMStateCreating {
+		d.collectOwnerless(ctx, b, rec)
+		return false
+	}
+	proc, err := b.ObserveVMM(ctx, rec)
+	switch {
+	case err == nil:
+		d.adoptLive(ctx, b, key, rec, proc)
+		return true
+	case errors.Is(err, hypervisor.ErrNotRunning):
+		d.convergeDead(ctx, b, key, rec)
+		return false
+	default:
+		// Fail closed: an inconclusive probe must never be read as an exit.
+		log.WithFunc("daemon.reconcileVM").Warnf(ctx, "liveness inconclusive for %s/%s: %v", key.backend, key.vmID, err)
+		return false
+	}
+}
+
+// adoptLive watches the exact live generation, repairing a record that drifted out of Running first.
+func (d *Daemon) adoptLive(ctx context.Context, b Supervisor, key watchKey, rec *hypervisor.VMRecord, proc utils.ProcRef) {
+	if rec.State == types.VMStateRunning {
+		d.watcher.ensure(key, proc, rec.TransitionGeneration)
+		return
+	}
+	if rec.Quarantine != "" {
+		return
+	}
+	unlock, ok := d.tryLock(ctx, b, key.vmID)
+	if !ok {
+		return
+	}
+	defer unlock()
+	fresh, err := b.PeekRecord(ctx, key.vmID)
+	if err != nil || fresh == nil || fresh.Quarantine != "" {
+		return
+	}
+	if fresh.State == types.VMStateRunning || fresh.State == types.VMStateCreating {
+		return
+	}
+	if again, obsErr := b.ObserveVMM(ctx, fresh); obsErr != nil || again != proc {
+		return
+	}
+	b.ReconcileToRunning(ctx, key.vmID)
+	log.WithFunc("daemon.adoptLive").Warnf(ctx, "adopted live VM %s whose record read %s", key.vmID, fresh.State)
+	// Re-read: the repair bumped the generation the watch must fence against.
+	if after, err := b.PeekRecord(ctx, key.vmID); err == nil && after != nil {
+		d.watcher.ensure(key, proc, after.TransitionGeneration)
+	}
+}
+
+// convergeDead lands the stop transition, or retries a quiesce the last stop could not finish.
+func (d *Daemon) convergeDead(ctx context.Context, b Supervisor, key watchKey, rec *hypervisor.VMRecord) {
+	d.watcher.drop(key)
+	if !hypervisor.NeedsDeadConvergence(rec) && !rec.QuiescePending {
+		return
+	}
+	unlock, ok := d.tryLock(ctx, b, key.vmID)
+	if !ok {
+		return
+	}
+	defer unlock()
+	fresh, err := b.PeekRecord(ctx, key.vmID)
+	if err != nil || fresh == nil {
+		return
+	}
+	if !d.confirmDead(ctx, b, fresh) {
+		return
+	}
+	logger := log.WithFunc("daemon.convergeDead")
+	if hypervisor.NeedsDeadConvergence(fresh) {
+		if err := b.ConvergeDead(ctx, key.vmID, fresh.TransitionGeneration, time.Now()); err != nil {
+			logger.Errorf(ctx, err, "converge %s", key.vmID)
+			return
+		}
+		logger.Warnf(ctx, "VM %s exited outside a cocoon stop", key.vmID)
+		return
+	}
+	if fresh.QuiescePending {
+		if err := b.QuiesceIfPending(ctx, key.vmID); err != nil {
+			logger.Errorf(ctx, err, "retry quiesce %s", key.vmID)
+		}
+	}
+}
+
+// collectOwnerless reclaims a creating placeholder whose owner died. A free ops
+// lock is the proof: create and clone hold it from prereserve through the final
+// record commit, so an unlocked placeholder has no live owner and its name
+// reservation must not wait out the GC grace.
+func (d *Daemon) collectOwnerless(ctx context.Context, b Supervisor, rec *hypervisor.VMRecord) {
+	unlock, ok := d.tryLock(ctx, b, rec.ID)
+	if !ok {
+		return
+	}
+	defer unlock()
+	fresh, err := b.PeekRecord(ctx, rec.ID)
+	if err != nil || fresh == nil || fresh.State != types.VMStateCreating {
+		return
+	}
+	logger := log.WithFunc("daemon.collectOwnerless")
+	if err := b.CollectStaleCreate(ctx, rec.ID, fresh); err != nil {
+		logger.Errorf(ctx, err, "collect ownerless create %s", rec.ID)
+		return
+	}
+	logger.Warnf(ctx, "collected ownerless creating VM %s", rec.ID)
+}
+
+// handleExit converges the one generation the watcher saw exit, dating the stop
+// from the observation rather than from detection, then republishes so a stream
+// consumer learns of the crash without waiting for the ticker.
+func (d *Daemon) handleExit(ctx context.Context, ev exitEvent) {
+	converged := d.convergeExit(ctx, ev)
+	for {
+		select {
+		case next := <-d.watcher.exits:
+			// Coalesce a burst: a host-wide kill must cost one pass, not one per VM.
+			converged = d.convergeExit(ctx, next) || converged
+		default:
+			if converged {
+				d.reconcile(ctx)
+			}
+			return
+		}
+	}
+}
+
+// convergeExit runs the locked half of handleExit; the pass that follows must not be inside the lock it takes.
+func (d *Daemon) convergeExit(ctx context.Context, ev exitEvent) bool {
+	b := d.backends[ev.key.backend]
+	if b == nil {
+		return false
+	}
+	unlock, ok := d.tryLock(ctx, b, ev.key.vmID)
+	if !ok {
+		return false
+	}
+	defer unlock()
+	rec, err := b.PeekRecord(ctx, ev.key.vmID)
+	if err != nil || rec == nil {
+		return false
+	}
+	// A newer transition owns the record; this event may not date or label it.
+	if rec.TransitionGeneration != ev.gen || !d.confirmDead(ctx, b, rec) {
+		return false
+	}
+	logger := log.WithFunc("daemon.handleExit")
+	if err := b.ConvergeDead(ctx, ev.key.vmID, ev.gen, ev.at); err != nil {
+		logger.Errorf(ctx, err, "converge %s", ev.key.vmID)
+		return false
+	}
+	logger.Warnf(ctx, "VM %s exited outside a cocoon stop", ev.key.vmID)
+	return true
+}
+
+// confirmDead re-observes under the ops lock; a live or inconclusive result defers the work to a later pass.
+func (d *Daemon) confirmDead(ctx context.Context, b Supervisor, rec *hypervisor.VMRecord) bool {
+	_, err := b.ObserveVMM(ctx, rec)
+	return errors.Is(err, hypervisor.ErrNotRunning)
+}
+
+// tryLock reports ok=false for both a busy lock (an operation owns the VM) and a
+// lock error; both retry on the next pass, only the error is logged.
+func (d *Daemon) tryLock(ctx context.Context, b Supervisor, vmID string) (func(), bool) {
+	unlock, ok, err := b.TryLockVMOps(ctx, vmID)
+	if err != nil {
+		log.WithFunc("daemon.tryLock").Errorf(ctx, err, "ops lock for %s", vmID)
+		return nil, false
+	}
+	return unlock, ok
+}

--- a/daemon/reconcile_test.go
+++ b/daemon/reconcile_test.go
@@ -59,6 +59,10 @@ func (f *fakeSupervisor) ScanSupervision(context.Context) (hypervisor.Supervisio
 	return scan, nil
 }
 
+func (f *fakeSupervisor) ObserveVMMIn(ctx context.Context, rec *hypervisor.VMRecord, _ utils.ProcScan) (utils.ProcRef, error) {
+	return f.ObserveVMM(ctx, rec)
+}
+
 func (f *fakeSupervisor) ObserveVMM(_ context.Context, rec *hypervisor.VMRecord) (utils.ProcRef, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -90,35 +94,35 @@ func (f *fakeSupervisor) PeekRecord(_ context.Context, vmID string) (*hypervisor
 	return f.records[vmID], nil
 }
 
+// ConvergeDead mirrors the real composition: the record transition when one is
+// due, then the pending quiesce.
 func (f *fakeSupervisor) ConvergeDead(_ context.Context, vmID string, gen uint64, _ time.Time) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.converged = append(f.converged, convergeCall{vmID: vmID, gen: gen})
-	if rec := f.records[vmID]; rec != nil {
+	rec := f.records[vmID]
+	if rec != nil && hypervisor.NeedsDeadConvergence(rec) && rec.TransitionGeneration == gen {
+		f.converged = append(f.converged, convergeCall{vmID: vmID, gen: gen})
 		rec.State = types.VMStateStopped
 		rec.TransitionGeneration++
 	}
-	return nil
-}
-
-func (f *fakeSupervisor) QuiesceIfPending(_ context.Context, vmID string) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.quiesced = append(f.quiesced, vmID)
-	if rec := f.records[vmID]; rec != nil {
+	if rec != nil && rec.QuiescePending {
+		f.quiesced = append(f.quiesced, vmID)
 		rec.QuiescePending = false
 	}
 	return nil
 }
 
-func (f *fakeSupervisor) ReconcileToRunning(_ context.Context, vmID string) {
+func (f *fakeSupervisor) ReconcileToRunning(_ context.Context, vmID string) uint64 {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.adopted = append(f.adopted, vmID)
-	if rec := f.records[vmID]; rec != nil {
-		rec.State = types.VMStateRunning
-		rec.TransitionGeneration++
+	rec := f.records[vmID]
+	if rec == nil || rec.Quarantine != "" || rec.State == types.VMStateCreating {
+		return 0
 	}
+	f.adopted = append(f.adopted, vmID)
+	rec.State = types.VMStateRunning
+	rec.TransitionGeneration++
+	return rec.TransitionGeneration
 }
 
 func (f *fakeSupervisor) CollectStaleCreate(_ context.Context, vmID string, _ *hypervisor.VMRecord) error {

--- a/daemon/reconcile_test.go
+++ b/daemon/reconcile_test.go
@@ -1,0 +1,308 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cocoonstack/cocoon/hypervisor"
+	"github.com/cocoonstack/cocoon/types"
+	"github.com/cocoonstack/cocoon/utils"
+)
+
+type convergeCall struct {
+	vmID string
+	gen  uint64
+}
+
+// fakeSupervisor scripts one backend's record set, liveness and lock state.
+type fakeSupervisor struct {
+	mu         sync.Mutex
+	records    map[string]*hypervisor.VMRecord
+	tombstoned map[string]struct{}
+	live       map[string]utils.ProcRef
+	busy       map[string]struct{}
+	lockErr    error
+	observeErr error
+
+	converged []convergeCall
+	adopted   []string
+	collected []string
+	quiesced  []string
+}
+
+func newFake() *fakeSupervisor {
+	return &fakeSupervisor{
+		records:    map[string]*hypervisor.VMRecord{},
+		tombstoned: map[string]struct{}{},
+		live:       map[string]utils.ProcRef{},
+		busy:       map[string]struct{}{},
+	}
+}
+
+func (f *fakeSupervisor) put(rec *hypervisor.VMRecord) *fakeSupervisor {
+	f.records[rec.ID] = rec
+	return f
+}
+
+func (f *fakeSupervisor) Type() string { return "fake-hv" }
+
+func (f *fakeSupervisor) ScanSupervision(context.Context) (hypervisor.SupervisionScan, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	scan := hypervisor.SupervisionScan{Tombstoned: f.tombstoned}
+	for _, rec := range f.records {
+		scan.Records = append(scan.Records, rec)
+	}
+	return scan, nil
+}
+
+func (f *fakeSupervisor) ObserveVMM(_ context.Context, rec *hypervisor.VMRecord) (utils.ProcRef, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.observeErr != nil {
+		return utils.ProcRef{}, f.observeErr
+	}
+	proc, ok := f.live[rec.ID]
+	if !ok {
+		return utils.ProcRef{}, hypervisor.ErrNotRunning
+	}
+	return proc, nil
+}
+
+func (f *fakeSupervisor) TryLockVMOps(_ context.Context, vmID string) (func(), bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.lockErr != nil {
+		return nil, false, f.lockErr
+	}
+	if _, held := f.busy[vmID]; held {
+		return nil, false, nil
+	}
+	return func() {}, true, nil
+}
+
+func (f *fakeSupervisor) PeekRecord(_ context.Context, vmID string) (*hypervisor.VMRecord, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.records[vmID], nil
+}
+
+func (f *fakeSupervisor) ConvergeDead(_ context.Context, vmID string, gen uint64, _ time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.converged = append(f.converged, convergeCall{vmID: vmID, gen: gen})
+	if rec := f.records[vmID]; rec != nil {
+		rec.State = types.VMStateStopped
+		rec.TransitionGeneration++
+	}
+	return nil
+}
+
+func (f *fakeSupervisor) QuiesceIfPending(_ context.Context, vmID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.quiesced = append(f.quiesced, vmID)
+	if rec := f.records[vmID]; rec != nil {
+		rec.QuiescePending = false
+	}
+	return nil
+}
+
+func (f *fakeSupervisor) ReconcileToRunning(_ context.Context, vmID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.adopted = append(f.adopted, vmID)
+	if rec := f.records[vmID]; rec != nil {
+		rec.State = types.VMStateRunning
+		rec.TransitionGeneration++
+	}
+}
+
+func (f *fakeSupervisor) CollectStaleCreate(_ context.Context, vmID string, _ *hypervisor.VMRecord) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.collected = append(f.collected, vmID)
+	delete(f.records, vmID)
+	return nil
+}
+
+func newTestDaemon(t *testing.T, f *fakeSupervisor) *Daemon {
+	t.Helper()
+	d, err := New(Config{RootDir: t.TempDir()}, nil, []Supervisor{f})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return d
+}
+
+func runningRec(id string, gen uint64) *hypervisor.VMRecord {
+	return &hypervisor.VMRecord{VM: types.VM{ID: id, State: types.VMStateRunning, TransitionGeneration: gen}}
+}
+
+func TestReconcileConvergesDeadRunningRecord(t *testing.T) {
+	f := newFake().put(runningRec("vm1", 7))
+	newTestDaemon(t, f).reconcile(t.Context())
+
+	if len(f.converged) != 1 || f.converged[0] != (convergeCall{vmID: "vm1", gen: 7}) {
+		t.Fatalf("got %+v, want one convergence fenced on generation 7", f.converged)
+	}
+}
+
+func TestReconcileSkipsVMWithBusyOpsLock(t *testing.T) {
+	f := newFake().put(runningRec("vm1", 1))
+	f.busy["vm1"] = struct{}{}
+	newTestDaemon(t, f).reconcile(t.Context())
+
+	if len(f.converged) != 0 {
+		t.Errorf("got %+v, want no convergence while an operation owns the VM", f.converged)
+	}
+}
+
+func TestReconcileSkipsOnLockError(t *testing.T) {
+	f := newFake().put(runningRec("vm1", 1))
+	f.lockErr = fmt.Errorf("no such directory")
+	newTestDaemon(t, f).reconcile(t.Context())
+
+	if len(f.converged) != 0 {
+		t.Errorf("got %+v, want no convergence when the lock could not be evaluated", f.converged)
+	}
+}
+
+// An inconclusive liveness probe must never be read as an exit.
+func TestReconcileSkipsInconclusiveLiveness(t *testing.T) {
+	f := newFake().put(runningRec("vm1", 1))
+	f.observeErr = fmt.Errorf("/proc scan errored")
+	newTestDaemon(t, f).reconcile(t.Context())
+
+	if len(f.converged) != 0 {
+		t.Errorf("got %+v, want no convergence on an inconclusive probe", f.converged)
+	}
+}
+
+func TestReconcileSkipsTombstonedVM(t *testing.T) {
+	f := newFake().put(runningRec("vm1", 1))
+	f.tombstoned["vm1"] = struct{}{}
+	newTestDaemon(t, f).reconcile(t.Context())
+
+	if len(f.converged) != 0 {
+		t.Errorf("got %+v, want an unfinished delete left to the entry guard and GC", f.converged)
+	}
+}
+
+func TestReconcileAdoptsLiveDriftedRecord(t *testing.T) {
+	rec := &hypervisor.VMRecord{VM: types.VM{ID: "vm1", State: types.VMStateStopped, TransitionGeneration: 3}}
+	f := newFake().put(rec)
+	f.live["vm1"] = utils.ProcRef{PID: 4242, Start: 99}
+	newTestDaemon(t, f).reconcile(t.Context())
+
+	if len(f.adopted) != 1 || f.adopted[0] != "vm1" {
+		t.Fatalf("got adopted %v, want the live VM repaired to running", f.adopted)
+	}
+	if len(f.converged) != 0 {
+		t.Errorf("got %+v, want no convergence for a live VM", f.converged)
+	}
+}
+
+func TestReconcileLeavesQuarantinedRecordAlone(t *testing.T) {
+	rec := &hypervisor.VMRecord{VM: types.VM{ID: "vm1", State: types.VMStateError}, Quarantine: "partial restore"}
+	f := newFake().put(rec)
+	f.live["vm1"] = utils.ProcRef{PID: 4242, Start: 99}
+	newTestDaemon(t, f).reconcile(t.Context())
+
+	if len(f.adopted) != 0 {
+		t.Errorf("got adopted %v, want a quarantined record left for restore or rm", f.adopted)
+	}
+}
+
+func TestReconcileCollectsOwnerlessCreating(t *testing.T) {
+	f := newFake().put(&hypervisor.VMRecord{VM: types.VM{ID: "vm1", State: types.VMStateCreating}})
+	newTestDaemon(t, f).reconcile(t.Context())
+
+	if len(f.collected) != 1 || f.collected[0] != "vm1" {
+		t.Fatalf("got collected %v, want the ownerless placeholder reclaimed", f.collected)
+	}
+}
+
+// A held ops lock is the create owner still working; the placeholder is not ownerless.
+func TestReconcileLeavesInFlightCreating(t *testing.T) {
+	f := newFake().put(&hypervisor.VMRecord{VM: types.VM{ID: "vm1", State: types.VMStateCreating}})
+	f.busy["vm1"] = struct{}{}
+	newTestDaemon(t, f).reconcile(t.Context())
+
+	if len(f.collected) != 0 {
+		t.Errorf("got collected %v, want an in-flight create untouched", f.collected)
+	}
+}
+
+func TestReconcileRetriesPendingQuiesce(t *testing.T) {
+	rec := &hypervisor.VMRecord{VM: types.VM{ID: "vm1", State: types.VMStateStopped, TransitionGeneration: 2}}
+	rec.QuiescePending = true
+	f := newFake().put(rec)
+	newTestDaemon(t, f).reconcile(t.Context())
+
+	if len(f.quiesced) != 1 || f.quiesced[0] != "vm1" {
+		t.Fatalf("got quiesced %v, want the pending quiesce retried", f.quiesced)
+	}
+	if len(f.converged) != 0 {
+		t.Errorf("got %+v, want no second transition for an already-stopped VM", f.converged)
+	}
+}
+
+func TestReconcileLeavesSettledVMAlone(t *testing.T) {
+	f := newFake().put(&hypervisor.VMRecord{VM: types.VM{ID: "vm1", State: types.VMStateStopped, TransitionGeneration: 2}})
+	newTestDaemon(t, f).reconcile(t.Context())
+
+	if len(f.converged)+len(f.quiesced)+len(f.adopted) != 0 {
+		t.Error("a settled record was rewritten")
+	}
+}
+
+func TestHandleExitConvergesWatchedGeneration(t *testing.T) {
+	f := newFake().put(runningRec("vm1", 4))
+	d := newTestDaemon(t, f)
+	at := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+
+	d.handleExit(t.Context(), exitEvent{key: watchKey{backend: f.Type(), vmID: "vm1"}, gen: 4, at: at})
+
+	if len(f.converged) != 1 || f.converged[0].gen != 4 {
+		t.Fatalf("got %+v, want one convergence at generation 4", f.converged)
+	}
+}
+
+// An exit observed before a restart must not date or re-label the newer transition.
+func TestHandleExitDropsStaleGeneration(t *testing.T) {
+	f := newFake().put(runningRec("vm1", 9))
+	d := newTestDaemon(t, f)
+
+	d.handleExit(t.Context(), exitEvent{key: watchKey{backend: f.Type(), vmID: "vm1"}, gen: 4, at: time.Now()})
+
+	if len(f.converged) != 0 {
+		t.Errorf("got %+v, want the stale event dropped", f.converged)
+	}
+}
+
+func TestHandleExitSkipsRevivedVM(t *testing.T) {
+	f := newFake().put(runningRec("vm1", 4))
+	f.live["vm1"] = utils.ProcRef{PID: 4242, Start: 7}
+	d := newTestDaemon(t, f)
+
+	d.handleExit(t.Context(), exitEvent{key: watchKey{backend: f.Type(), vmID: "vm1"}, gen: 4, at: time.Now()})
+
+	if len(f.converged) != 0 {
+		t.Errorf("got %+v, want no convergence while a VMM generation is live", f.converged)
+	}
+}
+
+func TestHandleExitIgnoresDeletedRecord(t *testing.T) {
+	f := newFake()
+	d := newTestDaemon(t, f)
+
+	d.handleExit(t.Context(), exitEvent{key: watchKey{backend: f.Type(), vmID: "gone"}, gen: 1, at: time.Now()})
+
+	if len(f.converged) != 0 {
+		t.Errorf("got %+v, want nothing for a record removed while the event queued", f.converged)
+	}
+}

--- a/daemon/reconcile_test.go
+++ b/daemon/reconcile_test.go
@@ -27,10 +27,13 @@ type fakeSupervisor struct {
 	lockErr    error
 	observeErr error
 
+	resumeErr error
+
 	converged []convergeCall
 	adopted   []string
 	collected []string
 	quiesced  []string
+	resumed   []string
 }
 
 func newFake() *fakeSupervisor {
@@ -125,6 +128,18 @@ func (f *fakeSupervisor) ReconcileToRunning(_ context.Context, vmID string) uint
 	return rec.TransitionGeneration
 }
 
+func (f *fakeSupervisor) RecoverTombstone(_ context.Context, vmID string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.resumed = append(f.resumed, vmID)
+	if f.resumeErr != nil {
+		return false, f.resumeErr
+	}
+	delete(f.records, vmID)
+	delete(f.tombstoned, vmID)
+	return true, nil
+}
+
 func (f *fakeSupervisor) CollectStaleCreate(_ context.Context, vmID string, _ *hypervisor.VMRecord) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -186,13 +201,29 @@ func TestReconcileSkipsInconclusiveLiveness(t *testing.T) {
 	}
 }
 
-func TestReconcileSkipsTombstonedVM(t *testing.T) {
+// A tombstoned record is not supervised as a live VM, but the daemon starts
+// deletes of its own, so it must finish one a crash left mid-protocol.
+func TestReconcileResumesInterruptedDelete(t *testing.T) {
 	f := newFake().put(runningRec("vm1", 1))
 	f.tombstoned["vm1"] = struct{}{}
 	newTestDaemon(t, f).reconcile(t.Context())
 
 	if len(f.converged) != 0 {
-		t.Errorf("got %+v, want an unfinished delete left to the entry guard and GC", f.converged)
+		t.Errorf("got %+v, want no state convergence for a record being deleted", f.converged)
+	}
+	if len(f.resumed) != 1 || f.resumed[0] != "vm1" {
+		t.Fatalf("got resumed %v, want the interrupted delete finished", f.resumed)
+	}
+}
+
+func TestReconcileLeavesInterruptedDeleteLockedByAnOwner(t *testing.T) {
+	f := newFake().put(runningRec("vm1", 1))
+	f.tombstoned["vm1"] = struct{}{}
+	f.busy["vm1"] = struct{}{}
+	newTestDaemon(t, f).reconcile(t.Context())
+
+	if len(f.resumed) != 0 {
+		t.Errorf("got resumed %v, want the owning operation left to finish it", f.resumed)
 	}
 }
 
@@ -308,5 +339,45 @@ func TestHandleExitIgnoresDeletedRecord(t *testing.T) {
 
 	if len(f.converged) != 0 {
 		t.Errorf("got %+v, want nothing for a record removed while the event queued", f.converged)
+	}
+}
+
+// /healthz promises a full pass succeeded, so a real failure must make the pass
+// unhealthy — while a busy ops lock, which is how supervision yields to a
+// command, must not.
+func TestPassHealthReflectsFailuresButNotBusyLocks(t *testing.T) {
+	tests := []struct {
+		name    string
+		arrange func(*fakeSupervisor)
+		healthy bool
+	}{
+		{"clean pass", func(*fakeSupervisor) {}, true},
+		{"busy ops lock", func(f *fakeSupervisor) { f.busy["vm1"] = struct{}{} }, true},
+		{"ops lock error", func(f *fakeSupervisor) { f.lockErr = fmt.Errorf("no such directory") }, false},
+		{"inconclusive liveness", func(f *fakeSupervisor) { f.observeErr = fmt.Errorf("/proc scan errored") }, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newFake().put(runningRec("vm1", 1))
+			tt.arrange(f)
+			d := newTestDaemon(t, f)
+			d.reconcile(t.Context())
+
+			if _, healthy, _ := d.state.snapshot(); healthy != tt.healthy {
+				t.Errorf("got healthy=%v, want %v", healthy, tt.healthy)
+			}
+		})
+	}
+}
+
+func TestPassUnhealthyWhenAnInterruptedDeleteCannotFinish(t *testing.T) {
+	f := newFake().put(runningRec("vm1", 1))
+	f.tombstoned["vm1"] = struct{}{}
+	f.resumeErr = fmt.Errorf("cni down")
+	d := newTestDaemon(t, f)
+	d.reconcile(t.Context())
+
+	if _, healthy, _ := d.state.snapshot(); healthy {
+		t.Error("a delete that could not be finished reported a healthy pass")
 	}
 }

--- a/daemon/reconcile_test.go
+++ b/daemon/reconcile_test.go
@@ -28,6 +28,7 @@ type fakeSupervisor struct {
 	observeErr error
 
 	resumeErr error
+	scanErr   error
 
 	converged []convergeCall
 	adopted   []string
@@ -55,6 +56,9 @@ func (f *fakeSupervisor) Type() string { return "fake-hv" }
 func (f *fakeSupervisor) ScanSupervision(context.Context) (hypervisor.SupervisionScan, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.scanErr != nil {
+		return hypervisor.SupervisionScan{}, f.scanErr
+	}
 	scan := hypervisor.SupervisionScan{Tombstoned: f.tombstoned}
 	for _, rec := range f.records {
 		scan.Records = append(scan.Records, rec)
@@ -342,19 +346,23 @@ func TestHandleExitIgnoresDeletedRecord(t *testing.T) {
 	}
 }
 
-// /healthz promises a full pass succeeded, so a real failure must make the pass
-// unhealthy — while a busy ops lock, which is how supervision yields to a
-// command, must not.
-func TestPassHealthReflectsFailuresButNotBusyLocks(t *testing.T) {
+// A VM the pass could not converge is reported degraded, not unready: restarting
+// the daemon does not fix it, and 503 would put a working daemon in a restart
+// loop. A busy ops lock is not a failure at all — it is how supervision yields.
+func TestPassCountsDegradedVMsWithoutGoingUnready(t *testing.T) {
 	tests := []struct {
-		name    string
-		arrange func(*fakeSupervisor)
-		healthy bool
+		name     string
+		arrange  func(*fakeSupervisor)
+		degraded int
 	}{
-		{"clean pass", func(*fakeSupervisor) {}, true},
-		{"busy ops lock", func(f *fakeSupervisor) { f.busy["vm1"] = struct{}{} }, true},
-		{"ops lock error", func(f *fakeSupervisor) { f.lockErr = fmt.Errorf("no such directory") }, false},
-		{"inconclusive liveness", func(f *fakeSupervisor) { f.observeErr = fmt.Errorf("/proc scan errored") }, false},
+		{"clean pass", func(*fakeSupervisor) {}, 0},
+		{"busy ops lock", func(f *fakeSupervisor) { f.busy["vm1"] = struct{}{} }, 0},
+		{"ops lock error", func(f *fakeSupervisor) { f.lockErr = fmt.Errorf("no such directory") }, 1},
+		{"inconclusive liveness", func(f *fakeSupervisor) { f.observeErr = fmt.Errorf("/proc scan errored") }, 1},
+		{"delete cannot finish", func(f *fakeSupervisor) {
+			f.tombstoned["vm1"] = struct{}{}
+			f.resumeErr = fmt.Errorf("cni down")
+		}, 1},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -363,21 +371,25 @@ func TestPassHealthReflectsFailuresButNotBusyLocks(t *testing.T) {
 			d := newTestDaemon(t, f)
 			d.reconcile(t.Context())
 
-			if _, healthy, _ := d.state.snapshot(); healthy != tt.healthy {
-				t.Errorf("got healthy=%v, want %v", healthy, tt.healthy)
+			_, h := d.state.snapshot()
+			if h.degraded != tt.degraded {
+				t.Errorf("got degraded=%d, want %d", h.degraded, tt.degraded)
+			}
+			if !h.ok {
+				t.Error("a pass that ran reported unready; only a scan failure may")
 			}
 		})
 	}
 }
 
-func TestPassUnhealthyWhenAnInterruptedDeleteCannotFinish(t *testing.T) {
+// A backend the daemon cannot even scan is the one case where restarting might help.
+func TestPassUnreadyWhenABackendCannotBeScanned(t *testing.T) {
 	f := newFake().put(runningRec("vm1", 1))
-	f.tombstoned["vm1"] = struct{}{}
-	f.resumeErr = fmt.Errorf("cni down")
+	f.scanErr = fmt.Errorf("meta store unavailable")
 	d := newTestDaemon(t, f)
 	d.reconcile(t.Context())
 
-	if _, healthy, _ := d.state.snapshot(); healthy {
-		t.Error("a delete that could not be finished reported a healthy pass")
+	if _, h := d.state.snapshot(); h.ok {
+		t.Error("a backend that could not be scanned still reported ready")
 	}
 }

--- a/daemon/reconcile_test.go
+++ b/daemon/reconcile_test.go
@@ -119,17 +119,17 @@ func (f *fakeSupervisor) ConvergeDead(_ context.Context, vmID string, gen uint64
 	return nil
 }
 
-func (f *fakeSupervisor) ReconcileToRunning(_ context.Context, vmID string) uint64 {
+func (f *fakeSupervisor) ReconcileToRunning(_ context.Context, vmID string) (uint64, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	rec := f.records[vmID]
 	if rec == nil || rec.Quarantine != "" || rec.State == types.VMStateCreating {
-		return 0
+		return 0, nil
 	}
 	f.adopted = append(f.adopted, vmID)
 	rec.State = types.VMStateRunning
 	rec.TransitionGeneration++
-	return rec.TransitionGeneration
+	return rec.TransitionGeneration, nil
 }
 
 func (f *fakeSupervisor) RecoverTombstone(_ context.Context, vmID string) (bool, error) {

--- a/daemon/watch.go
+++ b/daemon/watch.go
@@ -33,11 +33,10 @@ type watchEntry struct {
 type procWatcher struct {
 	exits chan exitEvent
 
-	mu     sync.Mutex
-	byKey  map[watchKey]watchEntry
-	byFD   map[int]watchKey
-	poll   *poller
-	closed bool
+	mu    sync.Mutex
+	byKey map[watchKey]watchEntry
+	byFD  map[int]watchKey
+	poll  *poller
 }
 
 func newProcWatcher() *procWatcher {
@@ -63,15 +62,12 @@ func (w *procWatcher) start(ctx context.Context) error {
 func (w *procWatcher) close() {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	w.closed = true
 	for key, entry := range w.byKey {
 		delete(w.byKey, key)
 		delete(w.byFD, entry.fd)
 		utils.CloseFD(entry.fd)
 	}
-	if w.poll != nil {
-		_ = w.poll.close()
-	}
+	_ = w.poll.close()
 }
 
 // ensure watches proc for key, replacing any entry naming a different generation.
@@ -84,11 +80,7 @@ func (w *procWatcher) ensure(key watchKey, proc utils.ProcRef, gen uint64) {
 		}
 		w.evictLocked(key, cur.fd)
 	}
-	closed := w.closed
 	w.mu.Unlock()
-	if closed {
-		return
-	}
 
 	fd, err := utils.OpenPidfd(proc.PID)
 	if err != nil {
@@ -102,10 +94,6 @@ func (w *procWatcher) ensure(key watchKey, proc utils.ProcRef, gen uint64) {
 
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	if _, taken := w.byKey[key]; w.closed || taken || w.poll == nil {
-		utils.CloseFD(fd)
-		return
-	}
 	if err := w.poll.add(fd); err != nil {
 		utils.CloseFD(fd)
 		return
@@ -177,8 +165,6 @@ func (w *procWatcher) fire(ctx context.Context, fd int) {
 func (w *procWatcher) evictLocked(key watchKey, fd int) {
 	delete(w.byKey, key)
 	delete(w.byFD, fd)
-	if w.poll != nil {
-		_ = w.poll.remove(fd)
-	}
+	_ = w.poll.remove(fd)
 	utils.CloseFD(fd)
 }

--- a/daemon/watch.go
+++ b/daemon/watch.go
@@ -1,0 +1,187 @@
+package daemon
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/cocoonstack/cocoon/utils"
+)
+
+// exitQueue buffers observed exits so the poll loop never blocks behind a pass in flight.
+const exitQueue = 64
+
+// watchKey identifies a supervised VM across backends.
+type watchKey struct {
+	backend string
+	vmID    string
+}
+
+// exitEvent reports that the watched process generation exited; gen fences it against a newer record transition.
+type exitEvent struct {
+	key watchKey
+	gen uint64
+	at  time.Time
+}
+
+type watchEntry struct {
+	proc utils.ProcRef
+	gen  uint64
+	fd   int
+}
+
+// procWatcher turns VMM process exits into events. Where the platform has no
+// process-exit notification the registry stays empty and the daemon's reconcile
+// ticker is the only detector.
+type procWatcher struct {
+	exits chan exitEvent
+
+	mu     sync.Mutex
+	byKey  map[watchKey]watchEntry
+	byFD   map[int]watchKey
+	poll   *poller
+	closed bool
+}
+
+func newProcWatcher() *procWatcher {
+	return &procWatcher{
+		exits: make(chan exitEvent, exitQueue),
+		byKey: map[watchKey]watchEntry{},
+		byFD:  map[int]watchKey{},
+	}
+}
+
+func (w *procWatcher) start(ctx context.Context) error {
+	p, err := newPoller()
+	if err != nil {
+		return err
+	}
+	w.mu.Lock()
+	w.poll = p
+	w.mu.Unlock()
+	go w.run(ctx)
+	return nil
+}
+
+func (w *procWatcher) close() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.closed = true
+	for key, entry := range w.byKey {
+		delete(w.byKey, key)
+		delete(w.byFD, entry.fd)
+		closeFD(entry.fd)
+	}
+	if w.poll != nil {
+		_ = w.poll.close()
+	}
+}
+
+// ensure watches proc for key, replacing any entry naming a different generation.
+func (w *procWatcher) ensure(key watchKey, proc utils.ProcRef, gen uint64) {
+	w.mu.Lock()
+	if cur, ok := w.byKey[key]; ok {
+		if cur.proc == proc && cur.gen == gen {
+			w.mu.Unlock()
+			return
+		}
+		w.evictLocked(key, cur.fd)
+	}
+	closed := w.closed
+	w.mu.Unlock()
+	if closed {
+		return
+	}
+
+	fd, err := openPidfd(proc.PID)
+	if err != nil {
+		return
+	}
+	// Re-verify after the open: a pid recycled in between would bind the wrong process.
+	if again, err := utils.ProcRefOf(proc.PID); err != nil || again != proc {
+		closeFD(fd)
+		return
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if _, taken := w.byKey[key]; w.closed || taken || w.poll == nil {
+		closeFD(fd)
+		return
+	}
+	if err := w.poll.add(fd); err != nil {
+		closeFD(fd)
+		return
+	}
+	w.byKey[key] = watchEntry{proc: proc, gen: gen, fd: fd}
+	w.byFD[fd] = key
+}
+
+func (w *procWatcher) drop(key watchKey) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if entry, ok := w.byKey[key]; ok {
+		w.evictLocked(key, entry.fd)
+	}
+}
+
+// dropAbsent releases watches for VMs the latest scan of one backend no longer lists.
+func (w *procWatcher) dropAbsent(backend string, seen map[string]struct{}) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for key, entry := range w.byKey {
+		if key.backend != backend {
+			continue
+		}
+		if _, ok := seen[key.vmID]; !ok {
+			w.evictLocked(key, entry.fd)
+		}
+	}
+}
+
+// pidOf reports the watched pid, or zero when the VM is not watched.
+func (w *procWatcher) pidOf(key watchKey) int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.byKey[key].proc.PID
+}
+
+func (w *procWatcher) run(ctx context.Context) {
+	ready := make([]int, exitQueue)
+	for ctx.Err() == nil {
+		n, err := w.poll.wait(ready)
+		if err != nil {
+			return
+		}
+		for _, fd := range ready[:n] {
+			w.fire(ctx, fd)
+		}
+	}
+}
+
+// fire evicts the entry before publishing, so a restart adopting the same key cannot collide with the exit still in flight.
+func (w *procWatcher) fire(ctx context.Context, fd int) {
+	w.mu.Lock()
+	key, ok := w.byFD[fd]
+	if !ok {
+		w.mu.Unlock()
+		return
+	}
+	gen := w.byKey[key].gen
+	w.evictLocked(key, fd)
+	w.mu.Unlock()
+
+	select {
+	case w.exits <- exitEvent{key: key, gen: gen, at: time.Now()}:
+	case <-ctx.Done():
+	}
+}
+
+func (w *procWatcher) evictLocked(key watchKey, fd int) {
+	delete(w.byKey, key)
+	delete(w.byFD, fd)
+	if w.poll != nil {
+		_ = w.poll.remove(fd)
+	}
+	closeFD(fd)
+}

--- a/daemon/watch.go
+++ b/daemon/watch.go
@@ -67,7 +67,7 @@ func (w *procWatcher) close() {
 	for key, entry := range w.byKey {
 		delete(w.byKey, key)
 		delete(w.byFD, entry.fd)
-		closeFD(entry.fd)
+		utils.CloseFD(entry.fd)
 	}
 	if w.poll != nil {
 		_ = w.poll.close()
@@ -90,24 +90,24 @@ func (w *procWatcher) ensure(key watchKey, proc utils.ProcRef, gen uint64) {
 		return
 	}
 
-	fd, err := openPidfd(proc.PID)
+	fd, err := utils.OpenPidfd(proc.PID)
 	if err != nil {
 		return
 	}
 	// Re-verify after the open: a pid recycled in between would bind the wrong process.
 	if again, err := utils.ProcRefOf(proc.PID); err != nil || again != proc {
-		closeFD(fd)
+		utils.CloseFD(fd)
 		return
 	}
 
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if _, taken := w.byKey[key]; w.closed || taken || w.poll == nil {
-		closeFD(fd)
+		utils.CloseFD(fd)
 		return
 	}
 	if err := w.poll.add(fd); err != nil {
-		closeFD(fd)
+		utils.CloseFD(fd)
 		return
 	}
 	w.byKey[key] = watchEntry{proc: proc, gen: gen, fd: fd}
@@ -180,5 +180,5 @@ func (w *procWatcher) evictLocked(key watchKey, fd int) {
 	if w.poll != nil {
 		_ = w.poll.remove(fd)
 	}
-	closeFD(fd)
+	utils.CloseFD(fd)
 }

--- a/daemon/watch.go
+++ b/daemon/watch.go
@@ -11,7 +11,6 @@ import (
 // exitQueue buffers observed exits so the poll loop never blocks behind a pass in flight.
 const exitQueue = 64
 
-// watchKey identifies a supervised VM across backends.
 type watchKey struct {
 	backend string
 	vmID    string
@@ -30,9 +29,7 @@ type watchEntry struct {
 	fd   int
 }
 
-// procWatcher turns VMM process exits into events. Where the platform has no
-// process-exit notification the registry stays empty and the daemon's reconcile
-// ticker is the only detector.
+// procWatcher turns VMM process exits into events; where the platform cannot notify, the registry stays empty and the reconcile ticker is the only detector.
 type procWatcher struct {
 	exits chan exitEvent
 

--- a/daemon/watch_linux.go
+++ b/daemon/watch_linux.go
@@ -1,0 +1,59 @@
+//go:build linux
+
+package daemon
+
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
+
+// pollTimeoutMS bounds how long a wait blocks, so shutdown is not gated on a VM exiting.
+const pollTimeoutMS = 500
+
+// poller waits for pidfd readability, which the kernel signals once the process exits.
+type poller struct {
+	epfd int
+}
+
+func newPoller() (*poller, error) {
+	epfd, err := unix.EpollCreate1(unix.EPOLL_CLOEXEC)
+	if err != nil {
+		return nil, err
+	}
+	return &poller{epfd: epfd}, nil
+}
+
+func (p *poller) add(fd int) error {
+	//nolint:gosec // a file descriptor never exceeds int32
+	return unix.EpollCtl(p.epfd, unix.EPOLL_CTL_ADD, fd, &unix.EpollEvent{Events: unix.EPOLLIN, Fd: int32(fd)})
+}
+
+func (p *poller) remove(fd int) error {
+	return unix.EpollCtl(p.epfd, unix.EPOLL_CTL_DEL, fd, nil)
+}
+
+func (p *poller) wait(out []int) (int, error) {
+	events := make([]unix.EpollEvent, len(out))
+	n, err := unix.EpollWait(p.epfd, events, pollTimeoutMS)
+	if err != nil {
+		if errors.Is(err, unix.EINTR) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	for i := range n {
+		out[i] = int(events[i].Fd)
+	}
+	return n, nil
+}
+
+func (p *poller) close() error { return unix.Close(p.epfd) }
+
+func openPidfd(pid int) (int, error) { return unix.PidfdOpen(pid, 0) }
+
+func closeFD(fd int) {
+	if fd > 0 {
+		_ = unix.Close(fd)
+	}
+}

--- a/daemon/watch_linux.go
+++ b/daemon/watch_linux.go
@@ -8,12 +8,16 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// pollTimeoutMS bounds how long a wait blocks, so shutdown is not gated on a VM exiting.
-const pollTimeoutMS = 500
+const (
+	// pollTimeoutMS bounds how long a wait blocks, so shutdown is not gated on a VM exiting.
+	pollTimeoutMS = 500
+	maxPollEvents = 64
+)
 
 // poller waits for pidfd readability, which the kernel signals once the process exits.
 type poller struct {
-	epfd int
+	epfd   int
+	events []unix.EpollEvent
 }
 
 func newPoller() (*poller, error) {
@@ -21,7 +25,7 @@ func newPoller() (*poller, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &poller{epfd: epfd}, nil
+	return &poller{epfd: epfd, events: make([]unix.EpollEvent, maxPollEvents)}, nil
 }
 
 func (p *poller) add(fd int) error {
@@ -34,8 +38,7 @@ func (p *poller) remove(fd int) error {
 }
 
 func (p *poller) wait(out []int) (int, error) {
-	events := make([]unix.EpollEvent, len(out))
-	n, err := unix.EpollWait(p.epfd, events, pollTimeoutMS)
+	n, err := unix.EpollWait(p.epfd, p.events[:min(len(out), maxPollEvents)], pollTimeoutMS)
 	if err != nil {
 		if errors.Is(err, unix.EINTR) {
 			return 0, nil
@@ -43,7 +46,7 @@ func (p *poller) wait(out []int) (int, error) {
 		return 0, err
 	}
 	for i := range n {
-		out[i] = int(events[i].Fd)
+		out[i] = int(p.events[i].Fd)
 	}
 	return n, nil
 }

--- a/daemon/watch_linux.go
+++ b/daemon/watch_linux.go
@@ -52,11 +52,3 @@ func (p *poller) wait(out []int) (int, error) {
 }
 
 func (p *poller) close() error { return unix.Close(p.epfd) }
-
-func openPidfd(pid int) (int, error) { return unix.PidfdOpen(pid, 0) }
-
-func closeFD(fd int) {
-	if fd > 0 {
-		_ = unix.Close(fd)
-	}
-}

--- a/daemon/watch_linux_test.go
+++ b/daemon/watch_linux_test.go
@@ -1,0 +1,118 @@
+//go:build linux
+
+package daemon
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/cocoonstack/cocoon/utils"
+)
+
+const exitWaitBudget = 5 * time.Second
+
+// startVictim launches a process the test can kill, returning its generation.
+func startVictim(t *testing.T) (*exec.Cmd, utils.ProcRef) {
+	t.Helper()
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Skipf("cannot start a victim process: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+	proc, err := utils.ProcRefOf(cmd.Process.Pid)
+	if err != nil {
+		t.Fatalf("ProcRefOf: %v", err)
+	}
+	return cmd, proc
+}
+
+func startWatcher(t *testing.T) *procWatcher {
+	t.Helper()
+	w := newProcWatcher()
+	if err := w.start(t.Context()); err != nil {
+		t.Fatalf("start watcher: %v", err)
+	}
+	t.Cleanup(w.close)
+	return w
+}
+
+func TestWatcherReportsProcessExit(t *testing.T) {
+	cmd, proc := startVictim(t)
+	w := startWatcher(t)
+	key := watchKey{backend: "fake-hv", vmID: "vm1"}
+
+	w.ensure(key, proc, 5)
+	if got := w.pidOf(key); got != proc.PID {
+		t.Fatalf("got watched pid %d, want %d", got, proc.PID)
+	}
+
+	_ = cmd.Process.Kill()
+	select {
+	case ev := <-w.exits:
+		if ev.key != key {
+			t.Errorf("got key %+v, want %+v", ev.key, key)
+		}
+		if ev.gen != 5 {
+			t.Errorf("got generation %d, want the one adopted (5)", ev.gen)
+		}
+	case <-time.After(exitWaitBudget):
+		t.Fatal("no exit event within the budget")
+	}
+	if got := w.pidOf(key); got != 0 {
+		t.Errorf("got watched pid %d after the exit, want the entry evicted", got)
+	}
+}
+
+func TestWatcherReplacesOnNewGeneration(t *testing.T) {
+	_, first := startVictim(t)
+	cmd2, second := startVictim(t)
+	w := startWatcher(t)
+	key := watchKey{backend: "fake-hv", vmID: "vm1"}
+
+	w.ensure(key, first, 1)
+	w.ensure(key, second, 2)
+	if got := w.pidOf(key); got != second.PID {
+		t.Fatalf("got watched pid %d, want the newer generation %d", got, second.PID)
+	}
+
+	// Only the adopted generation may report: the replaced one is no longer watched.
+	_ = cmd2.Process.Kill()
+	select {
+	case ev := <-w.exits:
+		if ev.gen != 2 {
+			t.Errorf("got generation %d, want 2", ev.gen)
+		}
+	case <-time.After(exitWaitBudget):
+		t.Fatal("no exit event within the budget")
+	}
+}
+
+func TestWatcherDropAbsentEvictsUnlistedVM(t *testing.T) {
+	_, proc := startVictim(t)
+	w := startWatcher(t)
+	key := watchKey{backend: "fake-hv", vmID: "vm1"}
+
+	w.ensure(key, proc, 1)
+	w.dropAbsent("fake-hv", map[string]struct{}{"vm2": {}})
+
+	if got := w.pidOf(key); got != 0 {
+		t.Errorf("got watched pid %d, want the deleted VM's watch released", got)
+	}
+}
+
+func TestWatcherKeepsOtherBackendsOnDropAbsent(t *testing.T) {
+	_, proc := startVictim(t)
+	w := startWatcher(t)
+	key := watchKey{backend: "fake-hv", vmID: "vm1"}
+
+	w.ensure(key, proc, 1)
+	w.dropAbsent("other-hv", nil)
+
+	if got := w.pidOf(key); got != proc.PID {
+		t.Errorf("got watched pid %d, want another backend's scan to leave this watch alone", got)
+	}
+}

--- a/daemon/watch_other.go
+++ b/daemon/watch_other.go
@@ -26,7 +26,3 @@ func (p *poller) close() error {
 	close(p.done)
 	return nil
 }
-
-func openPidfd(int) (int, error) { return 0, errNoProcNotify }
-
-func closeFD(int) {}

--- a/daemon/watch_other.go
+++ b/daemon/watch_other.go
@@ -6,7 +6,6 @@ import "errors"
 
 var errNoProcNotify = errors.New("process-exit notification is unsupported on this OS")
 
-// poller is inert off Linux: nothing is ever watched, so wait only parks until close.
 type poller struct {
 	done chan struct{}
 }

--- a/daemon/watch_other.go
+++ b/daemon/watch_other.go
@@ -1,0 +1,32 @@
+//go:build !linux
+
+package daemon
+
+import "errors"
+
+var errNoProcNotify = errors.New("process-exit notification is unsupported on this OS")
+
+// poller is inert off Linux: nothing is ever watched, so wait only parks until close.
+type poller struct {
+	done chan struct{}
+}
+
+func newPoller() (*poller, error) { return &poller{done: make(chan struct{})}, nil }
+
+func (p *poller) add(int) error { return errNoProcNotify }
+
+func (p *poller) remove(int) error { return nil }
+
+func (p *poller) wait([]int) (int, error) {
+	<-p.done
+	return 0, errNoProcNotify
+}
+
+func (p *poller) close() error {
+	close(p.done)
+	return nil
+}
+
+func openPidfd(int) (int, error) { return 0, errNoProcNotify }
+
+func closeFD(int) {}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -51,9 +51,12 @@ cocoon
 │   ├── init                       Initialize a fresh sqlite meta store (requires meta_backend=sqlite)
 │   ├── convert                    Convert existing metadata to the configured meta_backend (crash-resumable)
 │   └── backup DEST                Back up the sqlite meta store to a single consistent file
+├── daemon [flags]                 Supervise cocoon-managed VMs (optional resident process)
 ├── version                        Show version, revision, and build time
 └── completion [bash|zsh|fish|powershell]
 ```
+
+`daemon` is optional: every other command works standalone with no daemon running. See [Daemon](daemon.md).
 
 The meta engine is selected by `meta_backend` in the config: `json` (default) or `sqlite`; `meta convert` always converts TO the effective backend.
 

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -47,6 +47,12 @@ WantedBy=multi-user.target
 
 Shutdown is clean: VMs keep running, and the next start re-adopts them.
 
+One operational note: the daemon is the first long-lived writer of the metering
+ledger, and the `file` backend holds that file open for its whole lifetime. If
+you rotate `<root-dir>/metering/ledger.jsonl` out from under it, the daemon keeps
+writing to the unlinked inode until it restarts. Either restart the daemon after
+a rotation, or run the `meta` metering backend instead.
+
 ## How supervision works
 
 Each pass — on a meta change event, or on the reconcile ticker — reads every

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -65,7 +65,7 @@ record once and applies the same idempotent rules:
 | committed, not `running` | live | repair to `running` under the lock, then watch it |
 | any | dead | close the interval, mark `unexpected-exit`, quiesce the network |
 | `quiesce_pending` | dead | retry the quiesce |
-| unfinished delete tombstone | any | leave it to the entry guard and GC |
+| unfinished delete tombstone | any | finish the delete — supervision starts deletes of its own, so it resumes them |
 
 Exits are detected with `pidfd` + `epoll`, so the normal path costs no polling;
 the ticker is the correctness floor for anything the watcher missed, including
@@ -94,8 +94,8 @@ Supervision needs to tell a transition it has seen from one it has not, so every
 committed state change stamps the record:
 
 - `transition_generation` — increments once per committed transition;
-- `last_transition_reason` — `boot`, `restart`, `restore`, `stop-user`, `error`,
-  or `unexpected-exit`;
+- `last_transition_reason` — `create`, `boot`, `restart`, `clone`, `restore`,
+  `stop-user`, `error`, or `unexpected-exit`;
 - `last_transition_at`.
 
 `cocoon vm inspect` shows all three.
@@ -114,7 +114,11 @@ curl --unix-socket /var/lib/cocoon/run/cocoond.sock http://localhost/v1/vms
 curl --unix-socket /var/lib/cocoon/run/cocoond.sock -N http://localhost/v1/events
 ```
 
-- `GET /healthz` — 200 only while a full pass has succeeded recently, 503 otherwise.
+- `GET /healthz` — 200 while the loop is running and its last pass is recent;
+  503 only when a backend could not be scanned at all or the loop has stalled,
+  since that is the case where restarting the daemon might help. VMs the pass
+  could not converge are reported as a `degraded` count instead — a single VM
+  nobody can converge must not put a working daemon into a restart loop.
 - `GET /v1/vms` — every supervised VM: persisted state, transition triple, current
   liveness, watched pid.
 - `GET /v1/events` — SSE. Opens with a `sync` snapshot, then streams `ADDED`,

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -1,0 +1,114 @@
+# Daemon
+
+`cocoon daemon` is an optional resident supervisor for VMs the CLI created. Every
+CLI verb keeps working with no daemon running; when one is running it adopts the
+live VMM processes, notices exits as they happen, and converges metadata and host
+networking instead of waiting for the next command to heal them.
+
+## What it fixes
+
+Without a supervisor, a VMM that exits outside `cocoon vm stop` leaves work
+undone until something touches the VM again:
+
+- the tc redirect on its now-idle TAP keeps storming softirqs, the condition
+  behind the outage fixed for the normal stop path in #130;
+- the compute interval stays open, so the metered stop time drifts;
+- the record still reads `running`, and `list` can only render `stopped (stale)`;
+- consumers that want lifecycle signals have to poll by exec'ing the CLI.
+
+## Running it
+
+```bash
+cocoon daemon                          # adopt everything, reconcile every 5s
+cocoon daemon --reconcile-interval 2s  # tighter full-pass floor
+cocoon daemon --gc-interval 1h         # also sweep periodically (off by default)
+cocoon daemon --no-api                 # supervision only, no socket
+```
+
+One instance per root directory: a second one fails fast on
+`<root-dir>/locks/daemon.lock` without touching any VM.
+
+### systemd
+
+```ini
+[Unit]
+Description=Cocoon VM supervisor
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/cocoon daemon
+Restart=always
+RestartSec=1
+KillSignal=SIGTERM
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Shutdown is clean: VMs keep running, and the next start re-adopts them.
+
+## How supervision works
+
+Each pass — on a meta change event, or on the reconcile ticker — reads every
+record once and applies the same idempotent rules:
+
+| Record | Process | Action |
+|---|---|---|
+| `creating` | any | ownerless only if the ops lock is free; then run the stale-create cleanup at once, freeing the name |
+| `running` | live | watch that exact process generation |
+| committed, not `running` | live | repair to `running` under the lock, then watch it |
+| any | dead | close the interval, mark `unexpected-exit`, quiesce the network |
+| `quiesce_pending` | dead | retry the quiesce |
+| unfinished delete tombstone | any | leave it to the entry guard and GC |
+
+Exits are detected with `pidfd` + `epoll`, so the normal path costs no polling;
+the ticker is the correctness floor for anything the watcher missed, including
+exits that happened while the daemon was down.
+
+Every mutation takes the same per-VM ops lock the CLI takes. A busy lock simply
+defers the work to the next pass, so supervision never blocks a command and never
+interleaves with one.
+
+### What it will not do
+
+The daemon reports an unexpected exit; it never restarts a VM. Restart is policy
+and belongs to whatever runs on top of cocoon. It also refuses to guess a cause:
+an adopted process cannot report why it died, so every exit outside a cocoon stop
+is recorded as `unexpected-exit`.
+
+## Transition tracking
+
+Supervision needs to tell a transition it has seen from one it has not, so every
+committed state change stamps the record:
+
+- `transition_generation` — increments once per committed transition;
+- `last_transition_reason` — `boot`, `restart`, `restore`, `stop-user`, `error`,
+  or `unexpected-exit`;
+- `last_transition_at`.
+
+`cocoon vm inspect` shows all three.
+
+For an exit the watcher saw, `stopped_at` is the moment it became readable. For
+one discovered by a scan — during daemon downtime, say — it is detection time:
+the daemon does not claim an exit time it cannot know.
+
+## Read-only API
+
+The daemon serves HTTP/JSON over `<run-dir>/cocoond.sock` (`0660`, in a `0750`
+directory — filesystem permissions are the authorization boundary).
+
+```bash
+curl --unix-socket /var/lib/cocoon/run/cocoond.sock http://localhost/v1/vms
+curl --unix-socket /var/lib/cocoon/run/cocoond.sock -N http://localhost/v1/events
+```
+
+- `GET /healthz` — 200 only while a full pass has succeeded recently, 503 otherwise.
+- `GET /v1/vms` — every supervised VM: persisted state, transition triple, current
+  liveness, watched pid.
+- `GET /v1/events` — SSE. Opens with a `sync` snapshot, then streams `ADDED`,
+  `MODIFIED` and `DELETED` changes.
+
+The stream is a hint, not a log: it replays nothing and a slow reader loses
+events. After a reconnect, compare each VM's `transition_generation` against the
+last one you handled — a generation you have not seen whose state is `stopped`
+and whose reason is `unexpected-exit` is a crash you missed.

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -76,6 +76,12 @@ and belongs to whatever runs on top of cocoon. It also refuses to guess a cause:
 an adopted process cannot report why it died, so every exit outside a cocoon stop
 is recorded as `unexpected-exit`.
 
+If you do build a restart policy on top, trigger it on the `unexpected-exit`
+transition rather than on your own kill. `cocoon vm start` issued in the same
+instant a VMM is killed races that VMM's teardown and fails its launch timeout —
+with or without a daemon. Waiting for the transition costs about 30ms and makes
+the restart reliable.
+
 ## Transition tracking
 
 Supervision needs to tell a transition it has seen from one it has not, so every

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,8 @@ cocoon CLI ──► images: OCI (EROFS layers, direct boot) | cloudimg (qcow2, 
 - [Firecracker backend](firecracker.md) — what `--fc` trades for ~125ms
   boots and <5 MiB overhead
 - [Garbage collection](gc.md) — cross-module GC and snapshot LRU eviction
+- [Daemon](daemon.md) — the optional resident supervisor: crash convergence,
+  transition tracking, read-only API
 - [OS images](os-image.md) — the official Ubuntu/Android/Windows images
   and the build harness
 - [Known issues](known-issues.md) — limitations, workarounds, upstream

--- a/hypervisor/backend.go
+++ b/hypervisor/backend.go
@@ -72,6 +72,8 @@ type Backend struct {
 
 	// NetCleanup releases a VM's host networking during delete/recovery.
 	NetCleanup NetTeardown
+	// NetLife converges host networking inside the VM ops lock on start and stop.
+	NetLife NetLifecycle
 }
 
 // NewBackend wires shared init: EnsureDirs, the backend's namespace on the
@@ -96,6 +98,9 @@ func (b *Backend) Type() string { return b.Typ }
 
 // SetNetCleanup injects the network teardown used by delete and recovery.
 func (b *Backend) SetNetCleanup(fn NetTeardown) { b.NetCleanup = fn }
+
+// SetNetLifecycle injects the locked network convergence used by start, stop and supervision.
+func (b *Backend) SetNetLifecycle(nl NetLifecycle) { b.NetLife = nl }
 
 // LaunchSpec is the per-call input to Backend.LaunchVMProcess.
 type LaunchSpec struct {

--- a/hypervisor/backend.go
+++ b/hypervisor/backend.go
@@ -70,10 +70,8 @@ type Backend struct {
 	Meta     meta.Store
 	Metering metering.Recorder
 
-	// NetCleanup releases a VM's host networking during delete/recovery.
-	NetCleanup NetTeardown
-	// NetLife converges host networking inside the VM ops lock on start and stop.
-	NetLife NetLifecycle
+	// Net converges host networking inside the VM ops lock; nil disables it.
+	Net VMNetwork
 }
 
 // NewBackend wires shared init: EnsureDirs, the backend's namespace on the
@@ -95,12 +93,6 @@ func NewBackend(typ string, conf BackendConfig, rec metering.Recorder, store met
 }
 
 func (b *Backend) Type() string { return b.Typ }
-
-// SetNetCleanup injects the network teardown used by delete and recovery.
-func (b *Backend) SetNetCleanup(fn NetTeardown) { b.NetCleanup = fn }
-
-// SetNetLifecycle injects the locked network convergence used by start, stop and supervision.
-func (b *Backend) SetNetLifecycle(nl NetLifecycle) { b.NetLife = nl }
 
 // LaunchSpec is the per-call input to Backend.LaunchVMProcess.
 type LaunchSpec struct {

--- a/hypervisor/choreo_trace_test.go
+++ b/hypervisor/choreo_trace_test.go
@@ -126,7 +126,7 @@ func TestLegacyChoreographyTrace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load VM1 pre-delete: %v", err)
 	}
-	record("delete", "", b.deleteVMProtocol(ctx, "VM1", &vm1, nil))
+	record("delete", "", b.deleteVMProtocol(ctx, "VM1", &vm1))
 	_, err = b.ResolveRef(ctx, "alpha")
 	record("delete-then-resolve", "", err)
 

--- a/hypervisor/clone.go
+++ b/hypervisor/clone.go
@@ -67,6 +67,9 @@ func (b *Backend) cloneBase(
 func (b *Backend) FinalizeClone(ctx context.Context, vmID string, info *types.VM, bootCfg *types.BootConfig, blobIDs map[string]struct{}, sourceSnapshotID string) error {
 	if err := b.UpdateRecord(ctx, vmID, func(r *VMRecord) error {
 		r.VM = *info
+		// info was built in the backend subpackage, which cannot reach markTransition;
+		// without this the clone commits a running record at generation zero.
+		markTransition(r, info.State, types.TransitionClone, timeNow())
 		r.BootConfig = bootCfg
 		r.FirstBooted = true
 		if blobIDs != nil {

--- a/hypervisor/clone.go
+++ b/hypervisor/clone.go
@@ -67,8 +67,7 @@ func (b *Backend) cloneBase(
 func (b *Backend) FinalizeClone(ctx context.Context, vmID string, info *types.VM, bootCfg *types.BootConfig, blobIDs map[string]struct{}, sourceSnapshotID string) error {
 	if err := b.UpdateRecord(ctx, vmID, func(r *VMRecord) error {
 		r.VM = *info
-		// info was built in the backend subpackage, which cannot reach markTransition;
-		// without this the clone commits a running record at generation zero.
+		// The subpackage building info cannot reach markTransition; without this the clone commits at generation zero.
 		markTransition(r, info.State, types.TransitionClone, timeNow())
 		r.BootConfig = bootCfg
 		r.FirstBooted = true

--- a/hypervisor/create.go
+++ b/hypervisor/create.go
@@ -78,13 +78,17 @@ func (b *Backend) FinalizeCreate(ctx context.Context, id string, info *types.VM,
 		if err != nil {
 			return err
 		}
-		return t.Put(id, &VMRecord{
+		rec := &VMRecord{
 			VM:           *info,
 			BootConfig:   bootCfg,
 			ImageBlobIDs: blobIDs,
 			RunDir:       existing.RunDir,
 			LogDir:       existing.LogDir,
-		})
+		}
+		// info is built in the backend subpackage, which cannot reach markTransition;
+		// without this the placeholder and the finished record share generation zero.
+		markTransition(rec, info.State, types.TransitionCreate, timeNow())
+		return t.Put(id, rec)
 	}); err != nil {
 		return err
 	}

--- a/hypervisor/create.go
+++ b/hypervisor/create.go
@@ -85,8 +85,7 @@ func (b *Backend) FinalizeCreate(ctx context.Context, id string, info *types.VM,
 			RunDir:       existing.RunDir,
 			LogDir:       existing.LogDir,
 		}
-		// info is built in the backend subpackage, which cannot reach markTransition;
-		// without this the placeholder and the finished record share generation zero.
+		// The subpackage building info cannot reach markTransition; without this both create states share generation zero.
 		markTransition(rec, info.State, types.TransitionCreate, timeNow())
 		return t.Put(id, rec)
 	}); err != nil {

--- a/hypervisor/db.go
+++ b/hypervisor/db.go
@@ -17,4 +17,7 @@ type VMRecord struct {
 
 	// Quarantine names why start must refuse (e.g. partial restore merge); only a successful restore clears it — stop's state flip cannot.
 	Quarantine string `json:"quarantine,omitempty"`
+
+	// QuiescePending survives a crash between the stop transition and the network Quiesce, so a later pass retries it.
+	QuiescePending bool `json:"quiesce_pending,omitempty"`
 }

--- a/hypervisor/gc.go
+++ b/hypervisor/gc.go
@@ -188,11 +188,7 @@ func (b *Backend) gcCollect(ctx context.Context, ids []string, snap VMGCSnapshot
 			if rec.State != types.VMStateCreating || !rec.UpdatedAt.Before(cutoff) {
 				return
 			}
-			if err := b.ensureOrphanVMMDead(ctx, rec.RunDir); err != nil {
-				errs = append(errs, fmt.Errorf("orphan vmm for %s: %w (dirs kept)", id, err))
-				return
-			}
-			if err := b.deleteVMProtocol(ctx, id, rec, b.NetCleanup); err != nil {
+			if err := b.CollectStaleCreate(ctx, id, rec); err != nil {
 				errs = append(errs, fmt.Errorf("collect %s: %w", id, err))
 				return
 			}
@@ -286,14 +282,11 @@ func (b *Backend) sweepOrphanDirs(ctx context.Context, dirs []string) []error {
 
 // withOpsTryLock runs fn holding the VM ops lock, reporting false (fn skipped) when an in-flight operation owns it; GC never blocks on ops locks, so the reversed order vs. the ops-outer/index-inner convention cannot deadlock.
 func (b *Backend) withOpsTryLock(ctx context.Context, vmID string, fn func()) bool {
-	l, err := opsLock(b.Conf, vmID)
-	if err != nil {
+	unlock, ok, err := b.TryLockVMOps(ctx, vmID)
+	if err != nil || !ok {
 		return false
 	}
-	if ok, err := l.TryLock(ctx); err != nil || !ok {
-		return false
-	}
-	defer func() { _ = l.Unlock(ctx) }()
+	defer unlock()
 	fn()
 	return true
 }

--- a/hypervisor/gc.go
+++ b/hypervisor/gc.go
@@ -142,7 +142,7 @@ func (b *Backend) gcRecover(ctx context.Context) []error {
 	var errs []error
 	for _, id := range ids {
 		b.withOpsTryLock(ctx, id, func() {
-			if _, err := b.recoverVMTombstone(ctx, id, b.NetCleanup); err != nil {
+			if _, err := b.recoverVMTombstone(ctx, id); err != nil {
 				errs = append(errs, fmt.Errorf("recover %s: %w", id, err))
 			}
 		})

--- a/hypervisor/hypervisor.go
+++ b/hypervisor/hypervisor.go
@@ -41,11 +41,6 @@ type Reserver interface {
 	LockVMOps(ctx context.Context, vmID string) (func(), error)
 }
 
-// EntryGuarded lets cmd-layer flows run the tombstone entry guard under the ops lock before an entrypoint, so a half-removed resource is never rebuilt.
-type EntryGuarded interface {
-	EntryGuard(ctx context.Context, id string) error
-}
-
 // Direct is an optional interface for hypervisors that support clone/restore from a local snapshot directory.
 type Direct interface {
 	DirectClone(ctx context.Context, vmID string, vmCfg *types.VMConfig, net types.NetSetup, snapshotConfig *types.SnapshotConfig, srcDir string) (*types.VM, error)

--- a/hypervisor/network.go
+++ b/hypervisor/network.go
@@ -3,6 +3,8 @@ package hypervisor
 import (
 	"context"
 
+	"github.com/projecteru2/core/log"
+
 	"github.com/cocoonstack/cocoon/types"
 )
 
@@ -25,6 +27,18 @@ func (b *Backend) RecoverNetwork(ctx context.Context, rec *VMRecord) error {
 		return nil
 	}
 	return b.Net.Recover(ctx, &rec.VM)
+}
+
+// quiesceAfterStop runs the quiesce a just-committed stop scheduled. Gated on the
+// pre-stop record so an unplumbed VM pays no extra read — a stop cannot change what
+// that predicate reads. Best-effort: a failure keeps the pending flag for a later pass.
+func (b *Backend) quiesceAfterStop(ctx context.Context, id string, rec *VMRecord) {
+	if !needsQuiesce(rec) {
+		return
+	}
+	if err := b.QuiesceIfPending(ctx, id); err != nil {
+		log.WithFunc(b.Typ+".quiesceAfterStop").Warnf(ctx, "%v", err)
+	}
 }
 
 func (b *Backend) quiesceNetwork(ctx context.Context, vm *types.VM) error {

--- a/hypervisor/network.go
+++ b/hypervisor/network.go
@@ -1,0 +1,42 @@
+package hypervisor
+
+import (
+	"context"
+
+	"github.com/cocoonstack/cocoon/types"
+)
+
+// VMNetwork converges a VM's host networking. The command layer supplies it so a
+// state transition and its network action share one VM ops lock instead of
+// splitting across an unlock window (design §5).
+type VMNetwork interface {
+	Recover(ctx context.Context, vm *types.VM) error
+	Quiesce(ctx context.Context, vm *types.VM) error
+	Cleanup(ctx context.Context, vmID string) error
+}
+
+// SetNetwork injects the host-networking seam. A nil seam leaves every VM's
+// plumbing untouched, which is what a library or test embedding wants.
+func (b *Backend) SetNetwork(n VMNetwork) { b.Net = n }
+
+// RecoverNetwork rebuilds and un-quiesces a VM's plumbing before launch; the caller holds the VM ops lock.
+func (b *Backend) RecoverNetwork(ctx context.Context, rec *VMRecord) error {
+	if b.Net == nil {
+		return nil
+	}
+	return b.Net.Recover(ctx, &rec.VM)
+}
+
+func (b *Backend) quiesceNetwork(ctx context.Context, vm *types.VM) error {
+	if b.Net == nil {
+		return nil
+	}
+	return b.Net.Quiesce(ctx, vm)
+}
+
+func (b *Backend) cleanupNetwork(ctx context.Context, vmID string) error {
+	if b.Net == nil {
+		return nil
+	}
+	return b.Net.Cleanup(ctx, vmID)
+}

--- a/hypervisor/network.go
+++ b/hypervisor/network.go
@@ -8,17 +8,14 @@ import (
 	"github.com/cocoonstack/cocoon/types"
 )
 
-// VMNetwork converges a VM's host networking. The command layer supplies it so a
-// state transition and its network action share one VM ops lock instead of
-// splitting across an unlock window (design §5).
+// VMNetwork converges a VM's host networking; the command layer supplies it so a state transition and its network action share one VM ops lock (design §5).
 type VMNetwork interface {
 	Recover(ctx context.Context, vm *types.VM) error
 	Quiesce(ctx context.Context, vm *types.VM) error
 	Cleanup(ctx context.Context, vmID string) error
 }
 
-// SetNetwork injects the host-networking seam. A nil seam leaves every VM's
-// plumbing untouched, which is what a library or test embedding wants.
+// SetNetwork injects the host-networking seam; a nil seam leaves every VM's plumbing untouched, as a library or test embedding wants.
 func (b *Backend) SetNetwork(n VMNetwork) { b.Net = n }
 
 // RecoverNetwork rebuilds and un-quiesces a VM's plumbing before launch; the caller holds the VM ops lock.
@@ -29,9 +26,7 @@ func (b *Backend) RecoverNetwork(ctx context.Context, rec *VMRecord) error {
 	return b.Net.Recover(ctx, &rec.VM)
 }
 
-// quiesceAfterStop runs the quiesce a just-committed stop scheduled. Gated on the
-// pre-stop record so an unplumbed VM pays no extra read — a stop cannot change what
-// that predicate reads. Best-effort: a failure keeps the pending flag for a later pass.
+// quiesceAfterStop runs the quiesce a just-committed stop scheduled, gated on the pre-stop record so an unplumbed VM pays no extra read; a failure keeps the pending flag for a later pass.
 func (b *Backend) quiesceAfterStop(ctx context.Context, id string, rec *VMRecord) {
 	if !needsQuiesce(rec) {
 		return

--- a/hypervisor/restore.go
+++ b/hypervisor/restore.go
@@ -19,15 +19,15 @@ func (b *Backend) KillForRestore(ctx context.Context, vmID string, rec *VMRecord
 	killErr := b.WithRunningVM(ctx, rec, terminate)
 	if killErr != nil && !errors.Is(killErr, ErrNotRunning) {
 		// A stopped origin has no live VMM: a transient liveness-scan error must not brick the wake — nothing was mutated, retry converges.
-		b.FailRestore(ctx, vmID, rec.State)
+		b.failRestore(ctx, vmID, rec.State)
 		return fmt.Errorf("stop running VM: %w", killErr)
 	}
 	CleanupRuntimeFiles(ctx, rec.RunDir, runtimeFiles)
 	return nil
 }
 
-// FailRestore marks the VM error after a restore failure; a stopped origin (the pre-kill state) is spared so hibernate wake stays retryable — run-dir-mutating steps quarantine at their own site.
-func (b *Backend) FailRestore(ctx context.Context, vmID string, origin types.VMState) {
+// failRestore marks the VM error after a restore failure; a stopped origin (the pre-kill state) is spared so hibernate wake stays retryable — run-dir-mutating steps quarantine at their own site.
+func (b *Backend) failRestore(ctx context.Context, vmID string, origin types.VMState) {
 	if origin == types.VMStateStopped {
 		return
 	}
@@ -45,7 +45,7 @@ func (b *Backend) ResolveForRestore(ctx context.Context, vmRef string) (string, 
 	return vmID, &rec, nil
 }
 
-// restorableState allows Running, Stopped and Error origins. Stopped restores too (hibernate resume): the sequence cold-spawns a fresh VMM either way and the kill step tolerates a dead one. Error VMs are allowed through (quarantine sets Error too) — restore rebuilds the run dir, so it is the recovery path start.go redirects a crashed restore to; FailRestore leaves a running-origin failure in Error with no quarantine reason, and rejecting it here would dead-end at vm rm.
+// restorableState allows Running, Stopped and Error origins. Stopped restores too (hibernate resume): the sequence cold-spawns a fresh VMM either way and the kill step tolerates a dead one. Error VMs are allowed through (quarantine sets Error too) — restore rebuilds the run dir, so it is the recovery path start.go redirects a crashed restore to; failRestore leaves a running-origin failure in Error with no quarantine reason, and rejecting it here would dead-end at vm rm.
 func restorableState(vmID string, rec *VMRecord) error {
 	if rec.State != types.VMStateRunning && rec.State != types.VMStateStopped && rec.State != types.VMStateError {
 		return fmt.Errorf("vm %s is %s and cannot be restored", vmID, rec.State)
@@ -173,8 +173,7 @@ func (b *Backend) restoreCore(
 		return afterErr
 	}
 	if err := runWrapped(rec, wrap, inner); err != nil {
-		// Kill already completed, so any host networking left up must remain
-		// durable retry work even when a stopped origin stays retryable.
+		// The kill already ran, so networking left up stays durable retry work even for a retryable stopped origin.
 		b.markFailedOperation(ctx, vmID, rec.State != types.VMStateStopped)
 		return nil, err
 	}

--- a/hypervisor/restore.go
+++ b/hypervisor/restore.go
@@ -173,7 +173,9 @@ func (b *Backend) restoreCore(
 		return afterErr
 	}
 	if err := runWrapped(rec, wrap, inner); err != nil {
-		b.FailRestore(ctx, vmID, rec.State)
+		// Kill already completed, so any host networking left up must remain
+		// durable retry work even when a stopped origin stays retryable.
+		b.markFailedOperation(ctx, vmID, rec.State != types.VMStateStopped)
 		return nil, err
 	}
 	b.emitRestoreSuccess(ctx, result, oldShape, sourceSnapshotID)

--- a/hypervisor/restore.go
+++ b/hypervisor/restore.go
@@ -57,11 +57,11 @@ func (b *Backend) FinalizeRestore(ctx context.Context, vmID string, vmCfg *types
 	now := timeNow()
 	if err := b.UpdateRecord(ctx, vmID, func(r *VMRecord) error {
 		r.Config = *vmCfg
-		r.State = types.VMStateRunning
+		markTransition(r, types.VMStateRunning, types.TransitionRestore, now)
 		r.Quarantine = ""
 		r.StartedAt = &now
 		r.StoppedAt = nil
-		r.UpdatedAt = now
+		r.QuiescePending = false
 		return nil
 	}); err != nil {
 		return nil, fmt.Errorf("update record: %w", err)
@@ -164,6 +164,10 @@ func (b *Backend) restoreCore(
 		if err := apply(rec); err != nil {
 			return err
 		}
+		// Inside the ops lock, like StartSequence: a hibernate resume after a host reboot finds no plumbing left to un-quiesce.
+		if err := b.RecoverNetwork(ctx, rec); err != nil {
+			return fmt.Errorf("recover network: %w", err)
+		}
 		var afterErr error
 		result, afterErr = afterExtract(ctx, vmID, vmCfg, rec)
 		return afterErr
@@ -219,9 +223,8 @@ func (b *Backend) emitRestoreComputeStop(ctx context.Context, vmID string, oldSh
 		if r == nil || !hasOpenComputeInterval(r) {
 			return nil
 		}
-		r.State = types.VMStateStopped
+		markTransition(r, types.VMStateStopped, types.TransitionRestore, now)
 		r.StoppedAt = &now
-		r.UpdatedAt = now
 		closed = true
 		return t.Put(vmID, r)
 	}); err != nil {

--- a/hypervisor/restore_test.go
+++ b/hypervisor/restore_test.go
@@ -35,7 +35,7 @@ func TestFailRestoreSparesStoppedOrigin(t *testing.T) {
 				t.Fatalf("seed state: %v", err)
 			}
 
-			b.FailRestore(t.Context(), id, tt.origin)
+			b.failRestore(t.Context(), id, tt.origin)
 
 			rec, err := b.LoadRecord(t.Context(), id)
 			if err != nil {

--- a/hypervisor/restore_test.go
+++ b/hypervisor/restore_test.go
@@ -103,6 +103,54 @@ func TestDirectRestoreFailureKeepsOriginContract(t *testing.T) {
 	}
 }
 
+func TestRunningRestoreFailureSchedulesNetworkConvergence(t *testing.T) {
+	b, _ := newMeteringTestBackend(t)
+	ctx := t.Context()
+	const id = "vm-restore-network-fail"
+	seedRunningVM(t, b, id, 1, 1<<30, 10<<30)
+	runDir := shortTempDir(t)
+	if err := b.dbUpdate(ctx, func(idx *VMIndex) error {
+		idx.VMs[id].RunDir = runDir
+		idx.VMs[id].NetSetup = types.NetSetup{
+			NetBackend:     types.BackendCNI,
+			NetworkConfigs: []*types.NetworkConfig{{}},
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("seed network: %v", err)
+	}
+	quiesced := 0
+	b.SetNetwork(stubNetwork{quiesce: func(context.Context, *types.VM) error {
+		quiesced++
+		return nil
+	}})
+
+	_, err := b.DirectRestoreSequence(ctx, id, DirectRestoreSpec{
+		VMCfg:     &types.VMConfig{Config: types.Config{CPU: 1, Memory: 1 << 30, Storage: 10 << 30}},
+		SrcDir:    t.TempDir(),
+		Preflight: func(string, *VMRecord) error { return nil },
+		Kill:      func(context.Context, string, *VMRecord) error { return nil },
+		Populate:  func(*VMRecord, string) error { return nil },
+		AfterExtract: func(context.Context, string, *types.VMConfig, *VMRecord) (*types.VM, error) {
+			return nil, errors.New("launch boom")
+		},
+	})
+	if err == nil {
+		t.Fatal("expected restore failure")
+	}
+	rec := recordOf(t, b, id)
+	if rec.State != types.VMStateError || !rec.QuiescePending {
+		t.Fatalf("state = %s, pending = %v; want error/true", rec.State, rec.QuiescePending)
+	}
+	if err := b.ConvergeDead(ctx, id, rec.TransitionGeneration, timeNow()); err != nil {
+		t.Fatalf("ConvergeDead: %v", err)
+	}
+	after := recordOf(t, b, id)
+	if quiesced != 1 || after.QuiescePending {
+		t.Fatalf("quiesced = %d, pending = %v; want 1/false", quiesced, after.QuiescePending)
+	}
+}
+
 func TestRestorePartialMergeQuarantinesEvenStoppedOrigin(t *testing.T) {
 	b, _ := newMeteringTestBackend(t)
 	const id = "vm-merge-fail"

--- a/hypervisor/snapshot.go
+++ b/hypervisor/snapshot.go
@@ -150,11 +150,7 @@ func (b *Backend) HibernateSequence(ctx context.Context, ref string, spec Hibern
 	if uErr := b.UpdateStates(ctx, []string{vmID}, types.VMStateStopped); uErr != nil {
 		logger.Warnf(ctx, "mark stopped %s: %v", vmID, uErr)
 	}
-	if needsQuiesce(&rec) {
-		if qErr := b.QuiesceIfPending(ctx, vmID); qErr != nil {
-			logger.Warnf(ctx, "%v", qErr)
-		}
-	}
+	b.quiesceAfterStop(ctx, vmID, &rec)
 	return nil
 }
 

--- a/hypervisor/snapshot.go
+++ b/hypervisor/snapshot.go
@@ -150,6 +150,11 @@ func (b *Backend) HibernateSequence(ctx context.Context, ref string, spec Hibern
 	if uErr := b.UpdateStates(ctx, []string{vmID}, types.VMStateStopped); uErr != nil {
 		logger.Warnf(ctx, "mark stopped %s: %v", vmID, uErr)
 	}
+	if needsQuiesce(&rec) {
+		if qErr := b.QuiesceIfPending(ctx, vmID); qErr != nil {
+			logger.Warnf(ctx, "%v", qErr)
+		}
+	}
 	return nil
 }
 

--- a/hypervisor/start.go
+++ b/hypervisor/start.go
@@ -49,19 +49,19 @@ func (b *Backend) StartSequence(ctx context.Context, id string, spec StartSpec) 
 	return runWrapped(rec, spec.Wrap, func() error {
 		// Inside the ops lock so a concurrent stop's late quiesce cannot bring this VM's plumbing down after it is up.
 		if err := b.RecoverNetwork(ctx, rec); err != nil {
-			b.MarkError(ctx, id)
+			b.markFailedOperation(ctx, id, true)
 			return fmt.Errorf("recover network: %w", err)
 		}
 		sockPath := SocketPath(rec.RunDir)
 		pid, err := spec.Launch(ctx, rec, sockPath)
 		if err != nil {
-			b.MarkError(ctx, id)
+			b.markFailedOperation(ctx, id, true)
 			return fmt.Errorf("launch VM: %w", err)
 		}
 		if spec.PostLaunch != nil {
 			if err := spec.PostLaunch(ctx, rec, sockPath, pid); err != nil {
 				b.AbortLaunch(ctx, pid, sockPath, rec.RunDir, spec.RuntimeFiles)
-				b.MarkError(ctx, id)
+				b.markFailedOperation(ctx, id, true)
 				return fmt.Errorf("configure VM: %w", err)
 			}
 		}

--- a/hypervisor/start.go
+++ b/hypervisor/start.go
@@ -96,7 +96,7 @@ func (b *Backend) PrepareStart(ctx context.Context, id string, runtimeFiles []st
 	switch {
 	case runErr == nil:
 		if rec.State != types.VMStateRunning {
-			b.ReconcileToRunning(ctx, id)
+			_, _ = b.ReconcileToRunning(ctx, id)
 		}
 		return nil, nil
 	case errors.Is(runErr, ErrNotRunning):

--- a/hypervisor/start.go
+++ b/hypervisor/start.go
@@ -47,6 +47,11 @@ func (b *Backend) StartSequence(ctx context.Context, id string, spec StartSpec) 
 		return fmt.Errorf("network invariants violated: %w", vErr)
 	}
 	return runWrapped(rec, spec.Wrap, func() error {
+		// Inside the ops lock so a concurrent stop's late quiesce cannot bring this VM's plumbing down after it is up.
+		if err := b.RecoverNetwork(ctx, rec); err != nil {
+			b.MarkError(ctx, id)
+			return fmt.Errorf("recover network: %w", err)
+		}
 		sockPath := SocketPath(rec.RunDir)
 		pid, err := spec.Launch(ctx, rec, sockPath)
 		if err != nil {
@@ -91,13 +96,11 @@ func (b *Backend) PrepareStart(ctx context.Context, id string, runtimeFiles []st
 	switch {
 	case runErr == nil:
 		if rec.State != types.VMStateRunning {
-			b.reconcileToRunning(ctx, id)
+			b.ReconcileToRunning(ctx, id)
 		}
 		return nil, nil
 	case errors.Is(runErr, ErrNotRunning):
-		if hasOpenComputeInterval(&rec) {
-			b.closeStaleComputeInterval(ctx, &rec)
-		}
+		b.convergeCrashedStart(ctx, &rec)
 	default:
 		return nil, fmt.Errorf("reconcile running VM %s: %w", id, runErr)
 	}

--- a/hypervisor/start_test.go
+++ b/hypervisor/start_test.go
@@ -2,6 +2,7 @@ package hypervisor
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -57,6 +58,48 @@ func TestStartSequenceRejectsNilNIC(t *testing.T) {
 	loaded, _ := b.LoadRecord(ctx, id)
 	if loaded.State != types.VMStateError {
 		t.Errorf("state = %s, want error", loaded.State)
+	}
+}
+
+func TestStartSequenceLaunchFailureSchedulesNetworkConvergence(t *testing.T) {
+	b, _ := newMeteringTestBackend(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	const id = "vm-launch-fail"
+	seedStoppedVMWithDirs(t, b, id)
+	if err := b.dbUpdate(ctx, func(idx *VMIndex) error {
+		idx.VMs[id].NetSetup = types.NetSetup{
+			NetBackend:     types.BackendCNI,
+			NetworkConfigs: []*types.NetworkConfig{{}},
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("seed network: %v", err)
+	}
+	quiesced := 0
+	b.SetNetwork(stubNetwork{quiesce: func(context.Context, *types.VM) error {
+		quiesced++
+		return nil
+	}})
+
+	err := b.StartSequence(ctx, id, StartSpec{
+		Launch: func(context.Context, *VMRecord, string) (int, error) {
+			cancel()
+			return 0, errors.New("launch canceled")
+		},
+	})
+	if err == nil {
+		t.Fatal("expected launch failure")
+	}
+	rec := recordOf(t, b, id)
+	if rec.State != types.VMStateError || !rec.QuiescePending {
+		t.Fatalf("state = %s, pending = %v; want error/true", rec.State, rec.QuiescePending)
+	}
+	if err := b.ConvergeDead(t.Context(), id, rec.TransitionGeneration, timeNow()); err != nil {
+		t.Fatalf("ConvergeDead: %v", err)
+	}
+	after := recordOf(t, b, id)
+	if quiesced != 1 || after.QuiescePending {
+		t.Fatalf("quiesced = %d, pending = %v; want 1/false", quiesced, after.QuiescePending)
 	}
 }
 

--- a/hypervisor/state.go
+++ b/hypervisor/state.go
@@ -172,6 +172,38 @@ func (b *Backend) MarkError(ctx context.Context, id string) {
 	}
 }
 
+// markFailedOperation records retryable host-network convergence after an
+// operation may have brought plumbing up without committing a usable VMM.
+// The daemon re-observes liveness before acting: a surviving VMM is adopted,
+// while a dead one is quiesced and clears the pending bit.
+func (b *Backend) markFailedOperation(ctx context.Context, id string, markError bool) {
+	ctx, cancel := detachedWrite(ctx)
+	defer cancel()
+	now := timeNow()
+	if err := b.update(ctx, func(t *vmTx) error {
+		r, err := t.Get(id)
+		if err != nil || r == nil {
+			return err
+		}
+		changed := false
+		if markError && r.State != types.VMStateError {
+			markTransition(r, types.VMStateError, types.TransitionError, now)
+			changed = true
+		}
+		pending := needsQuiesce(r)
+		if r.QuiescePending != pending {
+			r.QuiescePending = pending
+			changed = true
+		}
+		if !changed {
+			return nil
+		}
+		return t.Put(id, r)
+	}); err != nil {
+		log.WithFunc(b.Typ+".markFailedOperation").Errorf(ctx, err, "persist failed operation for VM %s", id)
+	}
+}
+
 // QuarantineVM marks the VM error and persists the quarantine reason (see VMRecord.Quarantine).
 func (b *Backend) QuarantineVM(ctx context.Context, id, reason string) {
 	ctx, cancel := detachedWrite(ctx)

--- a/hypervisor/state.go
+++ b/hypervisor/state.go
@@ -121,12 +121,17 @@ func (b *Backend) UpdateStates(ctx context.Context, ids []string, state types.VM
 			markTransition(r, state, types.TransitionError, now)
 			return nil
 		}
+		open := hasOpenComputeInterval(r)
+		wasUp := open || r.State == types.VMStateRunning
 		markTransition(r, state, types.TransitionStopUser, now)
 		r.QuiescePending = needsQuiesce(r)
-		if !hasOpenComputeInterval(r) {
+		if wasUp {
+			// A VM that was up gets a stop time even when its ledger interval was never opened.
+			r.StoppedAt = &now
+		}
+		if !open {
 			return nil
 		}
-		r.StoppedAt = &now
 		return []metering.Entry{b.makeEntry(metering.KindVMComputeStop, id, metering.ReasonStopUser, shapeFromConfig(r.Config), now)}
 	})
 }

--- a/hypervisor/state.go
+++ b/hypervisor/state.go
@@ -103,13 +103,17 @@ func (b *Backend) UpdateStates(ctx context.Context, ids []string, state types.VM
 	}
 	now := timeNow()
 	return b.batchUpdateVMs(ctx, ids, func(r *VMRecord, id string) []metering.Entry {
-		r.State = state
-		r.UpdatedAt = now
-		if state == types.VMStateStopped && hasOpenComputeInterval(r) {
-			r.StoppedAt = &now
-			return []metering.Entry{b.makeEntry(metering.KindVMComputeStop, id, metering.ReasonStopUser, shapeFromConfig(r.Config), now)}
+		if state != types.VMStateStopped {
+			markTransition(r, state, types.TransitionError, now)
+			return nil
 		}
-		return nil
+		markTransition(r, state, types.TransitionStopUser, now)
+		r.QuiescePending = needsQuiesce(r)
+		if !hasOpenComputeInterval(r) {
+			return nil
+		}
+		r.StoppedAt = &now
+		return []metering.Entry{b.makeEntry(metering.KindVMComputeStop, id, metering.ReasonStopUser, shapeFromConfig(r.Config), now)}
 	})
 }
 
@@ -159,9 +163,8 @@ func (b *Backend) QuarantineVM(ctx context.Context, id, reason string) {
 		if err != nil || r == nil {
 			return err
 		}
-		r.State = types.VMStateError
+		markTransition(r, types.VMStateError, types.TransitionError, now)
 		r.Quarantine = reason
-		r.UpdatedAt = now
 		return t.Put(id, r)
 	}); err != nil {
 		log.WithFunc(b.Typ+".QuarantineVM").Errorf(ctx, err, "quarantine VM %s", id)
@@ -176,52 +179,23 @@ func (b *Backend) BatchMarkStarted(ctx context.Context, ids []string) error {
 	now := timeNow()
 	return b.batchUpdateVMs(ctx, ids, func(r *VMRecord, id string) []metering.Entry {
 		shape := shapeFromConfig(r.Config)
+		emitReason, transition := bootReasons(r.FirstBooted)
 		var staged []metering.Entry
 		if hasOpenComputeInterval(r) {
 			staged = append(staged, b.makeEntry(metering.KindVMComputeStop, id, metering.ReasonStopCrash, shape, now))
 		}
-		staged = append(staged, b.makeEntry(metering.KindVMComputeStart, id, bootOrRestartReason(r.FirstBooted), shape, now))
-		r.State = types.VMStateRunning
+		staged = append(staged, b.makeEntry(metering.KindVMComputeStart, id, emitReason, shape, now))
+		markTransition(r, types.VMStateRunning, transition, now)
 		r.StartedAt = &now
 		r.StoppedAt = nil
-		r.UpdatedAt = now
 		r.FirstBooted = true
+		r.QuiescePending = false
 		return staged
 	})
 }
 
-// closeStaleComputeInterval emits stop-crash and writes StoppedAt; precondition: caller confirmed the process is dead. Self-healing if the record vanishes (concurrent rm) or was already closed: skip emit.
-func (b *Backend) closeStaleComputeInterval(ctx context.Context, rec *VMRecord) {
-	now := timeNow()
-	closed := false
-	if err := b.update(ctx, func(t *vmTx) error {
-		closed = false
-		r, err := t.Get(rec.ID)
-		if err != nil {
-			return err
-		}
-		if r == nil || !hasOpenComputeInterval(r) {
-			return nil
-		}
-		if r.State == types.VMStateRunning {
-			r.State = types.VMStateStopped
-		}
-		r.StoppedAt = &now
-		r.UpdatedAt = now
-		closed = true
-		return t.Put(rec.ID, r)
-	}); err != nil {
-		log.WithFunc(b.Typ+".closeStaleComputeInterval").Warnf(ctx, "close interval for %s: %v", rec.ID, err)
-		return
-	}
-	if !closed {
-		return
-	}
-	b.Metering.Emit(ctx, b.makeEntry(metering.KindVMComputeStop, rec.ID, metering.ReasonStopCrash, shapeFromConfig(rec.Config), now))
-}
-
-// reconcileToRunning flips State→Running for a drifted record whose process is alive. With an open compute interval (Error after Running) the ledger already matches; without one (rare orphan: BatchMarkStarted's DB write failed after a successful launch) we emit a fresh compute.start so a later stop doesn't fire an unmatched compute.stop.
-func (b *Backend) reconcileToRunning(ctx context.Context, id string) {
+// ReconcileToRunning flips State→Running for a drifted record whose process is alive; the caller holds the VM ops lock. With an open compute interval (Error after Running) the ledger already matches; without one (rare orphan: BatchMarkStarted's DB write failed after a successful launch) we emit a fresh compute.start so a later stop doesn't fire an unmatched compute.stop.
+func (b *Backend) ReconcileToRunning(ctx context.Context, id string) {
 	now := timeNow()
 	var (
 		emit   bool
@@ -237,23 +211,22 @@ func (b *Backend) reconcileToRunning(ctx context.Context, id string) {
 		if r == nil || r.State == types.VMStateRunning {
 			return nil
 		}
-		if hasOpenComputeInterval(r) {
-			r.State = types.VMStateRunning
-			r.StoppedAt = nil
-			r.UpdatedAt = now
+		emitReason, transition := bootReasons(r.FirstBooted)
+		open := hasOpenComputeInterval(r)
+		markTransition(r, types.VMStateRunning, transition, now)
+		r.StoppedAt = nil
+		r.QuiescePending = false
+		if open {
 			return t.Put(id, r)
 		}
 		emit = true
 		shape = shapeFromConfig(r.Config)
-		reason = bootOrRestartReason(r.FirstBooted)
-		r.State = types.VMStateRunning
+		reason = emitReason
 		r.StartedAt = &now
-		r.StoppedAt = nil
-		r.UpdatedAt = now
 		r.FirstBooted = true
 		return t.Put(id, r)
 	}); err != nil {
-		log.WithFunc(b.Typ+".reconcileToRunning").Warnf(ctx, "flip %s to running: %v", id, err)
+		log.WithFunc(b.Typ+".ReconcileToRunning").Warnf(ctx, "flip %s to running: %v", id, err)
 		return
 	}
 	if emit {
@@ -271,9 +244,24 @@ func hasOpenComputeInterval(r *VMRecord) bool {
 	return r != nil && r.StartedAt != nil && r.StoppedAt == nil
 }
 
-func bootOrRestartReason(firstBooted bool) metering.Reason {
+// markTransition stamps one committed state change; every record state write goes through it so generations stay dense enough to fence a stale observation against a newer transition.
+func markTransition(r *VMRecord, state types.VMState, reason types.TransitionReason, at time.Time) {
+	r.State = state
+	r.TransitionGeneration++
+	r.LastTransitionReason = reason
+	r.LastTransitionAt = &at
+	r.UpdatedAt = at
+}
+
+// needsQuiesce reports whether the VM owns host plumbing a stop must bring down; it mirrors the provider selection, where a missing backend or NIC set means there is nothing to quiesce.
+func needsQuiesce(r *VMRecord) bool {
+	return r != nil && r.ResolvedNetBackend() != "" && len(r.NetworkConfigs) > 0
+}
+
+// bootReasons maps first-boot state onto the metering and transition vocabularies, which name the same event.
+func bootReasons(firstBooted bool) (metering.Reason, types.TransitionReason) {
 	if firstBooted {
-		return metering.ReasonRestart
+		return metering.ReasonRestart, types.TransitionRestart
 	}
-	return metering.ReasonBoot
+	return metering.ReasonBoot, types.TransitionBoot
 }

--- a/hypervisor/state.go
+++ b/hypervisor/state.go
@@ -28,9 +28,7 @@ func (b *Backend) WithRunningVM(ctx context.Context, rec *VMRecord, fn func(pid 
 	return b.withRunningVM(ctx, rec, nil, fn)
 }
 
-// withRunningVM resolves liveness against scan when the caller already walked
-// /proc for this pass; a nil scan walks it now. The fallback walk is per-call,
-// so a batch that skips it turns N walks into one.
+// withRunningVM resolves liveness against the caller's /proc walk; a nil scan walks now, so batch callers turn N walks into one.
 func (b *Backend) withRunningVM(ctx context.Context, rec *VMRecord, scan *utils.ProcScan, fn func(pid int) error) error {
 	logger := log.WithFunc(b.Typ + ".WithRunningVM")
 	pid, pidErr := utils.ReadPIDFile(b.PIDFilePath(rec.RunDir))
@@ -172,10 +170,7 @@ func (b *Backend) MarkError(ctx context.Context, id string) {
 	}
 }
 
-// markFailedOperation records retryable host-network convergence after an
-// operation may have brought plumbing up without committing a usable VMM.
-// The daemon re-observes liveness before acting: a surviving VMM is adopted,
-// while a dead one is quiesced and clears the pending bit.
+// markFailedOperation records retryable network convergence after an operation may have brought plumbing up without committing a usable VMM; the daemon re-observes before acting on it.
 func (b *Backend) markFailedOperation(ctx context.Context, id string, markError bool) {
 	ctx, cancel := detachedWrite(ctx)
 	defer cancel()
@@ -245,8 +240,8 @@ func (b *Backend) BatchMarkStarted(ctx context.Context, ids []string) error {
 	})
 }
 
-// ReconcileToRunning flips State→Running for a drifted record whose process is alive and returns the generation it committed (zero when it changed nothing); the caller holds the VM ops lock. With an open compute interval (Error after Running) the ledger already matches; without one (rare orphan: BatchMarkStarted's DB write failed after a successful launch) we emit a fresh compute.start so a later stop doesn't fire an unmatched compute.stop.
-func (b *Backend) ReconcileToRunning(ctx context.Context, id string) uint64 {
+// ReconcileToRunning flips a drifted record with a live process back to Running under the caller's ops lock, returning the committed generation (zero if unchanged); without an open interval it emits a fresh compute.start so a later stop stays matched.
+func (b *Backend) ReconcileToRunning(ctx context.Context, id string) (uint64, error) {
 	now := timeNow()
 	var (
 		emit   bool
@@ -260,8 +255,7 @@ func (b *Backend) ReconcileToRunning(ctx context.Context, id string) uint64 {
 		if err != nil {
 			return err
 		}
-		// A quarantined or still-creating record is nobody's to promote: repairing it
-		// would clear StoppedAt and the pending quiesce for a VM that never committed.
+		// A quarantined or still-creating record is nobody's to promote.
 		if r == nil || r.State == types.VMStateRunning || r.State == types.VMStateCreating || r.Quarantine != "" {
 			return nil
 		}
@@ -282,12 +276,12 @@ func (b *Backend) ReconcileToRunning(ctx context.Context, id string) uint64 {
 		return t.Put(id, r)
 	}); err != nil {
 		log.WithFunc(b.Typ+".ReconcileToRunning").Warnf(ctx, "flip %s to running: %v", id, err)
-		return 0
+		return 0, err
 	}
 	if emit {
 		b.Metering.Emit(ctx, b.makeEntry(metering.KindVMComputeStart, id, reason, shape, now))
 	}
-	return gen
+	return gen, nil
 }
 
 // detachedWrite returns a context for bookkeeping writes that must survive caller cancellation, bounded by persistTimeout.
@@ -300,7 +294,7 @@ func hasOpenComputeInterval(r *VMRecord) bool {
 	return r != nil && r.StartedAt != nil && r.StoppedAt == nil
 }
 
-// markTransition stamps one committed state change; every record state write goes through it so generations stay dense enough to fence a stale observation against a newer transition.
+// markTransition stamps one committed state change; every state write goes through it so generations stay dense enough to fence stale observations.
 func markTransition(r *VMRecord, state types.VMState, reason types.TransitionReason, at time.Time) {
 	r.State = state
 	r.TransitionGeneration++
@@ -309,12 +303,11 @@ func markTransition(r *VMRecord, state types.VMState, reason types.TransitionRea
 	r.UpdatedAt = at
 }
 
-// needsQuiesce reports whether the VM owns host plumbing a stop must bring down; it mirrors the provider selection, where a missing backend or NIC set means there is nothing to quiesce.
+// needsQuiesce reports whether the VM owns host plumbing a stop must bring down.
 func needsQuiesce(r *VMRecord) bool {
 	return r != nil && r.ResolvedNetBackend() != "" && len(r.NetworkConfigs) > 0
 }
 
-// bootReasons maps first-boot state onto the metering and transition vocabularies, which name the same event.
 func bootReasons(firstBooted bool) (metering.Reason, types.TransitionReason) {
 	if firstBooted {
 		return metering.ReasonRestart, types.TransitionRestart

--- a/hypervisor/state.go
+++ b/hypervisor/state.go
@@ -25,6 +25,13 @@ const (
 
 // WithRunningVM calls fn if rec still points to a live VM process.
 func (b *Backend) WithRunningVM(ctx context.Context, rec *VMRecord, fn func(pid int) error) error {
+	return b.withRunningVM(ctx, rec, nil, fn)
+}
+
+// withRunningVM resolves liveness against scan when the caller already walked
+// /proc for this pass; a nil scan walks it now. The fallback walk is per-call,
+// so a batch that skips it turns N walks into one.
+func (b *Backend) withRunningVM(ctx context.Context, rec *VMRecord, scan *utils.ProcScan, fn func(pid int) error) error {
 	logger := log.WithFunc(b.Typ + ".WithRunningVM")
 	pid, pidErr := utils.ReadPIDFile(b.PIDFilePath(rec.RunDir))
 	if pidErr != nil && !errors.Is(pidErr, fs.ErrNotExist) {
@@ -35,7 +42,7 @@ func (b *Backend) WithRunningVM(ctx context.Context, rec *VMRecord, fn func(pid 
 		return fn(pid)
 	}
 	// Covers pidfile/socket cleaned up before VMM exited. Fail-closed if scan errors so callers don't treat inconclusive state as ErrNotRunning.
-	scanned, scanErr := utils.FindVMMByCmdline(b.Conf.BinaryName(), sockPath)
+	scanned, scanErr := b.scanFor(scan, sockPath)
 	if scanErr != nil {
 		return fmt.Errorf("vm %s: pidfile-based check failed and /proc scan errored: %w (resolve the host issue and retry)", rec.ID, scanErr)
 	}
@@ -44,6 +51,13 @@ func (b *Backend) WithRunningVM(ctx context.Context, rec *VMRecord, fn func(pid 
 	}
 	logger.Warnf(ctx, "VM %s recovered live pids %v via cmdline scan", rec.ID, scanned)
 	return fn(scanned[0])
+}
+
+func (b *Backend) scanFor(scan *utils.ProcScan, sockPath string) ([]int, error) {
+	if scan != nil {
+		return scan.Find(sockPath), nil
+	}
+	return utils.FindVMMByCmdline(b.Conf.BinaryName(), sockPath)
 }
 
 // IsAPISocketLive: (true,nil)=confirmed live; (false,nil)=ENOENT/ECONNREFUSED; (true,err)=fail-closed for unknown dial errors.
@@ -194,21 +208,24 @@ func (b *Backend) BatchMarkStarted(ctx context.Context, ids []string) error {
 	})
 }
 
-// ReconcileToRunning flips State→Running for a drifted record whose process is alive; the caller holds the VM ops lock. With an open compute interval (Error after Running) the ledger already matches; without one (rare orphan: BatchMarkStarted's DB write failed after a successful launch) we emit a fresh compute.start so a later stop doesn't fire an unmatched compute.stop.
-func (b *Backend) ReconcileToRunning(ctx context.Context, id string) {
+// ReconcileToRunning flips State→Running for a drifted record whose process is alive and returns the generation it committed (zero when it changed nothing); the caller holds the VM ops lock. With an open compute interval (Error after Running) the ledger already matches; without one (rare orphan: BatchMarkStarted's DB write failed after a successful launch) we emit a fresh compute.start so a later stop doesn't fire an unmatched compute.stop.
+func (b *Backend) ReconcileToRunning(ctx context.Context, id string) uint64 {
 	now := timeNow()
 	var (
 		emit   bool
+		gen    uint64
 		shape  metering.Shape
 		reason metering.Reason
 	)
 	if err := b.update(ctx, func(t *vmTx) error {
-		emit = false
+		emit, gen = false, 0
 		r, err := t.Get(id)
 		if err != nil {
 			return err
 		}
-		if r == nil || r.State == types.VMStateRunning {
+		// A quarantined or still-creating record is nobody's to promote: repairing it
+		// would clear StoppedAt and the pending quiesce for a VM that never committed.
+		if r == nil || r.State == types.VMStateRunning || r.State == types.VMStateCreating || r.Quarantine != "" {
 			return nil
 		}
 		emitReason, transition := bootReasons(r.FirstBooted)
@@ -216,6 +233,7 @@ func (b *Backend) ReconcileToRunning(ctx context.Context, id string) {
 		markTransition(r, types.VMStateRunning, transition, now)
 		r.StoppedAt = nil
 		r.QuiescePending = false
+		gen = r.TransitionGeneration
 		if open {
 			return t.Put(id, r)
 		}
@@ -227,11 +245,12 @@ func (b *Backend) ReconcileToRunning(ctx context.Context, id string) {
 		return t.Put(id, r)
 	}); err != nil {
 		log.WithFunc(b.Typ+".ReconcileToRunning").Warnf(ctx, "flip %s to running: %v", id, err)
-		return
+		return 0
 	}
 	if emit {
 		b.Metering.Emit(ctx, b.makeEntry(metering.KindVMComputeStart, id, reason, shape, now))
 	}
+	return gen
 }
 
 // detachedWrite returns a context for bookkeeping writes that must survive caller cancellation, bounded by persistTimeout.

--- a/hypervisor/state_test.go
+++ b/hypervisor/state_test.go
@@ -446,7 +446,7 @@ func TestReconcileToRunningFromError(t *testing.T) {
 	b.MarkError(ctx, "vm1")
 	rec.Reset()
 
-	b.reconcileToRunning(ctx, "vm1")
+	b.ReconcileToRunning(ctx, "vm1")
 
 	loaded, err := b.LoadRecord(ctx, "vm1")
 	if err != nil {
@@ -472,7 +472,7 @@ func TestReconcileToRunningOrphanLaunchEmitsStart(t *testing.T) {
 	ctx := t.Context()
 	seedVMRecord(t, b, "vm1", 2, 2<<30, 20<<30, false)
 
-	b.reconcileToRunning(ctx, "vm1")
+	b.ReconcileToRunning(ctx, "vm1")
 
 	loaded, _ := b.LoadRecord(ctx, "vm1")
 	if loaded.State != types.VMStateRunning {
@@ -496,7 +496,7 @@ func TestReconcileToRunningOrphanLaunchAfterFirstBoot(t *testing.T) {
 	ctx := t.Context()
 	seedVMRecord(t, b, "vm1", 1, 1<<30, 10<<30, true)
 
-	b.reconcileToRunning(ctx, "vm1")
+	b.ReconcileToRunning(ctx, "vm1")
 
 	entries := rec.Entries()
 	if len(entries) != 1 || entries[0].Reason != metering.ReasonRestart {
@@ -510,7 +510,7 @@ func TestReconcileToRunningIdempotent(t *testing.T) {
 	seedRunningVM(t, b, "vm1", 2, 2<<30, 20<<30)
 	rec.Reset()
 
-	b.reconcileToRunning(ctx, "vm1")
+	b.ReconcileToRunning(ctx, "vm1")
 
 	if got := rec.Entries(); len(got) != 0 {
 		t.Errorf("idempotent reconcile must not emit; got %d", len(got))

--- a/hypervisor/stop.go
+++ b/hypervisor/stop.go
@@ -140,8 +140,7 @@ func (b *Backend) deleteOneLocked(ctx context.Context, id string, force bool, st
 	shape := shapeFromConfig(rec.Config)
 	hadRunningInterval := hasOpenComputeInterval(rec)
 	if stoppedByUs {
-		// The stop above closed the interval and emitted its own compute.stop; the
-		// pre-stop copy still reads open, and emitting from it double-closes the ledger.
+		// The stop above already emitted its compute.stop; the pre-stop copy still reads open.
 		if fresh, freshErr := b.LoadRecord(ctx, id); freshErr == nil {
 			hadRunningInterval = hasOpenComputeInterval(&fresh)
 		}

--- a/hypervisor/stop.go
+++ b/hypervisor/stop.go
@@ -56,8 +56,16 @@ func (b *Backend) StopOneLocked(ctx context.Context, id string, spec StopSpec) e
 		return err
 	}
 	// Warn-and-continue: the VMM is dead and the flip self-heals on the next reconcile.
+	logger := log.WithFunc(b.Typ + ".StopOneLocked")
 	if err := b.UpdateStates(ctx, []string{id}, types.VMStateStopped); err != nil {
-		log.WithFunc(b.Typ+".StopOneLocked").Warnf(ctx, "mark stopped %s: %v", id, err)
+		logger.Warnf(ctx, "mark stopped %s: %v", id, err)
+	}
+	// Still under the caller's ops lock: an idle TAP's TC redirect storms softirqs until its host NICs go down (#130). A failure keeps the pending flag for a later pass.
+	// Gated on the pre-stop record so an unplumbed VM's stop pays no extra read; the stop cannot have changed what that predicate reads.
+	if needsQuiesce(&rec) {
+		if err := b.QuiesceIfPending(ctx, id); err != nil {
+			logger.Warnf(ctx, "%v", err)
+		}
 	}
 	return nil
 }

--- a/hypervisor/stop.go
+++ b/hypervisor/stop.go
@@ -60,13 +60,8 @@ func (b *Backend) StopOneLocked(ctx context.Context, id string, spec StopSpec) e
 	if err := b.UpdateStates(ctx, []string{id}, types.VMStateStopped); err != nil {
 		logger.Warnf(ctx, "mark stopped %s: %v", id, err)
 	}
-	// Still under the caller's ops lock: an idle TAP's TC redirect storms softirqs until its host NICs go down (#130). A failure keeps the pending flag for a later pass.
-	// Gated on the pre-stop record so an unplumbed VM's stop pays no extra read; the stop cannot have changed what that predicate reads.
-	if needsQuiesce(&rec) {
-		if err := b.QuiesceIfPending(ctx, id); err != nil {
-			logger.Warnf(ctx, "%v", err)
-		}
-	}
+	// Still under the caller's ops lock: an idle TAP's TC redirect storms softirqs until its host NICs go down (#130).
+	b.quiesceAfterStop(ctx, id, &rec)
 	return nil
 }
 

--- a/hypervisor/stop.go
+++ b/hypervisor/stop.go
@@ -141,7 +141,14 @@ func (b *Backend) deleteOneLocked(ctx context.Context, id string, force bool, st
 	}
 	shape := shapeFromConfig(rec.Config)
 	hadRunningInterval := hasOpenComputeInterval(rec)
-	if err := b.deleteVMProtocol(ctx, id, rec, b.NetCleanup); err != nil {
+	if stoppedByUs {
+		// The stop above closed the interval and emitted its own compute.stop; the
+		// pre-stop copy still reads open, and emitting from it double-closes the ledger.
+		if fresh, freshErr := b.LoadRecord(ctx, id); freshErr == nil {
+			hadRunningInterval = hasOpenComputeInterval(&fresh)
+		}
+	}
+	if err := b.deleteVMProtocol(ctx, id, rec); err != nil {
 		return err
 	}
 	computeReason := metering.ReasonStopCrash

--- a/hypervisor/stop.go
+++ b/hypervisor/stop.go
@@ -52,13 +52,16 @@ func (b *Backend) StopOneLocked(ctx context.Context, id string, spec StopSpec) e
 	shutdownErr := b.WithRunningVM(ctx, &rec, func(pid int) error {
 		return spec.Shutdown(ctx, &rec, sockPath, pid)
 	})
+	settled := errors.Is(shutdownErr, ErrNotRunning) && rec.State == types.VMStateStopped && !hasOpenComputeInterval(&rec)
 	if err := b.HandleStopResult(ctx, id, rec.RunDir, spec.RuntimeFiles, shutdownErr); err != nil {
 		return err
 	}
-	// Warn-and-continue: the VMM is dead and the flip self-heals on the next reconcile.
-	logger := log.WithFunc(b.Typ + ".StopOneLocked")
-	if err := b.UpdateStates(ctx, []string{id}, types.VMStateStopped); err != nil {
-		logger.Warnf(ctx, "mark stopped %s: %v", id, err)
+	if !settled {
+		// Warn-and-continue: the VMM is dead and the flip self-heals on the next reconcile.
+		logger := log.WithFunc(b.Typ + ".StopOneLocked")
+		if err := b.UpdateStates(ctx, []string{id}, types.VMStateStopped); err != nil {
+			logger.Warnf(ctx, "mark stopped %s: %v", id, err)
+		}
 	}
 	// Still under the caller's ops lock: an idle TAP's TC redirect storms softirqs until its host NICs go down (#130).
 	b.quiesceAfterStop(ctx, id, &rec)

--- a/hypervisor/stop_test.go
+++ b/hypervisor/stop_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/cocoonstack/cocoon/metering"
+	meteringcapture "github.com/cocoonstack/cocoon/metering/capture"
 	"github.com/cocoonstack/cocoon/types"
 	"github.com/cocoonstack/cocoon/utils"
 )
@@ -153,5 +154,38 @@ func TestDeleteMigratedVMClearsCleanupIntent(t *testing.T) {
 	}
 	if _, err := os.Stat(runDir); !os.IsNotExist(err) {
 		t.Fatal("migrated run dir must be removed")
+	}
+}
+
+// A forced delete of a running VM stops it first, and that stop already closes
+// the compute interval; emitting again from the pre-stop record would bill two
+// stops against one start.
+func TestDeleteForceEmitsOneComputeStop(t *testing.T) {
+	b, id := newHibernateTestVM(t)
+	ctx := t.Context()
+	rec := meteringcapture.New()
+	b.Metering = rec
+	if err := b.BatchMarkStarted(ctx, []string{id}); err != nil {
+		t.Fatalf("BatchMarkStarted: %v", err)
+	}
+
+	stopLocked := func(ctx context.Context, id string) error {
+		return b.StopOneLocked(ctx, id, StopSpec{
+			RuntimeFiles: []string{APISocketName},
+			Shutdown:     func(context.Context, *VMRecord, string, int) error { return nil },
+		})
+	}
+	if _, err := b.DeleteAll(ctx, []string{id}, true, stopLocked, nil); err != nil {
+		t.Fatalf("DeleteAll: %v", err)
+	}
+
+	stops := 0
+	for _, e := range rec.Entries() {
+		if e.Kind == metering.KindVMComputeStop {
+			stops++
+		}
+	}
+	if stops != 1 {
+		t.Errorf("got %d vm.compute.stop for one start, want 1: %+v", stops, rec.Entries())
 	}
 }

--- a/hypervisor/stop_test.go
+++ b/hypervisor/stop_test.go
@@ -53,6 +53,78 @@ func TestDeleteAllStoppedVM(t *testing.T) {
 	}
 }
 
+func TestStopAfterUnexpectedExitIsIdempotent(t *testing.T) {
+	b, _ := newMeteringTestBackend(t)
+	ctx := t.Context()
+	const id = "vm-stop-race"
+	seedStoppedVMWithDirs(t, b, id)
+	if err := b.dbUpdate(ctx, func(idx *VMIndex) error {
+		r := idx.VMs[id]
+		r.TransitionGeneration = 7
+		r.LastTransitionReason = types.TransitionUnexpectedExit
+		r.QuiescePending = true
+		r.NetSetup = types.NetSetup{
+			NetBackend:     types.BackendCNI,
+			NetworkConfigs: []*types.NetworkConfig{{}},
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("seed unexpected exit: %v", err)
+	}
+	quiesced := 0
+	b.SetNetwork(stubNetwork{quiesce: func(context.Context, *types.VM) error {
+		quiesced++
+		return nil
+	}})
+
+	if err := b.StopOneLocked(ctx, id, StopSpec{}); err != nil {
+		t.Fatalf("StopOneLocked: %v", err)
+	}
+	rec := recordOf(t, b, id)
+	if rec.TransitionGeneration != 7 || rec.LastTransitionReason != types.TransitionUnexpectedExit {
+		t.Fatalf("generation = %d, reason = %s; want 7/unexpected-exit", rec.TransitionGeneration, rec.LastTransitionReason)
+	}
+	if quiesced != 1 || rec.QuiescePending {
+		t.Fatalf("quiesced = %d, pending = %v; want 1/false", quiesced, rec.QuiescePending)
+	}
+}
+
+func TestStopStaleStoppedRecordWithLiveVMMStillTransitions(t *testing.T) {
+	b, id := newHibernateTestVM(t)
+	ctx := t.Context()
+	if err := b.dbUpdate(ctx, func(idx *VMIndex) error {
+		r := idx.VMs[id]
+		r.State = types.VMStateStopped
+		r.TransitionGeneration = 7
+		r.NetSetup = types.NetSetup{
+			NetBackend:     types.BackendCNI,
+			NetworkConfigs: []*types.NetworkConfig{{}},
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("seed stale stopped record: %v", err)
+	}
+	quiesced := 0
+	b.SetNetwork(stubNetwork{quiesce: func(context.Context, *types.VM) error {
+		quiesced++
+		return nil
+	}})
+
+	err := b.StopOneLocked(ctx, id, StopSpec{Shutdown: func(ctx context.Context, rec *VMRecord, sockPath string, pid int) error {
+		return utils.TerminateProcess(ctx, pid, b.Conf.BinaryName(), sockPath, time.Second)
+	}})
+	if err != nil {
+		t.Fatalf("StopOneLocked: %v", err)
+	}
+	rec := recordOf(t, b, id)
+	if rec.TransitionGeneration != 8 || rec.LastTransitionReason != types.TransitionStopUser {
+		t.Fatalf("generation = %d, reason = %s; want 8/stop-user", rec.TransitionGeneration, rec.LastTransitionReason)
+	}
+	if quiesced != 1 || rec.QuiescePending {
+		t.Fatalf("quiesced = %d, pending = %v; want 1/false", quiesced, rec.QuiescePending)
+	}
+}
+
 // TestDeleteAllForceStopsUnderLock drives the full force path against a live
 // stub VMM: the delete body holds the ops lock while stopLocked runs, so this
 // deadlocks (and times out) if the stop variant re-takes the lock.

--- a/hypervisor/supervisor.go
+++ b/hypervisor/supervisor.go
@@ -15,10 +15,28 @@ import (
 	"github.com/cocoonstack/cocoon/utils"
 )
 
-// SupervisionScan is one reconcile pass's view of a backend namespace.
+var _ Supervisable = (*Backend)(nil)
+
+// Supervisable is the backend surface a resident supervisor drives; every
+// hypervisor backend embeds *Backend and satisfies it.
+type Supervisable interface {
+	Type() string
+	ScanSupervision(ctx context.Context) (SupervisionScan, error)
+	ObserveVMM(ctx context.Context, rec *VMRecord) (utils.ProcRef, error)
+	ObserveVMMIn(ctx context.Context, rec *VMRecord, scan utils.ProcScan) (utils.ProcRef, error)
+	TryLockVMOps(ctx context.Context, vmID string) (func(), bool, error)
+	PeekRecord(ctx context.Context, vmID string) (*VMRecord, error)
+	ConvergeDead(ctx context.Context, vmID string, gen uint64, observedAt time.Time) error
+	ReconcileToRunning(ctx context.Context, vmID string) uint64
+	CollectStaleCreate(ctx context.Context, vmID string, rec *VMRecord) error
+}
+
+// SupervisionScan is one reconcile pass's view of a backend namespace, plus the
+// single /proc walk its liveness checks share.
 type SupervisionScan struct {
 	Records    []*VMRecord
 	Tombstoned map[string]struct{}
+	Procs      utils.ProcScan
 }
 
 // ScanSupervision reads every record plus the unfinished-delete set in one
@@ -44,14 +62,32 @@ func (b *Backend) ScanSupervision(ctx context.Context) (SupervisionScan, error) 
 	}); err != nil {
 		return SupervisionScan{}, err
 	}
+	// Outside the transaction: the json engine holds the namespace flock for the
+	// whole closure, and this walks every process on the host.
+	procs, err := utils.ScanProcsByBinary(b.Conf.BinaryName())
+	if err != nil {
+		return SupervisionScan{}, fmt.Errorf("scan /proc for %s: %w", b.Typ, err)
+	}
+	scan.Procs = procs
 	return scan, nil
 }
 
 // ObserveVMM returns the live VMM's process generation, ErrNotRunning when none
 // is live, or an error when liveness is inconclusive and the caller must retry.
 func (b *Backend) ObserveVMM(ctx context.Context, rec *VMRecord) (utils.ProcRef, error) {
+	return b.observe(ctx, rec, nil)
+}
+
+// ObserveVMMIn is ObserveVMM against a pass-wide /proc walk. It is for deciding
+// what work to attempt: anything that then mutates must re-observe freshly under
+// the ops lock, because the scan predates the lock.
+func (b *Backend) ObserveVMMIn(ctx context.Context, rec *VMRecord, scan utils.ProcScan) (utils.ProcRef, error) {
+	return b.observe(ctx, rec, &scan)
+}
+
+func (b *Backend) observe(ctx context.Context, rec *VMRecord, scan *utils.ProcScan) (utils.ProcRef, error) {
 	var ref utils.ProcRef
-	err := b.WithRunningVM(ctx, rec, func(pid int) error {
+	err := b.withRunningVM(ctx, rec, scan, func(pid int) error {
 		var refErr error
 		ref, refErr = utils.ProcRefOf(pid)
 		return refErr
@@ -79,8 +115,7 @@ func (b *Backend) TryLockVMOps(ctx context.Context, vmID string) (unlock func(),
 // write against a record that transitioned since the observation, so a stale
 // event cannot date or re-label a newer transition; observedAt dates the stop.
 func (b *Backend) ConvergeDead(ctx context.Context, id string, gen uint64, observedAt time.Time) error {
-	pending, err := b.convergeDeadRecord(ctx, id, gen, observedAt)
-	if err != nil || !pending {
+	if err := b.convergeDeadRecord(ctx, id, gen, observedAt); err != nil {
 		return err
 	}
 	return b.QuiesceIfPending(ctx, id)
@@ -88,13 +123,10 @@ func (b *Backend) ConvergeDead(ctx context.Context, id string, gen uint64, obser
 
 // convergeDeadRecord commits the stop transition and publishes its staged
 // metering entry; the network quiesce it schedules is the caller's to run.
-func (b *Backend) convergeDeadRecord(ctx context.Context, id string, gen uint64, observedAt time.Time) (bool, error) {
-	var (
-		emit    []metering.Entry
-		pending bool
-	)
+func (b *Backend) convergeDeadRecord(ctx context.Context, id string, gen uint64, observedAt time.Time) error {
+	var emit []metering.Entry
 	if err := b.update(ctx, func(t *vmTx) error {
-		emit, pending = nil, false
+		emit = nil
 		r, err := t.Get(id)
 		if err != nil || r == nil {
 			return err
@@ -108,13 +140,12 @@ func (b *Backend) convergeDeadRecord(ctx context.Context, id string, gen uint64,
 		}
 		markTransition(r, types.VMStateStopped, types.TransitionUnexpectedExit, observedAt)
 		r.QuiescePending = needsQuiesce(r)
-		pending = r.QuiescePending
 		return t.Put(id, r)
 	}); err != nil {
-		return false, err
+		return err
 	}
 	b.emitAll(ctx, emit)
-	return pending, nil
+	return nil
 }
 
 // QuiesceIfPending brings a stopped VM's host NICs down and clears the flag
@@ -177,7 +208,7 @@ func (b *Backend) convergeCrashedStart(ctx context.Context, rec *VMRecord) {
 	if !NeedsDeadConvergence(rec) {
 		return
 	}
-	if _, err := b.convergeDeadRecord(ctx, rec.ID, rec.TransitionGeneration, timeNow()); err != nil {
+	if err := b.convergeDeadRecord(ctx, rec.ID, rec.TransitionGeneration, timeNow()); err != nil {
 		log.WithFunc(b.Typ+".convergeCrashedStart").Warnf(ctx, "converge crashed VM %s: %v", rec.ID, err)
 	}
 }

--- a/hypervisor/supervisor.go
+++ b/hypervisor/supervisor.go
@@ -29,6 +29,7 @@ type Supervisable interface {
 	ConvergeDead(ctx context.Context, vmID string, gen uint64, observedAt time.Time) error
 	ReconcileToRunning(ctx context.Context, vmID string) uint64
 	CollectStaleCreate(ctx context.Context, vmID string, rec *VMRecord) error
+	RecoverTombstone(ctx context.Context, vmID string) (bool, error)
 }
 
 // SupervisionScan is one reconcile pass's view of a backend namespace, plus the
@@ -133,8 +134,10 @@ func (b *Backend) convergeDeadRecord(ctx context.Context, id string, gen uint64,
 		}
 		if hasOpenComputeInterval(r) {
 			emit = []metering.Entry{b.makeEntry(metering.KindVMComputeStop, id, metering.ReasonStopCrash, shapeFromConfig(r.Config), observedAt)}
-			r.StoppedAt = &observedAt
 		}
+		// Dated whether or not a ledger interval was open: StoppedAt is when the VM was
+		// observed stopped, and a record predating the interval bookkeeping still has one.
+		r.StoppedAt = &observedAt
 		markTransition(r, types.VMStateStopped, types.TransitionUnexpectedExit, observedAt)
 		r.QuiescePending = needsQuiesce(r)
 		return t.Put(id, r)
@@ -182,6 +185,13 @@ func (b *Backend) CollectStaleCreate(ctx context.Context, id string, rec *VMReco
 		return fmt.Errorf("orphan vmm for %s: %w (dirs kept)", id, err)
 	}
 	return b.deleteVMProtocol(ctx, id, rec)
+}
+
+// RecoverTombstone drives an unfinished delete to completion under the held ops
+// lock, reporting whether the record is now gone. Supervision needs it because it
+// starts deletes of its own.
+func (b *Backend) RecoverTombstone(ctx context.Context, id string) (bool, error) {
+	return b.recoverVMTombstone(ctx, id)
 }
 
 // clearQuiescePending is relaxed: losing the clear only costs one idempotent re-quiesce on a later pass.

--- a/hypervisor/supervisor.go
+++ b/hypervisor/supervisor.go
@@ -15,14 +15,6 @@ import (
 	"github.com/cocoonstack/cocoon/utils"
 )
 
-// NetLifecycle converges a VM's host networking. The command layer supplies it
-// so a state transition and its network action share one VM ops lock instead of
-// splitting across an unlock window.
-type NetLifecycle struct {
-	Recover func(ctx context.Context, vm *types.VM) error
-	Quiesce func(ctx context.Context, vm *types.VM) error
-}
-
 // SupervisionScan is one reconcile pass's view of a backend namespace.
 type SupervisionScan struct {
 	Records    []*VMRecord
@@ -130,7 +122,7 @@ func (b *Backend) convergeDeadRecord(ctx context.Context, id string, gen uint64,
 // pending work its own stop scheduled. The caller holds the VM ops lock and has
 // established that no VMM is live.
 func (b *Backend) QuiesceIfPending(ctx context.Context, id string) error {
-	if b.NetLife.Quiesce == nil {
+	if b.Net == nil {
 		return nil
 	}
 	var (
@@ -147,19 +139,10 @@ func (b *Backend) QuiesceIfPending(ctx context.Context, id string) error {
 	}); err != nil || vm == nil {
 		return err
 	}
-	if err := b.NetLife.Quiesce(ctx, vm); err != nil {
+	if err := b.quiesceNetwork(ctx, vm); err != nil {
 		return fmt.Errorf("quiesce network for VM %s (pending kept): %w", id, err)
 	}
 	return b.clearQuiescePending(ctx, id, gen)
-}
-
-// RecoverNetwork rebuilds and un-quiesces a VM's host plumbing before launch;
-// the caller holds the VM ops lock.
-func (b *Backend) RecoverNetwork(ctx context.Context, rec *VMRecord) error {
-	if b.NetLife.Recover == nil {
-		return nil
-	}
-	return b.NetLife.Recover(ctx, &rec.VM)
 }
 
 // CollectStaleCreate terminates any orphan VMM and runs the delete protocol for
@@ -170,7 +153,7 @@ func (b *Backend) CollectStaleCreate(ctx context.Context, id string, rec *VMReco
 	if err := b.ensureOrphanVMMDead(ctx, rec.RunDir); err != nil {
 		return fmt.Errorf("orphan vmm for %s: %w (dirs kept)", id, err)
 	}
-	return b.deleteVMProtocol(ctx, id, rec, b.NetCleanup)
+	return b.deleteVMProtocol(ctx, id, rec)
 }
 
 // clearQuiescePending is relaxed: losing the clear only costs one idempotent re-quiesce on a later pass.
@@ -189,6 +172,11 @@ func (b *Backend) clearQuiescePending(ctx context.Context, id string, gen uint64
 // It schedules no quiesce of its own: the launch about to follow brings the same
 // plumbing up, and a failed launch leaves the pending flag for a later pass.
 func (b *Backend) convergeCrashedStart(ctx context.Context, rec *VMRecord) {
+	// Prechecked in memory: rec is fresh from the entry guard under the ops lock, and a
+	// transaction that would decide there is nothing to do still takes the namespace flock.
+	if !NeedsDeadConvergence(rec) {
+		return
+	}
 	if _, err := b.convergeDeadRecord(ctx, rec.ID, rec.TransitionGeneration, timeNow()); err != nil {
 		log.WithFunc(b.Typ+".convergeCrashedStart").Warnf(ctx, "converge crashed VM %s: %v", rec.ID, err)
 	}

--- a/hypervisor/supervisor.go
+++ b/hypervisor/supervisor.go
@@ -1,0 +1,203 @@
+package hypervisor
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"time"
+
+	"github.com/projecteru2/core/log"
+
+	"github.com/cocoonstack/cocoon/meta"
+	"github.com/cocoonstack/cocoon/metering"
+	"github.com/cocoonstack/cocoon/types"
+	"github.com/cocoonstack/cocoon/utils"
+)
+
+// NetLifecycle converges a VM's host networking. The command layer supplies it
+// so a state transition and its network action share one VM ops lock instead of
+// splitting across an unlock window.
+type NetLifecycle struct {
+	Recover func(ctx context.Context, vm *types.VM) error
+	Quiesce func(ctx context.Context, vm *types.VM) error
+}
+
+// SupervisionScan is one reconcile pass's view of a backend namespace.
+type SupervisionScan struct {
+	Records    []*VMRecord
+	Tombstoned map[string]struct{}
+}
+
+// ScanSupervision reads every record plus the unfinished-delete set in one
+// transaction: the json engine holds the namespace lock for the whole closure,
+// so a pass must never widen this into per-VM reads.
+func (b *Backend) ScanSupervision(ctx context.Context) (SupervisionScan, error) {
+	var scan SupervisionScan
+	if err := b.view(ctx, func(t *vmTx) error {
+		all, err := t.All()
+		if err != nil {
+			return err
+		}
+		ids, err := b.tombstones().PendingIDs(ctx, t.r)
+		if err != nil {
+			return err
+		}
+		scan.Records = slices.Collect(maps.Values(all))
+		scan.Tombstoned = make(map[string]struct{}, len(ids))
+		for _, id := range ids {
+			scan.Tombstoned[id] = struct{}{}
+		}
+		return nil
+	}); err != nil {
+		return SupervisionScan{}, err
+	}
+	return scan, nil
+}
+
+// ObserveVMM returns the live VMM's process generation, ErrNotRunning when none
+// is live, or an error when liveness is inconclusive and the caller must retry.
+func (b *Backend) ObserveVMM(ctx context.Context, rec *VMRecord) (utils.ProcRef, error) {
+	var ref utils.ProcRef
+	err := b.WithRunningVM(ctx, rec, func(pid int) error {
+		var refErr error
+		ref, refErr = utils.ProcRefOf(pid)
+		return refErr
+	})
+	return ref, err
+}
+
+// TryLockVMOps takes the VM ops lock without blocking; ok=false with a nil error
+// means another operation owns it and the caller should retry on a later pass.
+func (b *Backend) TryLockVMOps(ctx context.Context, vmID string) (unlock func(), ok bool, err error) {
+	l, err := opsLock(b.Conf, vmID)
+	if err != nil {
+		return nil, false, err
+	}
+	locked, err := l.TryLock(ctx)
+	if err != nil || !locked {
+		return nil, false, err
+	}
+	return func() { _ = l.Unlock(ctx) }, true, nil
+}
+
+// ConvergeDead lands the transition for a VMM that exited outside a cocoon stop,
+// then runs any network quiesce it schedules. The caller holds the VM ops lock
+// and has conclusively observed that no VMM generation is live. gen fences the
+// write against a record that transitioned since the observation, so a stale
+// event cannot date or re-label a newer transition; observedAt dates the stop.
+func (b *Backend) ConvergeDead(ctx context.Context, id string, gen uint64, observedAt time.Time) error {
+	pending, err := b.convergeDeadRecord(ctx, id, gen, observedAt)
+	if err != nil || !pending {
+		return err
+	}
+	return b.QuiesceIfPending(ctx, id)
+}
+
+// convergeDeadRecord commits the stop transition and publishes its staged
+// metering entry; the network quiesce it schedules is the caller's to run.
+func (b *Backend) convergeDeadRecord(ctx context.Context, id string, gen uint64, observedAt time.Time) (bool, error) {
+	var (
+		emit    []metering.Entry
+		pending bool
+	)
+	if err := b.update(ctx, func(t *vmTx) error {
+		emit, pending = nil, false
+		r, err := t.Get(id)
+		if err != nil || r == nil {
+			return err
+		}
+		if r.TransitionGeneration != gen || !NeedsDeadConvergence(r) {
+			return nil
+		}
+		if hasOpenComputeInterval(r) {
+			emit = []metering.Entry{b.makeEntry(metering.KindVMComputeStop, id, metering.ReasonStopCrash, shapeFromConfig(r.Config), observedAt)}
+			r.StoppedAt = &observedAt
+		}
+		markTransition(r, types.VMStateStopped, types.TransitionUnexpectedExit, observedAt)
+		r.QuiescePending = needsQuiesce(r)
+		pending = r.QuiescePending
+		return t.Put(id, r)
+	}); err != nil {
+		return false, err
+	}
+	b.emitAll(ctx, emit)
+	return pending, nil
+}
+
+// QuiesceIfPending brings a stopped VM's host NICs down and clears the flag
+// under the generation it observed, so a VM restarted in between keeps the
+// pending work its own stop scheduled. The caller holds the VM ops lock and has
+// established that no VMM is live.
+func (b *Backend) QuiesceIfPending(ctx context.Context, id string) error {
+	if b.NetLife.Quiesce == nil {
+		return nil
+	}
+	var (
+		vm  *types.VM
+		gen uint64
+	)
+	if err := b.view(ctx, func(t *vmTx) error {
+		r, err := t.Get(id)
+		if err != nil || r == nil || !r.QuiescePending {
+			return err
+		}
+		vm, gen = &r.VM, r.TransitionGeneration
+		return nil
+	}); err != nil || vm == nil {
+		return err
+	}
+	if err := b.NetLife.Quiesce(ctx, vm); err != nil {
+		return fmt.Errorf("quiesce network for VM %s (pending kept): %w", id, err)
+	}
+	return b.clearQuiescePending(ctx, id, gen)
+}
+
+// RecoverNetwork rebuilds and un-quiesces a VM's host plumbing before launch;
+// the caller holds the VM ops lock.
+func (b *Backend) RecoverNetwork(ctx context.Context, rec *VMRecord) error {
+	if b.NetLife.Recover == nil {
+		return nil
+	}
+	return b.NetLife.Recover(ctx, &rec.VM)
+}
+
+// CollectStaleCreate terminates any orphan VMM and runs the delete protocol for
+// a creating placeholder whose owner is gone, freeing the name reservation. The
+// caller holds the VM ops lock, which is itself the proof of ownerlessness:
+// create and clone hold it from prereserve through the final record commit.
+func (b *Backend) CollectStaleCreate(ctx context.Context, id string, rec *VMRecord) error {
+	if err := b.ensureOrphanVMMDead(ctx, rec.RunDir); err != nil {
+		return fmt.Errorf("orphan vmm for %s: %w (dirs kept)", id, err)
+	}
+	return b.deleteVMProtocol(ctx, id, rec, b.NetCleanup)
+}
+
+// clearQuiescePending is relaxed: losing the clear only costs one idempotent re-quiesce on a later pass.
+func (b *Backend) clearQuiescePending(ctx context.Context, id string, gen uint64) error {
+	return b.updateRelaxed(ctx, func(t *vmTx) error {
+		r, err := t.Get(id)
+		if err != nil || r == nil || r.TransitionGeneration != gen || !r.QuiescePending {
+			return err
+		}
+		r.QuiescePending = false
+		return t.Put(id, r, meta.RelaxedOK)
+	})
+}
+
+// convergeCrashedStart closes a crashed VM's ledger interval on the start path.
+// It schedules no quiesce of its own: the launch about to follow brings the same
+// plumbing up, and a failed launch leaves the pending flag for a later pass.
+func (b *Backend) convergeCrashedStart(ctx context.Context, rec *VMRecord) {
+	if _, err := b.convergeDeadRecord(ctx, rec.ID, rec.TransitionGeneration, timeNow()); err != nil {
+		log.WithFunc(b.Typ+".convergeCrashedStart").Warnf(ctx, "converge crashed VM %s: %v", rec.ID, err)
+	}
+}
+
+// NeedsDeadConvergence reports whether a record still claims a VM the ledger or the state field thinks is up. Creating placeholders are excluded: their owner is the create path, and the stale-create protocol collects them.
+func NeedsDeadConvergence(r *VMRecord) bool {
+	if r == nil || r.State == types.VMStateCreating {
+		return false
+	}
+	return r.State == types.VMStateRunning || hasOpenComputeInterval(r)
+}

--- a/hypervisor/supervisor.go
+++ b/hypervisor/supervisor.go
@@ -62,8 +62,7 @@ func (b *Backend) ScanSupervision(ctx context.Context) (SupervisionScan, error) 
 	}); err != nil {
 		return SupervisionScan{}, err
 	}
-	// Outside the transaction: the json engine holds the namespace flock for the
-	// whole closure, and this walks every process on the host.
+	// Outside the transaction: this walks every process on the host, and the json engine holds the namespace flock for the whole closure.
 	procs, err := utils.ScanProcsByBinary(b.Conf.BinaryName())
 	if err != nil {
 		return SupervisionScan{}, fmt.Errorf("scan /proc for %s: %w", b.Typ, err)
@@ -78,9 +77,7 @@ func (b *Backend) ObserveVMM(ctx context.Context, rec *VMRecord) (utils.ProcRef,
 	return b.observe(ctx, rec, nil)
 }
 
-// ObserveVMMIn is ObserveVMM against a pass-wide /proc walk. It is for deciding
-// what work to attempt: anything that then mutates must re-observe freshly under
-// the ops lock, because the scan predates the lock.
+// ObserveVMMIn is ObserveVMM against a pass-wide /proc walk; it decides what work to attempt, so anything that then mutates must re-observe freshly under the ops lock.
 func (b *Backend) ObserveVMMIn(ctx context.Context, rec *VMRecord, scan utils.ProcScan) (utils.ProcRef, error) {
 	return b.observe(ctx, rec, &scan)
 }
@@ -203,8 +200,7 @@ func (b *Backend) clearQuiescePending(ctx context.Context, id string, gen uint64
 // It schedules no quiesce of its own: the launch about to follow brings the same
 // plumbing up, and a failed launch leaves the pending flag for a later pass.
 func (b *Backend) convergeCrashedStart(ctx context.Context, rec *VMRecord) {
-	// Prechecked in memory: rec is fresh from the entry guard under the ops lock, and a
-	// transaction that would decide there is nothing to do still takes the namespace flock.
+	// Prechecked in memory: rec is fresh from the entry guard, and a transaction that decides nothing to do still takes the namespace flock.
 	if !NeedsDeadConvergence(rec) {
 		return
 	}

--- a/hypervisor/supervisor.go
+++ b/hypervisor/supervisor.go
@@ -17,8 +17,7 @@ import (
 
 var _ Supervisable = (*Backend)(nil)
 
-// Supervisable is the backend surface a resident supervisor drives; every
-// hypervisor backend embeds *Backend and satisfies it.
+// Supervisable is the backend surface a resident supervisor drives.
 type Supervisable interface {
 	Type() string
 	ScanSupervision(ctx context.Context) (SupervisionScan, error)
@@ -27,22 +26,19 @@ type Supervisable interface {
 	TryLockVMOps(ctx context.Context, vmID string) (func(), bool, error)
 	PeekRecord(ctx context.Context, vmID string) (*VMRecord, error)
 	ConvergeDead(ctx context.Context, vmID string, gen uint64, observedAt time.Time) error
-	ReconcileToRunning(ctx context.Context, vmID string) uint64
+	ReconcileToRunning(ctx context.Context, vmID string) (uint64, error)
 	CollectStaleCreate(ctx context.Context, vmID string, rec *VMRecord) error
 	RecoverTombstone(ctx context.Context, vmID string) (bool, error)
 }
 
-// SupervisionScan is one reconcile pass's view of a backend namespace, plus the
-// single /proc walk its liveness checks share.
+// SupervisionScan is one reconcile pass's view of a backend namespace plus the single /proc walk its liveness checks share.
 type SupervisionScan struct {
 	Records    []*VMRecord
 	Tombstoned map[string]struct{}
 	Procs      utils.ProcScan
 }
 
-// ScanSupervision reads every record plus the unfinished-delete set in one
-// transaction: the json engine holds the namespace lock for the whole closure,
-// so a pass must never widen this into per-VM reads.
+// ScanSupervision reads every record plus the unfinished-delete set in one transaction; the json engine holds the namespace flock for the whole closure, so never widen this into per-VM reads.
 func (b *Backend) ScanSupervision(ctx context.Context) (SupervisionScan, error) {
 	var scan SupervisionScan
 	if err := b.view(ctx, func(t *vmTx) error {
@@ -63,7 +59,6 @@ func (b *Backend) ScanSupervision(ctx context.Context) (SupervisionScan, error) 
 	}); err != nil {
 		return SupervisionScan{}, err
 	}
-	// Outside the transaction: this walks every process on the host, and the json engine holds the namespace flock for the whole closure.
 	procs, err := utils.ScanProcsByBinary(b.Conf.BinaryName())
 	if err != nil {
 		return SupervisionScan{}, fmt.Errorf("scan /proc for %s: %w", b.Typ, err)
@@ -72,13 +67,12 @@ func (b *Backend) ScanSupervision(ctx context.Context) (SupervisionScan, error) 
 	return scan, nil
 }
 
-// ObserveVMM returns the live VMM's process generation, ErrNotRunning when none
-// is live, or an error when liveness is inconclusive and the caller must retry.
+// ObserveVMM returns the live VMM's process generation, ErrNotRunning when none is live, or an error when liveness is inconclusive.
 func (b *Backend) ObserveVMM(ctx context.Context, rec *VMRecord) (utils.ProcRef, error) {
 	return b.observe(ctx, rec, nil)
 }
 
-// ObserveVMMIn is ObserveVMM against a pass-wide /proc walk; it decides what work to attempt, so anything that then mutates must re-observe freshly under the ops lock.
+// ObserveVMMIn is ObserveVMM against a pass-wide /proc walk; mutations must still re-observe freshly under the ops lock.
 func (b *Backend) ObserveVMMIn(ctx context.Context, rec *VMRecord, scan utils.ProcScan) (utils.ProcRef, error) {
 	return b.observe(ctx, rec, &scan)
 }
@@ -93,8 +87,7 @@ func (b *Backend) observe(ctx context.Context, rec *VMRecord, scan *utils.ProcSc
 	return ref, err
 }
 
-// TryLockVMOps takes the VM ops lock without blocking; ok=false with a nil error
-// means another operation owns it and the caller should retry on a later pass.
+// TryLockVMOps takes the VM ops lock without blocking; ok=false with a nil error means another operation owns it.
 func (b *Backend) TryLockVMOps(ctx context.Context, vmID string) (unlock func(), ok bool, err error) {
 	l, err := opsLock(b.Conf, vmID)
 	if err != nil {
@@ -107,11 +100,8 @@ func (b *Backend) TryLockVMOps(ctx context.Context, vmID string) (unlock func(),
 	return func() { _ = l.Unlock(ctx) }, true, nil
 }
 
-// ConvergeDead lands the transition for a VMM that exited outside a cocoon stop,
-// then runs any network quiesce it schedules. The caller holds the VM ops lock
-// and has conclusively observed that no VMM generation is live. gen fences the
-// write against a record that transitioned since the observation, so a stale
-// event cannot date or re-label a newer transition; observedAt dates the stop.
+// ConvergeDead lands the stop transition for a VMM that exited outside a cocoon stop, then runs the quiesce it schedules; the caller holds the ops lock and observed no live VMM.
+// gen fences the write so a stale observation cannot date or re-label a newer transition.
 func (b *Backend) ConvergeDead(ctx context.Context, id string, gen uint64, observedAt time.Time) error {
 	if err := b.convergeDeadRecord(ctx, id, gen, observedAt); err != nil {
 		return err
@@ -119,8 +109,7 @@ func (b *Backend) ConvergeDead(ctx context.Context, id string, gen uint64, obser
 	return b.QuiesceIfPending(ctx, id)
 }
 
-// convergeDeadRecord commits the stop transition and publishes its staged
-// metering entry; the network quiesce it schedules is the caller's to run.
+// convergeDeadRecord commits the stop transition and publishes its staged metering entry; the quiesce it schedules is the caller's to run.
 func (b *Backend) convergeDeadRecord(ctx context.Context, id string, gen uint64, observedAt time.Time) error {
 	var emit []metering.Entry
 	if err := b.update(ctx, func(t *vmTx) error {
@@ -135,8 +124,7 @@ func (b *Backend) convergeDeadRecord(ctx context.Context, id string, gen uint64,
 		if hasOpenComputeInterval(r) {
 			emit = []metering.Entry{b.makeEntry(metering.KindVMComputeStop, id, metering.ReasonStopCrash, shapeFromConfig(r.Config), observedAt)}
 		}
-		// Dated whether or not a ledger interval was open: StoppedAt is when the VM was
-		// observed stopped, and a record predating the interval bookkeeping still has one.
+		// StoppedAt is observation time, owed even to records predating the interval bookkeeping.
 		r.StoppedAt = &observedAt
 		markTransition(r, types.VMStateStopped, types.TransitionUnexpectedExit, observedAt)
 		r.QuiescePending = needsQuiesce(r)
@@ -148,10 +136,7 @@ func (b *Backend) convergeDeadRecord(ctx context.Context, id string, gen uint64,
 	return nil
 }
 
-// QuiesceIfPending brings a stopped VM's host NICs down and clears the flag
-// under the generation it observed, so a VM restarted in between keeps the
-// pending work its own stop scheduled. The caller holds the VM ops lock and has
-// established that no VMM is live.
+// QuiesceIfPending runs a scheduled quiesce and clears the flag fenced on the generation it read; the caller holds the ops lock with no VMM live.
 func (b *Backend) QuiesceIfPending(ctx context.Context, id string) error {
 	if b.Net == nil {
 		return nil
@@ -176,10 +161,7 @@ func (b *Backend) QuiesceIfPending(ctx context.Context, id string) error {
 	return b.clearQuiescePending(ctx, id, gen)
 }
 
-// CollectStaleCreate terminates any orphan VMM and runs the delete protocol for
-// a creating placeholder whose owner is gone, freeing the name reservation. The
-// caller holds the VM ops lock, which is itself the proof of ownerlessness:
-// create and clone hold it from prereserve through the final record commit.
+// CollectStaleCreate reclaims an ownerless creating placeholder; the held ops lock is the proof of ownerlessness, since create and clone hold it from prereserve through the final commit.
 func (b *Backend) CollectStaleCreate(ctx context.Context, id string, rec *VMRecord) error {
 	if err := b.ensureOrphanVMMDead(ctx, rec.RunDir); err != nil {
 		return fmt.Errorf("orphan vmm for %s: %w (dirs kept)", id, err)
@@ -187,9 +169,7 @@ func (b *Backend) CollectStaleCreate(ctx context.Context, id string, rec *VMReco
 	return b.deleteVMProtocol(ctx, id, rec)
 }
 
-// RecoverTombstone drives an unfinished delete to completion under the held ops
-// lock, reporting whether the record is now gone. Supervision needs it because it
-// starts deletes of its own.
+// RecoverTombstone drives an unfinished delete to completion under the held ops lock; supervision starts deletes of its own, so it must be able to finish them.
 func (b *Backend) RecoverTombstone(ctx context.Context, id string) (bool, error) {
 	return b.recoverVMTombstone(ctx, id)
 }
@@ -206,11 +186,8 @@ func (b *Backend) clearQuiescePending(ctx context.Context, id string, gen uint64
 	})
 }
 
-// convergeCrashedStart closes a crashed VM's ledger interval on the start path.
-// It schedules no quiesce of its own: the launch about to follow brings the same
-// plumbing up, and a failed launch leaves the pending flag for a later pass.
+// convergeCrashedStart closes a crashed VM's ledger on the start path, skipping the quiesce the imminent launch would undo; the in-memory precheck exists because even an empty transaction takes the namespace flock.
 func (b *Backend) convergeCrashedStart(ctx context.Context, rec *VMRecord) {
-	// Prechecked in memory: rec is fresh from the entry guard, and a transaction that decides nothing to do still takes the namespace flock.
 	if !NeedsDeadConvergence(rec) {
 		return
 	}
@@ -219,7 +196,7 @@ func (b *Backend) convergeCrashedStart(ctx context.Context, rec *VMRecord) {
 	}
 }
 
-// NeedsDeadConvergence reports whether a record still claims a VM the ledger or the state field thinks is up. Creating placeholders are excluded: their owner is the create path, and the stale-create protocol collects them.
+// NeedsDeadConvergence reports whether a record still claims a VM as up; creating placeholders are the stale-create protocol's to collect.
 func NeedsDeadConvergence(r *VMRecord) bool {
 	if r == nil || r.State == types.VMStateCreating {
 		return false

--- a/hypervisor/supervisor_test.go
+++ b/hypervisor/supervisor_test.go
@@ -131,7 +131,7 @@ func TestConvergeDeadQuiescesPlumbedVM(t *testing.T) {
 	ctx := t.Context()
 	seedPlumbedVM(t, b, "vm1")
 	var quiesced []string
-	b.SetNetLifecycle(NetLifecycle{Quiesce: func(_ context.Context, vm *types.VM) error {
+	b.SetNetwork(stubNetwork{quiesce: func(_ context.Context, vm *types.VM) error {
 		quiesced = append(quiesced, vm.ID)
 		return nil
 	}})
@@ -151,7 +151,7 @@ func TestConvergeDeadKeepsPendingWhenQuiesceFails(t *testing.T) {
 	b, _ := newMeteringTestBackend(t)
 	ctx := t.Context()
 	seedPlumbedVM(t, b, "vm1")
-	b.SetNetLifecycle(NetLifecycle{Quiesce: func(context.Context, *types.VM) error {
+	b.SetNetwork(stubNetwork{quiesce: func(context.Context, *types.VM) error {
 		return fmt.Errorf("netns gone")
 	}})
 
@@ -172,7 +172,7 @@ func TestQuiesceIfPendingFencedByGeneration(t *testing.T) {
 	b, _ := newMeteringTestBackend(t)
 	ctx := t.Context()
 	seedPlumbedVM(t, b, "vm1")
-	b.SetNetLifecycle(NetLifecycle{Quiesce: func(context.Context, *types.VM) error {
+	b.SetNetwork(stubNetwork{quiesce: func(context.Context, *types.VM) error {
 		// A concurrent stop transitions the record while the quiesce is in flight.
 		return b.UpdateStates(ctx, []string{"vm1"}, types.VMStateStopped)
 	}})

--- a/hypervisor/supervisor_test.go
+++ b/hypervisor/supervisor_test.go
@@ -301,3 +301,62 @@ func TestTryLockVMOpsReportsBusyWithoutError(t *testing.T) {
 		t.Fatal("acquired an ops lock already held by an in-flight operation")
 	}
 }
+
+// StoppedAt is when the VM was observed stopped, so a record predating the
+// interval bookkeeping still gets one.
+func TestConvergeDeadDatesARecordWithNoOpenInterval(t *testing.T) {
+	b, rec := newMeteringTestBackend(t)
+	ctx := t.Context()
+	seedVMRecord(t, b, "vm1", 1, 1<<30, 10<<30, true)
+	if err := b.dbUpdate(ctx, func(idx *VMIndex) error {
+		idx.VMs["vm1"].State = types.VMStateRunning
+		return nil
+	}); err != nil {
+		t.Fatalf("seed legacy running: %v", err)
+	}
+	observed := time.Date(2026, 7, 21, 11, 0, 0, 0, time.UTC)
+
+	if err := b.ConvergeDead(ctx, "vm1", recordOf(t, b, "vm1").TransitionGeneration, observed); err != nil {
+		t.Fatalf("ConvergeDead: %v", err)
+	}
+	got := recordOf(t, b, "vm1")
+	if got.StoppedAt == nil || !got.StoppedAt.Equal(observed) {
+		t.Errorf("got StoppedAt %v, want the observation time %v", got.StoppedAt, observed)
+	}
+	if n := len(rec.Entries()); n != 0 {
+		t.Errorf("got %d metering entries, want 0 without an open interval", n)
+	}
+}
+
+func TestUpdateStatesDatesAStoppedRecordThatWasRunning(t *testing.T) {
+	b, _ := newMeteringTestBackend(t)
+	ctx := t.Context()
+	seedVMRecord(t, b, "vm1", 1, 1<<30, 10<<30, true)
+	if err := b.dbUpdate(ctx, func(idx *VMIndex) error {
+		idx.VMs["vm1"].State = types.VMStateRunning
+		return nil
+	}); err != nil {
+		t.Fatalf("seed legacy running: %v", err)
+	}
+
+	if err := b.UpdateStates(ctx, []string{"vm1"}, types.VMStateStopped); err != nil {
+		t.Fatalf("UpdateStates: %v", err)
+	}
+	if recordOf(t, b, "vm1").StoppedAt == nil {
+		t.Error("a running record stopped by the user got no stop time")
+	}
+}
+
+// A VM that never started must not be dated as though it had.
+func TestUpdateStatesLeavesACreatedRecordUndated(t *testing.T) {
+	b, _ := newMeteringTestBackend(t)
+	ctx := t.Context()
+	seedVMRecord(t, b, "vm1", 1, 1<<30, 10<<30, false)
+
+	if err := b.UpdateStates(ctx, []string{"vm1"}, types.VMStateStopped); err != nil {
+		t.Fatalf("UpdateStates: %v", err)
+	}
+	if got := recordOf(t, b, "vm1"); got.StoppedAt != nil {
+		t.Errorf("got StoppedAt %v for a VM that never ran, want nil", got.StoppedAt)
+	}
+}

--- a/hypervisor/supervisor_test.go
+++ b/hypervisor/supervisor_test.go
@@ -1,0 +1,303 @@
+package hypervisor
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cocoonstack/cocoon/metering"
+	"github.com/cocoonstack/cocoon/types"
+)
+
+// seedPlumbedVM gives a running VM the persisted network state a stop must quiesce.
+func seedPlumbedVM(t *testing.T, b *Backend, id string) {
+	t.Helper()
+	seedRunningVM(t, b, id, 1, 1<<30, 10<<30)
+	if err := b.dbUpdate(t.Context(), func(idx *VMIndex) error {
+		idx.VMs[id].NetSetup = types.NetSetup{
+			NetBackend:     types.BackendCNI,
+			NetworkConfigs: []*types.NetworkConfig{{}},
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("seed network: %v", err)
+	}
+}
+
+func recordOf(t *testing.T, b *Backend, id string) *VMRecord {
+	t.Helper()
+	rec, err := b.PeekRecord(t.Context(), id)
+	if err != nil {
+		t.Fatalf("peek %s: %v", id, err)
+	}
+	if rec == nil {
+		t.Fatalf("record %s is gone", id)
+	}
+	return rec
+}
+
+func TestConvergeDeadMarksUnexpectedExit(t *testing.T) {
+	b, rec := newMeteringTestBackend(t)
+	ctx := t.Context()
+	seedRunningVM(t, b, "vm1", 2, 1<<30, 10<<30)
+	observed := time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC)
+
+	if err := b.ConvergeDead(ctx, "vm1", recordOf(t, b, "vm1").TransitionGeneration, observed); err != nil {
+		t.Fatalf("ConvergeDead: %v", err)
+	}
+
+	got := recordOf(t, b, "vm1")
+	if got.State != types.VMStateStopped {
+		t.Errorf("got state %q, want stopped", got.State)
+	}
+	if got.LastTransitionReason != types.TransitionUnexpectedExit {
+		t.Errorf("got reason %q, want %q", got.LastTransitionReason, types.TransitionUnexpectedExit)
+	}
+	if got.StoppedAt == nil || !got.StoppedAt.Equal(observed) {
+		t.Errorf("got StoppedAt %v, want the observation time %v", got.StoppedAt, observed)
+	}
+	entries := rec.Entries()
+	if len(entries) != 1 || entries[0].Kind != metering.KindVMComputeStop || entries[0].Reason != metering.ReasonStopCrash {
+		t.Fatalf("got %+v, want one compute.stop/stop-crash", entries)
+	}
+	if !entries[0].EmittedAt.Equal(observed) {
+		t.Errorf("got EmittedAt %v, want the observation time %v", entries[0].EmittedAt, observed)
+	}
+}
+
+// A second convergence must not re-close the ledger: the generation it fences on has already advanced.
+func TestConvergeDeadIsIdempotent(t *testing.T) {
+	b, rec := newMeteringTestBackend(t)
+	ctx := t.Context()
+	seedRunningVM(t, b, "vm1", 1, 1<<30, 10<<30)
+	gen := recordOf(t, b, "vm1").TransitionGeneration
+
+	for range 3 {
+		if err := b.ConvergeDead(ctx, "vm1", gen, timeNow()); err != nil {
+			t.Fatalf("ConvergeDead: %v", err)
+		}
+	}
+	if got := len(rec.Entries()); got != 1 {
+		t.Errorf("got %d metering entries, want 1", got)
+	}
+	if got := recordOf(t, b, "vm1").TransitionGeneration; got != gen+1 {
+		t.Errorf("got generation %d, want exactly one increment from %d", got, gen)
+	}
+}
+
+func TestConvergeDeadFencesStaleGeneration(t *testing.T) {
+	b, rec := newMeteringTestBackend(t)
+	ctx := t.Context()
+	seedRunningVM(t, b, "vm1", 1, 1<<30, 10<<30)
+	gen := recordOf(t, b, "vm1").TransitionGeneration
+
+	if err := b.ConvergeDead(ctx, "vm1", gen+1, timeNow()); err != nil {
+		t.Fatalf("ConvergeDead: %v", err)
+	}
+	if got := recordOf(t, b, "vm1").State; got != types.VMStateRunning {
+		t.Errorf("got state %q, want the record untouched at running", got)
+	}
+	if got := len(rec.Entries()); got != 0 {
+		t.Errorf("got %d metering entries, want 0 for a stale observation", got)
+	}
+}
+
+// A record left Running by an older cocoon carries no open interval; the state must still converge, without an unmatched stop.
+func TestConvergeDeadStopsLegacyRunningWithoutInterval(t *testing.T) {
+	b, rec := newMeteringTestBackend(t)
+	ctx := t.Context()
+	seedVMRecord(t, b, "vm1", 1, 1<<30, 10<<30, true)
+	if err := b.dbUpdate(ctx, func(idx *VMIndex) error {
+		idx.VMs["vm1"].State = types.VMStateRunning
+		return nil
+	}); err != nil {
+		t.Fatalf("seed legacy running: %v", err)
+	}
+
+	if err := b.ConvergeDead(ctx, "vm1", recordOf(t, b, "vm1").TransitionGeneration, timeNow()); err != nil {
+		t.Fatalf("ConvergeDead: %v", err)
+	}
+	if got := recordOf(t, b, "vm1").State; got != types.VMStateStopped {
+		t.Errorf("got state %q, want stopped", got)
+	}
+	if got := len(rec.Entries()); got != 0 {
+		t.Errorf("got %d metering entries, want 0 without an open interval", got)
+	}
+}
+
+func TestConvergeDeadQuiescesPlumbedVM(t *testing.T) {
+	b, _ := newMeteringTestBackend(t)
+	ctx := t.Context()
+	seedPlumbedVM(t, b, "vm1")
+	var quiesced []string
+	b.SetNetLifecycle(NetLifecycle{Quiesce: func(_ context.Context, vm *types.VM) error {
+		quiesced = append(quiesced, vm.ID)
+		return nil
+	}})
+
+	if err := b.ConvergeDead(ctx, "vm1", recordOf(t, b, "vm1").TransitionGeneration, timeNow()); err != nil {
+		t.Fatalf("ConvergeDead: %v", err)
+	}
+	if len(quiesced) != 1 || quiesced[0] != "vm1" {
+		t.Errorf("got quiesce calls %v, want one for vm1", quiesced)
+	}
+	if recordOf(t, b, "vm1").QuiescePending {
+		t.Error("QuiescePending still set after a successful quiesce")
+	}
+}
+
+func TestConvergeDeadKeepsPendingWhenQuiesceFails(t *testing.T) {
+	b, _ := newMeteringTestBackend(t)
+	ctx := t.Context()
+	seedPlumbedVM(t, b, "vm1")
+	b.SetNetLifecycle(NetLifecycle{Quiesce: func(context.Context, *types.VM) error {
+		return fmt.Errorf("netns gone")
+	}})
+
+	if err := b.ConvergeDead(ctx, "vm1", recordOf(t, b, "vm1").TransitionGeneration, timeNow()); err == nil {
+		t.Fatal("ConvergeDead returned nil, want the quiesce failure surfaced")
+	}
+	got := recordOf(t, b, "vm1")
+	if !got.QuiescePending {
+		t.Error("QuiescePending cleared despite a failed quiesce")
+	}
+	if got.State != types.VMStateStopped {
+		t.Errorf("got state %q, want the transition to have landed anyway", got.State)
+	}
+}
+
+// The clear is fenced: a transition landing during the quiesce owns the pending flag it set.
+func TestQuiesceIfPendingFencedByGeneration(t *testing.T) {
+	b, _ := newMeteringTestBackend(t)
+	ctx := t.Context()
+	seedPlumbedVM(t, b, "vm1")
+	b.SetNetLifecycle(NetLifecycle{Quiesce: func(context.Context, *types.VM) error {
+		// A concurrent stop transitions the record while the quiesce is in flight.
+		return b.UpdateStates(ctx, []string{"vm1"}, types.VMStateStopped)
+	}})
+	if err := b.dbUpdate(ctx, func(idx *VMIndex) error {
+		idx.VMs["vm1"].QuiescePending = true
+		return nil
+	}); err != nil {
+		t.Fatalf("seed pending: %v", err)
+	}
+
+	if err := b.QuiesceIfPending(ctx, "vm1"); err != nil {
+		t.Fatalf("QuiesceIfPending: %v", err)
+	}
+	if !recordOf(t, b, "vm1").QuiescePending {
+		t.Error("stale clear won: the newer transition's pending work was dropped")
+	}
+}
+
+func TestBatchMarkStartedClearsQuiescePending(t *testing.T) {
+	b, _ := newMeteringTestBackend(t)
+	ctx := t.Context()
+	seedPlumbedVM(t, b, "vm1")
+	if err := b.dbUpdate(ctx, func(idx *VMIndex) error {
+		idx.VMs["vm1"].QuiescePending = true
+		return nil
+	}); err != nil {
+		t.Fatalf("seed pending: %v", err)
+	}
+
+	if err := b.BatchMarkStarted(ctx, []string{"vm1"}); err != nil {
+		t.Fatalf("BatchMarkStarted: %v", err)
+	}
+	if recordOf(t, b, "vm1").QuiescePending {
+		t.Error("a start left stale pending quiesce work that would down its own plumbing")
+	}
+}
+
+func TestUpdateStatesStoppedSchedulesQuiesce(t *testing.T) {
+	b, _ := newMeteringTestBackend(t)
+	ctx := t.Context()
+	seedPlumbedVM(t, b, "vm1")
+
+	if err := b.UpdateStates(ctx, []string{"vm1"}, types.VMStateStopped); err != nil {
+		t.Fatalf("UpdateStates: %v", err)
+	}
+	got := recordOf(t, b, "vm1")
+	if !got.QuiescePending {
+		t.Error("a stop of a plumbed VM scheduled no quiesce")
+	}
+	if got.LastTransitionReason != types.TransitionStopUser {
+		t.Errorf("got reason %q, want %q", got.LastTransitionReason, types.TransitionStopUser)
+	}
+}
+
+func TestUpdateStatesStoppedSkipsQuiesceWithoutPlumbing(t *testing.T) {
+	b, _ := newMeteringTestBackend(t)
+	ctx := t.Context()
+	seedRunningVM(t, b, "vm1", 1, 1<<30, 10<<30)
+
+	if err := b.UpdateStates(ctx, []string{"vm1"}, types.VMStateStopped); err != nil {
+		t.Fatalf("UpdateStates: %v", err)
+	}
+	if recordOf(t, b, "vm1").QuiescePending {
+		t.Error("scheduled a quiesce for a VM with no host plumbing")
+	}
+}
+
+func TestNeedsDeadConvergence(t *testing.T) {
+	started := time.Now()
+	tests := []struct {
+		name string
+		rec  *VMRecord
+		want bool
+	}{
+		{"nil", nil, false},
+		{"creating stays with the create path", &VMRecord{VM: types.VM{State: types.VMStateCreating}}, false},
+		{"running", &VMRecord{VM: types.VM{State: types.VMStateRunning}}, true},
+		{"stopped and settled", &VMRecord{VM: types.VM{State: types.VMStateStopped}}, false},
+		{"error with an open interval", &VMRecord{VM: types.VM{State: types.VMStateError, StartedAt: &started}}, true},
+		{"error already closed", &VMRecord{VM: types.VM{State: types.VMStateError, StartedAt: &started, StoppedAt: &started}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NeedsDeadConvergence(tt.rec); got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCollectStaleCreateFreesTheName(t *testing.T) {
+	b, _ := newMeteringTestBackend(t)
+	ctx := t.Context()
+	cfg := &types.VMConfig{Name: "alpha", Config: types.Config{CPU: 1}}
+	if err := b.ReserveVM(ctx, "vm1", cfg, nil, t.TempDir(), t.TempDir()); err != nil {
+		t.Fatalf("ReserveVM: %v", err)
+	}
+
+	if err := b.CollectStaleCreate(ctx, "vm1", recordOf(t, b, "vm1")); err != nil {
+		t.Fatalf("CollectStaleCreate: %v", err)
+	}
+	if rec, err := b.PeekRecord(ctx, "vm1"); err != nil || rec != nil {
+		t.Errorf("got record %v (err %v), want it collected", rec, err)
+	}
+	if _, err := b.ResolveRef(ctx, "alpha"); err == nil {
+		t.Error("the name is still reserved; a retry would be blocked until GC")
+	}
+}
+
+func TestTryLockVMOpsReportsBusyWithoutError(t *testing.T) {
+	b, _ := newMeteringTestBackend(t)
+	ctx := t.Context()
+
+	held, err := b.LockVMOps(ctx, "vm1")
+	if err != nil {
+		t.Fatalf("LockVMOps: %v", err)
+	}
+	defer held()
+
+	unlock, ok, err := b.TryLockVMOps(ctx, "vm1")
+	if err != nil {
+		t.Fatalf("got error %v, want a plain busy report", err)
+	}
+	if ok {
+		unlock()
+		t.Fatal("acquired an ops lock already held by an in-flight operation")
+	}
+}

--- a/hypervisor/teardown.go
+++ b/hypervisor/teardown.go
@@ -23,10 +23,6 @@ type vmCleanup struct {
 	LogDir string `json:"log_dir,omitempty"`
 }
 
-// NetTeardown releases a VM's host networking; the command layer supplies it
-// so record deletion and network teardown share one VM lock (design §5).
-type NetTeardown func(ctx context.Context, vmID string) error
-
 func (b *Backend) tombstones() *tombstone.Table {
 	return tombstone.NewTable(b.Meta, b.NS)
 }
@@ -35,7 +31,7 @@ func (b *Backend) tombstones() *tombstone.Table {
 // lock: lease with full payload → deleting → slow teardown → fenced finalize.
 // A crash at any point leaves a phase-directed tombstone a later worker
 // resumes.
-func (b *Backend) deleteVMProtocol(ctx context.Context, id string, rec *VMRecord, teardown NetTeardown) error {
+func (b *Backend) deleteVMProtocol(ctx context.Context, id string, rec *VMRecord) error {
 	ts := b.tombstones()
 	cl := vmCleanup{Name: rec.Config.Name, RunDir: rec.RunDir, LogDir: rec.LogDir}
 	cleanup, err := tombstone.MarshalCleanup(cl)
@@ -67,16 +63,14 @@ func (b *Backend) deleteVMProtocol(ctx context.Context, id string, rec *VMRecord
 	}); err != nil {
 		return err
 	}
-	return b.finishVMTeardown(ctx, id, leaseID, cl, teardown)
+	return b.finishVMTeardown(ctx, id, leaseID, cl)
 }
 
 // finishVMTeardown runs the slow cleanup outside any transaction, then the
 // fenced finalize that deletes record, name and tombstone together.
-func (b *Backend) finishVMTeardown(ctx context.Context, id, leaseID string, cl vmCleanup, teardown NetTeardown) error {
-	if teardown != nil {
-		if err := teardown(ctx, id); err != nil {
-			return fmt.Errorf("vm %s network teardown (tombstone kept, retry or gc resumes): %w", id, err)
-		}
+func (b *Backend) finishVMTeardown(ctx context.Context, id, leaseID string, cl vmCleanup) error {
+	if err := b.cleanupNetwork(ctx, id); err != nil {
+		return fmt.Errorf("vm %s network teardown (tombstone kept, retry or gc resumes): %w", id, err)
 	}
 	if err := RemoveVMDirs(cl.RunDir, cl.LogDir); err != nil {
 		return fmt.Errorf("cleanup VM dirs (tombstone kept, retry or gc resumes): %w", err)
@@ -101,7 +95,7 @@ func (b *Backend) finishVMTeardown(ctx context.Context, id, leaseID string, cl v
 // recoverVMTombstone drives id's tombstone to completion under the held ops
 // lock: leased rolls back (record stays live), deleting rolls forward from
 // the payload. done reports the entity was finalized (record gone).
-func (b *Backend) recoverVMTombstone(ctx context.Context, id string, teardown NetTeardown) (done bool, err error) { //nolint:unparam // done is asserted by the protocol gates
+func (b *Backend) recoverVMTombstone(ctx context.Context, id string) (done bool, err error) { //nolint:unparam // done is asserted by the protocol gates
 	ts := b.tombstones()
 	var (
 		rec     *tombstone.Record
@@ -121,19 +115,11 @@ func (b *Backend) recoverVMTombstone(ctx context.Context, id string, teardown Ne
 	if err := json.Unmarshal(rec.Payload.Cleanup, &cl); err != nil {
 		return false, fmt.Errorf("tombstone %s payload: %w", id, err)
 	}
-	if err := b.finishVMTeardown(ctx, id, leaseID, cl, teardown); err != nil {
+	if err := b.finishVMTeardown(ctx, id, leaseID, cl); err != nil {
 		return false, err
 	}
 	log.WithFunc(b.Typ+".recoverVMTombstone").Warnf(ctx, "rolled forward interrupted delete of VM %s", id)
 	return true, nil
-}
-
-// EntryGuard enforces the entrypoint discipline under a held ops lock:
-// roll a leased tombstone back in place; drive a deleting one to completion —
-// including the injected network cleanup — and refuse the operation.
-func (b *Backend) EntryGuard(ctx context.Context, id string) error {
-	_, err := b.entryGuard(ctx, id)
-	return err
 }
 
 // EntryGuardLoad is EntryGuard returning the VM's record from the guard's own
@@ -162,7 +148,7 @@ func (b *Backend) entryGuard(ctx context.Context, id string) (*VMRecord, error) 
 	if !errors.Is(err, ErrTombstoned) {
 		return rec, err
 	}
-	if _, rerr := b.recoverVMTombstone(ctx, id, b.NetCleanup); rerr != nil {
+	if _, rerr := b.recoverVMTombstone(ctx, id); rerr != nil {
 		return nil, fmt.Errorf("vm %s: recover interrupted delete: %w", id, rerr)
 	}
 	return nil, fmt.Errorf("vm %s was partially deleted; recovery finished the removal: %w", id, ErrNotFound)

--- a/hypervisor/teardown_test.go
+++ b/hypervisor/teardown_test.go
@@ -39,11 +39,11 @@ func TestDeleteProtocolFullRun(t *testing.T) {
 	rec := seedProtoVM(t, b, "vmproto1")
 
 	var tornDown []string
-	teardown := func(_ context.Context, id string) error {
+	b.SetNetwork(stubNetwork{cleanup: func(_ context.Context, id string) error {
 		tornDown = append(tornDown, id)
 		return nil
-	}
-	if err := b.deleteVMProtocol(ctx, "vmproto1", rec, teardown); err != nil {
+	}})
+	if err := b.deleteVMProtocol(ctx, "vmproto1", rec); err != nil {
 		t.Fatalf("protocol: %v", err)
 	}
 	if len(tornDown) != 1 || tornDown[0] != "vmproto1" {
@@ -74,14 +74,16 @@ func TestDeleteProtocolTeardownFailureKeepsTombstoneThenConverges(t *testing.T) 
 
 	boom := errors.New("cni down")
 	failing := func(context.Context, string) error { return boom }
-	if err := b.deleteVMProtocol(ctx, "vmproto2", rec, failing); !errors.Is(err, boom) {
+	b.SetNetwork(stubNetwork{cleanup: failing})
+	if err := b.deleteVMProtocol(ctx, "vmproto2", rec); !errors.Is(err, boom) {
 		t.Fatalf("want teardown failure surfaced, got %v", err)
 	}
 	// Record stays live over a deleting tombstone; the retry rolls forward.
 	if _, err := b.LoadRecord(ctx, "vmproto2"); err != nil {
 		t.Fatalf("record must stay live through deleting: %v", err)
 	}
-	done, err := b.recoverVMTombstone(ctx, "vmproto2", nil)
+	b.SetNetwork(stubNetwork{})
+	done, err := b.recoverVMTombstone(ctx, "vmproto2")
 	if err != nil || !done {
 		t.Fatalf("roll forward: done=%v err=%v", done, err)
 	}
@@ -108,7 +110,7 @@ func TestRecoverLeasedRollsBack(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	done, err := b.recoverVMTombstone(ctx, "vmproto3", nil)
+	done, err := b.recoverVMTombstone(ctx, "vmproto3")
 	if err != nil || done {
 		t.Fatalf("leased must roll back, not finalize: done=%v err=%v", done, err)
 	}
@@ -144,7 +146,7 @@ func TestTombstoneFencingABA(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Worker B recovers under a NEW lease and finalizes.
-	done, err := b.recoverVMTombstone(ctx, "vmproto4", nil)
+	done, err := b.recoverVMTombstone(ctx, "vmproto4")
 	if err != nil || !done {
 		t.Fatalf("recover: done=%v err=%v", done, err)
 	}
@@ -174,7 +176,7 @@ func TestEntryGuardDisciplines(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.EntryGuard(ctx, "vmproto5"); err != nil {
+	if err := entryGuardOnly(ctx, b, "vmproto5"); err != nil {
 		t.Fatalf("leased guard must roll back and proceed: %v", err)
 	}
 
@@ -191,7 +193,7 @@ func TestEntryGuardDisciplines(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	err = b.EntryGuard(ctx, "vmproto5")
+	err = entryGuardOnly(ctx, b, "vmproto5")
 	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("deleting guard must refuse after recovery: %v", err)
 	}
@@ -257,10 +259,10 @@ func TestLiveHolderKeepsLease(t *testing.T) {
 func TestPrepareStartRefusesMidDeleting(t *testing.T) {
 	b, _ := newMeteringTestBackend(t)
 	var netTorn []string
-	b.NetCleanup = func(_ context.Context, id string) error {
+	b.SetNetwork(stubNetwork{cleanup: func(_ context.Context, id string) error {
 		netTorn = append(netTorn, id)
 		return nil
-	}
+	}})
 	ctx := t.Context()
 	rec := seedProtoVM(t, b, "vmentry1")
 	ts := b.tombstones()
@@ -305,4 +307,38 @@ func TestPrepareStartRefusesMidDeleting(t *testing.T) {
 	if len(netTorn) != 1 || netTorn[0] != "vmentry1" {
 		t.Fatalf("entry-driven recovery skipped the injected network cleanup: %v", netTorn)
 	}
+}
+
+// stubNetwork stands in for the injected host-networking seam; unset hooks are no-ops.
+type stubNetwork struct {
+	recover func(context.Context, *types.VM) error
+	quiesce func(context.Context, *types.VM) error
+	cleanup func(context.Context, string) error
+}
+
+func (s stubNetwork) Recover(ctx context.Context, vm *types.VM) error {
+	if s.recover == nil {
+		return nil
+	}
+	return s.recover(ctx, vm)
+}
+
+func (s stubNetwork) Quiesce(ctx context.Context, vm *types.VM) error {
+	if s.quiesce == nil {
+		return nil
+	}
+	return s.quiesce(ctx, vm)
+}
+
+func (s stubNetwork) Cleanup(ctx context.Context, vmID string) error {
+	if s.cleanup == nil {
+		return nil
+	}
+	return s.cleanup(ctx, vmID)
+}
+
+// entryGuardOnly exercises the entry guard the way an entrypoint does, discarding the record.
+func entryGuardOnly(ctx context.Context, b *Backend, id string) error {
+	_, err := b.entryGuard(ctx, id)
+	return err
 }

--- a/hypervisor/testdata/legacy-choreo-trace.json
+++ b/hypervisor/testdata/legacy-choreo-trace.json
@@ -22,7 +22,7 @@
     {
       "op": "finalize",
       "err_class": "nil",
-      "result": "{\"id\":\"VM1\",\"hypervisor\":\"test-hv\",\"state\":\"stopped\",\"config\":{\"cpu\":2,\"memory\":1073741824,\"storage\":10737418240,\"image\":\"img:1\",\"name\":\"alpha\"},\"pid\":0,\"first_booted\":false,\"created_at\":\"0001-01-01T00:00:00Z\",\"updated_at\":\"0001-01-01T00:00:00Z\",\"image_blob_ids\":{\"blobA\":{},\"blobB\":{}},\"run_dir\":\"/r2/VM1\",\"log_dir\":\"/l2/VM1\"}",
+      "result": "{\"id\":\"VM1\",\"hypervisor\":\"test-hv\",\"state\":\"stopped\",\"config\":{\"cpu\":2,\"memory\":1073741824,\"storage\":10737418240,\"image\":\"img:1\",\"name\":\"alpha\"},\"pid\":0,\"first_booted\":false,\"transition_generation\":1,\"last_transition_reason\":\"create\",\"last_transition_at\":\"2026-01-02T03:04:05Z\",\"created_at\":\"0001-01-01T00:00:00Z\",\"updated_at\":\"2026-01-02T03:04:05Z\",\"image_blob_ids\":{\"blobA\":{},\"blobB\":{}},\"run_dir\":\"/r2/VM1\",\"log_dir\":\"/l2/VM1\"}",
       "metering": [
         "vm.storage.start/boot"
       ]
@@ -40,12 +40,12 @@
     {
       "op": "resize",
       "err_class": "nil",
-      "result": "{\"id\":\"VM1\",\"hypervisor\":\"test-hv\",\"state\":\"stopped\",\"config\":{\"cpu\":4,\"memory\":1073741824,\"storage\":21474836480,\"image\":\"img:1\",\"name\":\"alpha\"},\"pid\":0,\"first_booted\":false,\"created_at\":\"0001-01-01T00:00:00Z\",\"updated_at\":\"0001-01-01T00:00:00Z\",\"image_blob_ids\":{\"blobA\":{},\"blobB\":{}},\"run_dir\":\"/r2/VM1\",\"log_dir\":\"/l2/VM1\"}"
+      "result": "{\"id\":\"VM1\",\"hypervisor\":\"test-hv\",\"state\":\"stopped\",\"config\":{\"cpu\":4,\"memory\":1073741824,\"storage\":21474836480,\"image\":\"img:1\",\"name\":\"alpha\"},\"pid\":0,\"first_booted\":false,\"transition_generation\":1,\"last_transition_reason\":\"create\",\"last_transition_at\":\"2026-01-02T03:04:05Z\",\"created_at\":\"0001-01-01T00:00:00Z\",\"updated_at\":\"2026-01-02T03:04:05Z\",\"image_blob_ids\":{\"blobA\":{},\"blobB\":{}},\"run_dir\":\"/r2/VM1\",\"log_dir\":\"/l2/VM1\"}"
     },
     {
       "op": "mark-started",
       "err_class": "nil",
-      "result": "{\"id\":\"VM1\",\"hypervisor\":\"test-hv\",\"state\":\"running\",\"config\":{\"cpu\":4,\"memory\":1073741824,\"storage\":21474836480,\"image\":\"img:1\",\"name\":\"alpha\"},\"pid\":0,\"first_booted\":true,\"transition_generation\":1,\"last_transition_reason\":\"boot\",\"last_transition_at\":\"2026-01-02T03:04:05Z\",\"created_at\":\"0001-01-01T00:00:00Z\",\"updated_at\":\"2026-01-02T03:04:05Z\",\"started_at\":\"2026-01-02T03:04:05Z\",\"image_blob_ids\":{\"blobA\":{},\"blobB\":{}},\"run_dir\":\"/r2/VM1\",\"log_dir\":\"/l2/VM1\"}",
+      "result": "{\"id\":\"VM1\",\"hypervisor\":\"test-hv\",\"state\":\"running\",\"config\":{\"cpu\":4,\"memory\":1073741824,\"storage\":21474836480,\"image\":\"img:1\",\"name\":\"alpha\"},\"pid\":0,\"first_booted\":true,\"transition_generation\":2,\"last_transition_reason\":\"boot\",\"last_transition_at\":\"2026-01-02T03:04:05Z\",\"created_at\":\"0001-01-01T00:00:00Z\",\"updated_at\":\"2026-01-02T03:04:05Z\",\"started_at\":\"2026-01-02T03:04:05Z\",\"image_blob_ids\":{\"blobA\":{},\"blobB\":{}},\"run_dir\":\"/r2/VM1\",\"log_dir\":\"/l2/VM1\"}",
       "metering": [
         "vm.compute.start/boot"
       ]
@@ -53,7 +53,7 @@
     {
       "op": "update-stopped",
       "err_class": "nil",
-      "result": "{\"id\":\"VM1\",\"hypervisor\":\"test-hv\",\"state\":\"stopped\",\"config\":{\"cpu\":4,\"memory\":1073741824,\"storage\":21474836480,\"image\":\"img:1\",\"name\":\"alpha\"},\"pid\":0,\"first_booted\":true,\"transition_generation\":2,\"last_transition_reason\":\"stop-user\",\"last_transition_at\":\"2026-01-02T03:04:05Z\",\"created_at\":\"0001-01-01T00:00:00Z\",\"updated_at\":\"2026-01-02T03:04:05Z\",\"started_at\":\"2026-01-02T03:04:05Z\",\"stopped_at\":\"2026-01-02T03:04:05Z\",\"image_blob_ids\":{\"blobA\":{},\"blobB\":{}},\"run_dir\":\"/r2/VM1\",\"log_dir\":\"/l2/VM1\"}",
+      "result": "{\"id\":\"VM1\",\"hypervisor\":\"test-hv\",\"state\":\"stopped\",\"config\":{\"cpu\":4,\"memory\":1073741824,\"storage\":21474836480,\"image\":\"img:1\",\"name\":\"alpha\"},\"pid\":0,\"first_booted\":true,\"transition_generation\":3,\"last_transition_reason\":\"stop-user\",\"last_transition_at\":\"2026-01-02T03:04:05Z\",\"created_at\":\"0001-01-01T00:00:00Z\",\"updated_at\":\"2026-01-02T03:04:05Z\",\"started_at\":\"2026-01-02T03:04:05Z\",\"stopped_at\":\"2026-01-02T03:04:05Z\",\"image_blob_ids\":{\"blobA\":{},\"blobB\":{}},\"run_dir\":\"/r2/VM1\",\"log_dir\":\"/l2/VM1\"}",
       "metering": [
         "vm.compute.stop/stop-user"
       ]

--- a/hypervisor/testdata/legacy-choreo-trace.json
+++ b/hypervisor/testdata/legacy-choreo-trace.json
@@ -45,7 +45,7 @@
     {
       "op": "mark-started",
       "err_class": "nil",
-      "result": "{\"id\":\"VM1\",\"hypervisor\":\"test-hv\",\"state\":\"running\",\"config\":{\"cpu\":4,\"memory\":1073741824,\"storage\":21474836480,\"image\":\"img:1\",\"name\":\"alpha\"},\"pid\":0,\"first_booted\":true,\"created_at\":\"0001-01-01T00:00:00Z\",\"updated_at\":\"2026-01-02T03:04:05Z\",\"started_at\":\"2026-01-02T03:04:05Z\",\"image_blob_ids\":{\"blobA\":{},\"blobB\":{}},\"run_dir\":\"/r2/VM1\",\"log_dir\":\"/l2/VM1\"}",
+      "result": "{\"id\":\"VM1\",\"hypervisor\":\"test-hv\",\"state\":\"running\",\"config\":{\"cpu\":4,\"memory\":1073741824,\"storage\":21474836480,\"image\":\"img:1\",\"name\":\"alpha\"},\"pid\":0,\"first_booted\":true,\"transition_generation\":1,\"last_transition_reason\":\"boot\",\"last_transition_at\":\"2026-01-02T03:04:05Z\",\"created_at\":\"0001-01-01T00:00:00Z\",\"updated_at\":\"2026-01-02T03:04:05Z\",\"started_at\":\"2026-01-02T03:04:05Z\",\"image_blob_ids\":{\"blobA\":{},\"blobB\":{}},\"run_dir\":\"/r2/VM1\",\"log_dir\":\"/l2/VM1\"}",
       "metering": [
         "vm.compute.start/boot"
       ]
@@ -53,7 +53,7 @@
     {
       "op": "update-stopped",
       "err_class": "nil",
-      "result": "{\"id\":\"VM1\",\"hypervisor\":\"test-hv\",\"state\":\"stopped\",\"config\":{\"cpu\":4,\"memory\":1073741824,\"storage\":21474836480,\"image\":\"img:1\",\"name\":\"alpha\"},\"pid\":0,\"first_booted\":true,\"created_at\":\"0001-01-01T00:00:00Z\",\"updated_at\":\"2026-01-02T03:04:05Z\",\"started_at\":\"2026-01-02T03:04:05Z\",\"stopped_at\":\"2026-01-02T03:04:05Z\",\"image_blob_ids\":{\"blobA\":{},\"blobB\":{}},\"run_dir\":\"/r2/VM1\",\"log_dir\":\"/l2/VM1\"}",
+      "result": "{\"id\":\"VM1\",\"hypervisor\":\"test-hv\",\"state\":\"stopped\",\"config\":{\"cpu\":4,\"memory\":1073741824,\"storage\":21474836480,\"image\":\"img:1\",\"name\":\"alpha\"},\"pid\":0,\"first_booted\":true,\"transition_generation\":2,\"last_transition_reason\":\"stop-user\",\"last_transition_at\":\"2026-01-02T03:04:05Z\",\"created_at\":\"0001-01-01T00:00:00Z\",\"updated_at\":\"2026-01-02T03:04:05Z\",\"started_at\":\"2026-01-02T03:04:05Z\",\"stopped_at\":\"2026-01-02T03:04:05Z\",\"image_blob_ids\":{\"blobA\":{},\"blobB\":{}},\"run_dir\":\"/r2/VM1\",\"log_dir\":\"/l2/VM1\"}",
       "metering": [
         "vm.compute.stop/stop-user"
       ]

--- a/meta/json/events.go
+++ b/meta/json/events.go
@@ -2,6 +2,8 @@ package json
 
 import (
 	"context"
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -51,7 +53,10 @@ func newNotifier(nss map[string]*nsState) (*notifier, error) {
 		dirs[filepath.Dir(st.def.FilePath)] = struct{}{}
 	}
 	for dir := range dirs {
-		if err := watcher.Add(dir); err != nil {
+		// A namespace whose owning backend has not run yet has no directory to
+		// watch; the safety poll still covers it and a later subscribe picks the
+		// watch up, so a missing dir must not disable the whole subscription.
+		if err := watcher.Add(dir); err != nil && !errors.Is(err, fs.ErrNotExist) {
 			_ = watcher.Close()
 			return nil, err
 		}

--- a/meta/json/events.go
+++ b/meta/json/events.go
@@ -53,9 +53,7 @@ func newNotifier(nss map[string]*nsState) (*notifier, error) {
 		dirs[filepath.Dir(st.def.FilePath)] = struct{}{}
 	}
 	for dir := range dirs {
-		// A namespace whose owning backend has not run yet has no directory to
-		// watch; the safety poll still covers it and a later subscribe picks the
-		// watch up, so a missing dir must not disable the whole subscription.
+		// A namespace whose backend has not run yet has no directory; the safety poll covers it, so a missing dir must not disable the subscription.
 		if err := watcher.Add(dir); err != nil && !errors.Is(err, fs.ErrNotExist) {
 			_ = watcher.Close()
 			return nil, err

--- a/network/cni/cni.go
+++ b/network/cni/cni.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"maps"
 	"os"
 	"slices"
@@ -201,7 +202,14 @@ func (c *CNI) setLinkState(ctx context.Context, vmID string, up bool) error {
 	for _, rec := range records {
 		ifNames = append(ifNames, rec.IfName)
 	}
-	return setLinkStateFn(netnsPath(vmID), ifNames, up)
+	nsPath := netnsPath(vmID)
+	// A host reboot wipes every netns while the records survive; with no netns
+	// there is no plumbing left to quiesce, and failing here would leave a stop's
+	// pending work retrying for the rest of the daemon's life.
+	if _, err := statNetnsFn(nsPath); errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	return setLinkStateFn(nsPath, ifNames, up)
 }
 
 // confListByName resolves a conflist by name; empty name returns the default (first alphabetically).

--- a/network/cni/cni.go
+++ b/network/cni/cni.go
@@ -203,9 +203,7 @@ func (c *CNI) setLinkState(ctx context.Context, vmID string, up bool) error {
 		ifNames = append(ifNames, rec.IfName)
 	}
 	nsPath := netnsPath(vmID)
-	// A host reboot wipes every netns while the records survive; with no netns
-	// there is no plumbing left to quiesce, and failing here would leave a stop's
-	// pending work retrying for the rest of the daemon's life.
+	// A host reboot wipes netns but not records; with no netns there is nothing left to quiesce, and failing would retry forever.
 	if _, err := statNetnsFn(nsPath); errors.Is(err, fs.ErrNotExist) {
 		return nil
 	}

--- a/network/cni/cni_test.go
+++ b/network/cni/cni_test.go
@@ -3,6 +3,7 @@ package cni
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
@@ -305,6 +306,27 @@ func TestAddFailsClosedOnStaleReclaim(t *testing.T) {
 	}
 }
 
+func TestQuiesceSkipsMissingNetns(t *testing.T) {
+	c, _ := newTestCNIWithStore(t)
+	called := false
+	origSet := setLinkStateFn
+	setLinkStateFn = func(string, []string, bool) error { called = true; return nil }
+	origStat := statNetnsFn
+	statNetnsFn = func(string) (os.FileInfo, error) { return nil, fs.ErrNotExist }
+	t.Cleanup(func() { setLinkStateFn, statNetnsFn = origSet, origStat })
+
+	seedRecords(t, c, "vm1", "eth0")
+
+	// A host reboot wipes every netns while the records survive; with no plumbing
+	// left, a stop's pending quiesce must settle instead of retrying forever.
+	if err := c.Quiesce(t.Context(), "vm1"); err != nil {
+		t.Fatalf("Quiesce with a missing netns: %v", err)
+	}
+	if called {
+		t.Error("tried to enter a netns that no longer exists")
+	}
+}
+
 func TestQuiesceUnquiesceTogglesEveryNIC(t *testing.T) {
 	c, _ := newTestCNIWithStore(t)
 	var gotNS string
@@ -317,6 +339,9 @@ func TestQuiesceUnquiesceTogglesEveryNIC(t *testing.T) {
 		return nil
 	}
 	t.Cleanup(func() { setLinkStateFn = origSet })
+	origStat := statNetnsFn
+	statNetnsFn = func(string) (os.FileInfo, error) { return nil, nil }
+	t.Cleanup(func() { statNetnsFn = origStat })
 
 	ctx := t.Context()
 	seedRecords(t, c, "vm1", "eth0", "eth1")

--- a/types/vm.go
+++ b/types/vm.go
@@ -12,6 +12,13 @@ const (
 	VMStateRunning  VMState = "running"  // CH process alive, guest is up
 	VMStateStopped  VMState = "stopped"  // CH process has exited cleanly
 	VMStateError    VMState = "error"    // start, stop, or restore failed
+
+	TransitionBoot           TransitionReason = "boot"
+	TransitionRestart        TransitionReason = "restart"
+	TransitionRestore        TransitionReason = "restore"
+	TransitionStopUser       TransitionReason = "stop-user"
+	TransitionError          TransitionReason = "error"
+	TransitionUnexpectedExit TransitionReason = "unexpected-exit" // any exit outside a cocoon stop; an adopted process cannot report its cause
 )
 
 var (
@@ -24,6 +31,9 @@ var (
 
 // VMState represents the lifecycle state of a VM.
 type VMState string
+
+// TransitionReason annotates why a VM last changed state.
+type TransitionReason string
 
 // VMConfig describes the resources requested for a new VM.
 type VMConfig struct {
@@ -97,6 +107,11 @@ type VM struct {
 
 	// SnapshotIDs tracks snapshots created from this VM; populated by toVM() from VMRecord.SnapshotIDs.
 	SnapshotIDs map[string]struct{} `json:"snapshot_ids,omitempty"`
+
+	// TransitionGeneration increments once per committed state transition, so a consumer that missed events can tell a transition it has not handled from one it has.
+	TransitionGeneration uint64           `json:"transition_generation,omitempty"`
+	LastTransitionReason TransitionReason `json:"last_transition_reason,omitempty"`
+	LastTransitionAt     *time.Time       `json:"last_transition_at,omitempty"`
 
 	CreatedAt time.Time  `json:"created_at"`
 	UpdatedAt time.Time  `json:"updated_at"`

--- a/types/vm.go
+++ b/types/vm.go
@@ -13,6 +13,7 @@ const (
 	VMStateStopped  VMState = "stopped"  // CH process has exited cleanly
 	VMStateError    VMState = "error"    // start, stop, or restore failed
 
+	TransitionCreate         TransitionReason = "create"
 	TransitionBoot           TransitionReason = "boot"
 	TransitionRestart        TransitionReason = "restart"
 	TransitionClone          TransitionReason = "clone"

--- a/types/vm.go
+++ b/types/vm.go
@@ -110,7 +110,7 @@ type VM struct {
 	// SnapshotIDs tracks snapshots created from this VM; populated by toVM() from VMRecord.SnapshotIDs.
 	SnapshotIDs map[string]struct{} `json:"snapshot_ids,omitempty"`
 
-	// TransitionGeneration increments once per committed state transition, so a consumer that missed events can tell a transition it has not handled from one it has.
+	// TransitionGeneration increments once per committed transition, letting a consumer spot transitions it missed.
 	TransitionGeneration uint64           `json:"transition_generation,omitempty"`
 	LastTransitionReason TransitionReason `json:"last_transition_reason,omitempty"`
 	LastTransitionAt     *time.Time       `json:"last_transition_at,omitempty"`

--- a/types/vm.go
+++ b/types/vm.go
@@ -15,6 +15,7 @@ const (
 
 	TransitionBoot           TransitionReason = "boot"
 	TransitionRestart        TransitionReason = "restart"
+	TransitionClone          TransitionReason = "clone"
 	TransitionRestore        TransitionReason = "restore"
 	TransitionStopUser       TransitionReason = "stop-user"
 	TransitionError          TransitionReason = "error"

--- a/utils/pidfd_linux.go
+++ b/utils/pidfd_linux.go
@@ -46,3 +46,13 @@ func terminateWithPidfd(ctx context.Context, pid int, binaryName, expectArg stri
 	}
 	return true, waitDead(ctx, pid, killWaitTimeout)
 }
+
+// OpenPidfd returns a pidfd for pid; the fd becomes readable once the process exits.
+func OpenPidfd(pid int) (int, error) { return unix.PidfdOpen(pid, 0) }
+
+// CloseFD closes a raw descriptor, ignoring a zero or negative one.
+func CloseFD(fd int) {
+	if fd > 0 {
+		_ = unix.Close(fd)
+	}
+}

--- a/utils/pidfd_other.go
+++ b/utils/pidfd_other.go
@@ -4,9 +4,18 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"time"
 )
+
+var errPidfdUnsupported = errors.New("pidfd is unsupported on this OS")
 
 func terminateWithPidfd(_ context.Context, _ int, _, _ string, _ time.Duration) (bool, error) {
 	return false, nil
 }
+
+// OpenPidfd has no counterpart outside Linux.
+func OpenPidfd(int) (int, error) { return 0, errPidfdUnsupported }
+
+// CloseFD is a no-op where no descriptor is ever opened.
+func CloseFD(int) {}

--- a/utils/procref.go
+++ b/utils/procref.go
@@ -9,9 +9,6 @@ type ProcRef struct {
 	Start uint64
 }
 
-// Valid reports whether the ref names an observed process.
-func (p ProcRef) Valid() bool { return p.PID > 0 }
-
 // ProcRefOf captures pid's current generation; where the start time is
 // unreadable the pid alone identifies the process and reuse is undetectable.
 func ProcRefOf(pid int) (ProcRef, error) {

--- a/utils/procref.go
+++ b/utils/procref.go
@@ -1,0 +1,26 @@
+package utils
+
+import "fmt"
+
+// ProcRef identifies one process generation: a pid plus its start time, so a
+// recycled pid reads as a different process rather than the original one.
+type ProcRef struct {
+	PID   int
+	Start uint64
+}
+
+// Valid reports whether the ref names an observed process.
+func (p ProcRef) Valid() bool { return p.PID > 0 }
+
+// ProcRefOf captures pid's current generation; where the start time is
+// unreadable the pid alone identifies the process and reuse is undetectable.
+func ProcRefOf(pid int) (ProcRef, error) {
+	if pid <= 0 {
+		return ProcRef{}, fmt.Errorf("invalid pid %d", pid)
+	}
+	start, err := procStartTime(pid)
+	if err != nil {
+		return ProcRef{}, err
+	}
+	return ProcRef{PID: pid, Start: start}, nil
+}

--- a/utils/procref.go
+++ b/utils/procref.go
@@ -1,20 +1,13 @@
 package utils
 
-import "fmt"
-
-// ProcRef identifies one process generation: a pid plus its start time, so a
-// recycled pid reads as a different process rather than the original one.
+// ProcRef is one process generation: pid plus start time, so a recycled pid reads as a different process.
 type ProcRef struct {
 	PID   int
 	Start uint64
 }
 
-// ProcRefOf captures pid's current generation; where the start time is
-// unreadable the pid alone identifies the process and reuse is undetectable.
+// ProcRefOf captures pid's current generation.
 func ProcRefOf(pid int) (ProcRef, error) {
-	if pid <= 0 {
-		return ProcRef{}, fmt.Errorf("invalid pid %d", pid)
-	}
 	start, err := procStartTime(pid)
 	if err != nil {
 		return ProcRef{}, err

--- a/utils/procref_linux.go
+++ b/utils/procref_linux.go
@@ -12,8 +12,7 @@ import (
 // startTimeField is starttime's 0-based index among the stat fields that follow comm's closing paren.
 const startTimeField = 19
 
-// procStartTime reads pid's start time from /proc/<pid>/stat. Parsing resumes
-// after the last ')' because comm is unquoted and may itself contain parens.
+// procStartTime reads /proc/<pid>/stat; parsing resumes after the last ')' because comm may itself contain parens.
 func procStartTime(pid int) (uint64, error) {
 	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid)) //nolint:gosec // internal runtime path
 	if err != nil {

--- a/utils/procref_linux.go
+++ b/utils/procref_linux.go
@@ -1,0 +1,35 @@
+//go:build linux
+
+package utils
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// startTimeField is starttime's 0-based index among the stat fields that follow comm's closing paren.
+const startTimeField = 19
+
+// procStartTime reads pid's start time from /proc/<pid>/stat. Parsing resumes
+// after the last ')' because comm is unquoted and may itself contain parens.
+func procStartTime(pid int) (uint64, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid)) //nolint:gosec // internal runtime path
+	if err != nil {
+		return 0, err
+	}
+	end := strings.LastIndexByte(string(data), ')')
+	if end < 0 {
+		return 0, fmt.Errorf("parse /proc/%d/stat: no comm terminator", pid)
+	}
+	fields := strings.Fields(string(data)[end+1:])
+	if len(fields) <= startTimeField {
+		return 0, fmt.Errorf("parse /proc/%d/stat: got %d fields after comm", pid, len(fields))
+	}
+	start, err := strconv.ParseUint(fields[startTimeField], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse /proc/%d/stat starttime: %w", pid, err)
+	}
+	return start, nil
+}

--- a/utils/procref_other.go
+++ b/utils/procref_other.go
@@ -1,0 +1,14 @@
+//go:build !linux
+
+package utils
+
+import "fmt"
+
+// procStartTime has no portable source outside Linux; a live pid degrades to
+// pid-only identity, which cannot detect pid reuse.
+func procStartTime(pid int) (uint64, error) {
+	if !IsProcessAlive(pid) {
+		return 0, fmt.Errorf("process %d is not alive", pid)
+	}
+	return 0, nil
+}

--- a/utils/procref_other.go
+++ b/utils/procref_other.go
@@ -4,8 +4,7 @@ package utils
 
 import "fmt"
 
-// procStartTime has no portable source outside Linux; a live pid degrades to
-// pid-only identity, which cannot detect pid reuse.
+// procStartTime has no portable source outside Linux; identity degrades to pid-only.
 func procStartTime(pid int) (uint64, error) {
 	if !IsProcessAlive(pid) {
 		return 0, fmt.Errorf("process %d is not alive", pid)

--- a/utils/procref_test.go
+++ b/utils/procref_test.go
@@ -11,7 +11,7 @@ func TestProcRefOfSelfIsStable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProcRefOf: %v", err)
 	}
-	if first.PID != pid || !first.Valid() {
+	if first.PID != pid {
 		t.Fatalf("got %+v, want a valid ref for pid %d", first, pid)
 	}
 	second, err := ProcRefOf(pid)
@@ -28,11 +28,5 @@ func TestProcRefOfRejectsInvalidPID(t *testing.T) {
 		if ref, err := ProcRefOf(pid); err == nil {
 			t.Errorf("pid %d: got %+v, want an error", pid, ref)
 		}
-	}
-}
-
-func TestProcRefZeroValueIsNotValid(t *testing.T) {
-	if (ProcRef{}).Valid() {
-		t.Error("the zero ProcRef reported valid")
 	}
 }

--- a/utils/procref_test.go
+++ b/utils/procref_test.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"os"
+	"testing"
+)
+
+func TestProcRefOfSelfIsStable(t *testing.T) {
+	pid := os.Getpid()
+	first, err := ProcRefOf(pid)
+	if err != nil {
+		t.Fatalf("ProcRefOf: %v", err)
+	}
+	if first.PID != pid || !first.Valid() {
+		t.Fatalf("got %+v, want a valid ref for pid %d", first, pid)
+	}
+	second, err := ProcRefOf(pid)
+	if err != nil {
+		t.Fatalf("ProcRefOf again: %v", err)
+	}
+	if first != second {
+		t.Errorf("got %+v then %+v, want one generation to read identically", first, second)
+	}
+}
+
+func TestProcRefOfRejectsInvalidPID(t *testing.T) {
+	for _, pid := range []int{0, -1} {
+		if ref, err := ProcRefOf(pid); err == nil {
+			t.Errorf("pid %d: got %+v, want an error", pid, ref)
+		}
+	}
+}
+
+func TestProcRefZeroValueIsNotValid(t *testing.T) {
+	if (ProcRef{}).Valid() {
+		t.Error("the zero ProcRef reported valid")
+	}
+}


### PR DESCRIPTION
Implements #152 P0 + P1: `cocoon daemon`, an optional resident supervisor for VMs the one-shot CLI created.

Every CLI verb still works with no daemon running. When one is running it adopts
the live VMM processes, notices exits as they happen, and converges metadata and
host networking instead of waiting for the next command to heal them.

## What it fixes

A VMM that exits outside `cocoon vm stop` used to leave work undone until the
next CLI touch: the tc redirect on its idle TAP kept storming softirqs (the
condition #130 fixed for the normal stop path), the compute interval stayed open,
and the record still read `running`.

## How it works

- **Exit detection** is `pidfd` + `epoll`, so the normal path costs no polling.
  The reconcile ticker is the correctness floor for anything the watcher missed,
  including exits while the daemon was down.
- **Two fences.** Process identity is `pid` + `/proc/<pid>/stat` start time, so
  pid reuse reads as a different generation. Every committed state write stamps a
  `transition_generation`, so an exit observed before a restart can neither date
  nor re-label the newer transition.
- **`quiesce_pending`** rides the stop transition's durable commit and is cleared
  by a relaxed, generation-fenced write, so a crash between the transition and
  the network quiesce is retried rather than lost.
- **Every mutation takes the same per-VM ops lock the CLI takes**, non-blocking:
  a busy lock defers the work to the next pass, so supervision never blocks a
  command and never interleaves with one.
- **Ownerless `creating` placeholders** are collected at once — create and clone
  hold the ops lock from prereserve through the final commit, so a free lock
  proves there is no owner — freeing the name instead of waiting the GC grace.
- **No auto-restart.** The daemon reports `unexpected-exit`; restart is policy
  and belongs to the consumer.

P1 adds a read-only HTTP/JSON API over `<run-dir>/cocoond.sock` (`0660` in a
`0750` dir): `/healthz`, `/v1/vms`, and `/v1/events` (SSE). The stream replays
nothing; a reconnecting client compares per-VM generations against the opening
snapshot to find what it missed.

## Changes outside the daemon

`recoverNetwork` / `quiesceNetwork` lived in the command layer, outside the lock
the hypervisor takes for start and stop. That left two windows open: a stop's
late quiesce could down plumbing a concurrent start had just brought up, and a
crashed VM's TAP kept its tc redirect because only the stop path quiesced at all.
Both now run through an injected `VMNetwork` seam inside `StartSequence`,
`StopOneLocked`, `HibernateSequence` and `restoreCore`. `cmd/vm` shed 177 prod
lines to that move; the seam replaced three hooks with two shapes and two nil
checks, so a missing hook is now a compile error rather than a silent no-op.

## Bugs found and fixed on the way

- **`vm rm --force` on a running VM emitted two `vm.compute.stop` for one
  `vm.compute.start`.** `deleteOneLocked` read the compute interval from the
  record copy loaded *before* the stop, and moving the force-stop out of the
  command layer put that stale read on the default path. Regression test fails
  without the fix (2 stops) and passes with it (1).
- The json meta engine's `Events` failed the whole subscription when any
  namespace directory did not exist yet, silently degrading the daemon to
  ticker-only reconciliation.
- CNI `Quiesce` entered the netns unconditionally. Once `quiesce_pending` made
  that failure durable, a host reboot (netns gone, records alive) would have had
  every VM retrying a doomed quiesce forever.
- Clone committed a running record without stamping the transition, so every
  cloned VM read generation 0 with an empty reason.

## Evidence

Gates: `go build` and `golangci-lint` clean on GOOS=linux and darwin;
`go test ./...` green including `-race` on `daemon/`.

Hardware, bare metal, isolated roots in a KVM container, re-taken after the
review round rather than carried forward:

| Round | Result |
|---|---|
| Acceptance CH+json | 33/33 — crash to `stopped` 25 ms, SSE 44 ms, ownerless placeholder collected in 55 ms with the name freed |
| FC+json / CH+sqlite / FC+sqlite | 18/18 — converged 28 / 32 / 45 ms |
| Linux unit tests | pass, including the four pidfd/epoll watcher tests that cannot run on darwin |

Performance — the risk worth measuring was whether a resident reader would stall
concurrent CLI commands, since the json engine's `View` takes a cross-process
namespace flock. It does not:

| Command | daemon off | daemon @5s | daemon @200ms |
|---|---|---|---|
| `vm list` | 2.9 ms | 2.9 ms | 2.9 ms |
| `vm inspect` | — | 3.9 ms | 4.0 ms |

Crash detection 28–31 ms over 5 rounds. Steady state with 10 VMs: 0.05% of one
core, 22 MiB RSS. The API over UDS (2.4 ms p50) is not meaningfully faster than
the CLI subprocess (2.8 ms) — both are dominated by process spawn, so the real
win for a consumer is the SSE stream, which spawns nothing.

Two failures chased down and proved pre-existing by A/B against the `master`
binary: a restart issued in the same instant as the kill fails its launch timeout
with no daemon running either (waiting for the converged transition, ~30 ms,
succeeds — now documented), and CH exiting instantly was another tenant on the
testbed holding hugepages while the container had no hugetlbfs mount.
