### PR TITLE
fc: never enable hugepages, they break hibernate/clone

### DIFF
--- a/docs/firecracker.md
+++ b/docs/firecracker.md
@@ -32,7 +32,7 @@ cocoon vm clone my-snap --name clone-vm
 | Memory balloon | Y | Y |
 | qcow2 storage | Y | N |
 | Interactive console | Y | Y |
-| HugePages | Y | Y |
+| HugePages | Y | N (would break snapshot restore) |
 | Boot time | ~200-500ms | ~125ms |
 | Memory overhead | ~10-20 MiB/VM | <5 MiB/VM |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ cocoon CLI ──► images: OCI (EROFS layers, direct boot) | cloudimg (qcow2, 
 - **DNS configuration** — custom DNS servers injected into VMs via kernel cmdline (OCI) or cloud-init network-config (cloudimg)
 - **Cloud-init metadata** — automatic NoCloud cidata FAT12 disk for cloudimg VMs (hostname, configurable user/password via `--user`/`--password`, multi-NIC Netplan v2 network-config); cidata is automatically skipped on subsequent boots
 - **User data disks** — `--data-disk` attaches additional virtio-blk disks per VM, with optional ext4 mkfs at create time, cloud-init `mounts:` auto-mount on cloudimg+CH (via `/dev/disk/by-id/virtio-<name>`), per-disk DirectIO override, and 1:1 inheritance through snapshot/clone/restore; `vm clone --data-disk` adds fresh disks to a clone and `vm disk attach/detach` hot-plugs existing raw files on a running VM (both CH only)
-- **Hugepages** — automatic detection of host hugepage configuration; VM memory backed by hugepages when available
+- **Hugepages** — automatic detection of host hugepage configuration; Cloud Hypervisor VM memory backed by hugepages when available (never used for Firecracker, whose snapshots cannot restore from hugetlbfs)
 - **Memory balloon** — 25% of memory returned via virtio-balloon (deflate-on-OOM, free-page reporting) when memory >= 256 MiB
 - **Graceful shutdown** — ACPI power-button for UEFI VMs with configurable timeout, fallback to SIGTERM → SIGKILL
 - **Interactive console** — `cocoon vm console` with bidirectional PTY relay, SSH-style escape sequences (`~.` disconnect, `~?` help), configurable escape character, SIGWINCH propagation

--- a/docs/vm.md
+++ b/docs/vm.md
@@ -31,7 +31,7 @@ States, shutdown behavior, cloud-init first boot, data disks, performance tuning
 
 ## Performance Tuning
 
-- **Hugepages**: automatically detected from `/proc/sys/vm/nr_hugepages`; when available, VM memory is backed by 2 MiB hugepages for reduced TLB pressure
+- **Hugepages** (Cloud Hypervisor only): automatically detected from `/proc/sys/vm/nr_hugepages`; when available, VM memory is backed by 2 MiB hugepages for reduced TLB pressure. Firecracker VMs never use hugepages: FC cannot restore a hugetlbfs-backed snapshot, which would break hibernate/clone
 - **Disk I/O**: multi-queue virtio-blk; readonly base disks keep host page cache (`direct=off`), while writable raw/qcow2 COW disks use O_DIRECT (`direct=on`) to avoid host cache buildup and guest flush storms
 - **Balloon**: 25% of memory auto-returned via virtio-balloon with deflate-on-OOM and free-page reporting (VMs with < 256 MiB memory skip balloon)
 - **Watchdog**: hardware watchdog enabled by default for automatic guest reset on hang

--- a/hypervisor/firecracker/api.go
+++ b/hypervisor/firecracker/api.go
@@ -21,17 +21,14 @@ const (
 	driveIDFmt = "drive_%d"
 	ifaceIDFmt = "eth%d"
 
-	hugePagesNone = "None"
-	hugePages2M   = "2M"
 	ioEngineAsync = "Async" // io_uring
 )
 
 // fcMachineConfig and the request types below follow Firecracker's pre-boot
 // config model: start empty, configure via PUT/PATCH, then InstanceStart.
 type fcMachineConfig struct {
-	VCPUCount  int    `json:"vcpu_count"`
-	MemSizeMiB int    `json:"mem_size_mib"`
-	HugePages  string `json:"huge_pages,omitempty"`
+	VCPUCount  int `json:"vcpu_count"`
+	MemSizeMiB int `json:"mem_size_mib"`
 }
 
 type fcBootSource struct {

--- a/hypervisor/firecracker/start.go
+++ b/hypervisor/firecracker/start.go
@@ -42,14 +42,10 @@ func (fc *Firecracker) startOne(ctx context.Context, id string) error {
 // configureVM sends pre-boot config via REST then InstanceStart.
 func (fc *Firecracker) configureVM(ctx context.Context, hc *http.Client, rec *hypervisor.VMRecord) error {
 	memMiB := int(rec.Config.Memory >> 20) //nolint:mnd
-	hugePages := hugePagesNone
-	if utils.DetectHugePages() {
-		hugePages = hugePages2M
-	}
+	// No hugepages: FC's File restore backend cannot map hugetlbfs-backed snapshots, which would break hibernate/clone (#155).
 	if err := putMachineConfig(ctx, hc, fcMachineConfig{
 		VCPUCount:  rec.Config.CPU,
 		MemSizeMiB: memMiB,
-		HugePages:  hugePages,
 	}); err != nil {
 		return fmt.Errorf("machine-config: %w", err)
 	}


### PR DESCRIPTION
## Summary

On any host with `vm.nr_hugepages > 0`, every FC `hibernate` → `clone` failed with an opaque `snapshot/load` 400: cocoon auto-enabled hugetlbfs-backed guest memory from host state, and FC's `File` restore backend cannot mmap a hugetlbfs-backed snapshot. The operator never opted in, and nothing in the failure pointed at hugepages.

## Fix

Drop the host-state auto-detection on the FC lane entirely: `huge_pages` is never set on the FC machine config (field and consts removed). CH is untouched — its eager-copy restore handles hugepages and its mmap/CoW modes already have an explicit guard. THP still applies to FC guests as usual.

Alternatives considered and rejected: a capture-time guard defends a state that can no longer be produced; switching FC restore to the `Uffd` backend means implementing an external page-fault handler for a TLB win nobody asked for.

## Verification

- `nr_hugepages=3072` (the exact breaking condition): `image import` → `vm run --fc` → `hibernate` → `vm clone` succeeds, clone `running` (previously: `Cannot restore hugetlbfs backed snapshot`)
- `go test -race ./...`: 33 packages ok
- `make lint`: 0 issues on linux and darwin
- LOC: net −7 prod lines

Fixes #155
