### PR TITLE
ch: default clones to the mmap restore fast path

### DIFF
--- a/cmd/vm/commands.go
+++ b/cmd/vm/commands.go
@@ -331,7 +331,7 @@ func addCloneFlags(cmd *cobra.Command) {
 	cmd.Flags().String("network", "", "CNI conflist name (empty = inherit from source VM)")
 	cmd.Flags().String("bridge", "", "use TAP-on-bridge instead of CNI (value is bridge device, e.g. cni0)")
 	cmd.Flags().Bool("no-direct-io", false, "disable O_DIRECT on writable disks (inherit from snapshot if not set)")
-	cmd.Flags().String("restore-mode", "", "memory restore mode: copy|ondemand|mmap (CH only; ondemand/mmap require the snapshot file to remain on disk; mmap needs a plain private-anon snapshot — no hugepages/shared)")
+	cmd.Flags().String("restore-mode", "", "memory restore mode: copy|ondemand|mmap (CH only; default mmap for plain private-anon snapshots, else copy; hugepages/shared degrade mmap to copy with a warning)")
 	cmd.Flags().Bool("pull", false, "auto-pull base image if not found locally (for cross-node clone)")
 	cmd.Flags().StringArray("data-disk", nil, "create and hot-add an extra data disk to the clone: size=20G[,name=...][,fstype=ext4|none]; repeatable (CH only)")
 	cmd.Flags().String("from-dir", "", "clone from a snapshot directory (must contain snapshot.json) instead of the local snapshot DB; mutually exclusive with positional SNAPSHOT")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -116,7 +116,7 @@ Applies to `cocoon vm clone`:
 | `--network` | empty (inherit)          | CNI conflist name (empty = inherit from source VM)       |
 | `--bridge`  | empty                    | TAP-on-bridge mode (value is bridge device); mutually exclusive with `--network` |
 | `--no-direct-io` | `false` (inherit)  | Disable O_DIRECT on writable disks (inherit from snapshot if not set) |
-| `--restore-mode` | `copy`           | Memory restore mode: `copy`, `ondemand` (UFFD) or `mmap` (CoW map, shares page cache across clones); CH only, non-copy modes require the snapshot file to remain on disk and a CH build with matching support — an older CH silently ignores the field and restores by copy |
+| `--restore-mode` | `mmap` for plain private-anon snapshots, else `copy` | Memory restore mode: `copy`, `ondemand` (UFFD) or `mmap` (CoW map, shares page cache across clones); CH only, non-copy modes require a CH build with matching support — an older CH silently ignores the field and restores by copy; hugepages/shared snapshots degrade `mmap` to `copy` with a warning |
 | `--pull`  | `false`              | Auto-pull base image if not found locally (for cross-node clone)      |
 | `--from-dir` | empty                | Clone from a snapshot directory (must contain `snapshot.json`); mutually exclusive with positional `SNAPSHOT` |
 | `--data-disk` | empty (repeatable)  | Create a fresh data disk for the clone and hot-add it after restore: `size=20G[,name=...][,fstype=ext4|none]` (CH only; names must not collide with disks inherited from the snapshot) |

--- a/hypervisor/cloudhypervisor/clone.go
+++ b/hypervisor/cloudhypervisor/clone.go
@@ -232,7 +232,7 @@ func (ch *CloudHypervisor) ensureCloneCidata(vmID string, vmCfg *types.VMConfig,
 	return storageConfigs, nil
 }
 
-// cloneRestoreMode defaults clones of plain private-anon snapshots to the mmap fast path (zero eager copy, page cache shared across sibling clones); explicit modes win. Safe against snapshot GC: the extracted memory file is mapped at restore time and the mapping keeps its inode alive.
+// cloneRestoreMode defaults clones of plain private-anon snapshots to mmap — the mapping vm.restore takes keeps the extracted file's inode alive past snapshot GC; explicit modes win.
 func cloneRestoreMode(ctx context.Context, mode string, mem chMemory) string {
 	if mode == "" && !mem.HugePages && !mem.Shared {
 		return restoreModeMmap

--- a/hypervisor/cloudhypervisor/clone.go
+++ b/hypervisor/cloudhypervisor/clone.go
@@ -44,7 +44,7 @@ func (ch *CloudHypervisor) cloneAfterExtract(ctx context.Context, vmID string, v
 		return nil, fmt.Errorf("parse CH config: %w", err)
 	}
 
-	vmCfg.RestoreMode = resolveRestoreMode(ctx, vmCfg.RestoreMode, chCfg.Memory)
+	vmCfg.RestoreMode = cloneRestoreMode(ctx, vmCfg.RestoreMode, chCfg.Memory)
 
 	meta, err := ch.conf.LoadAndValidateMeta(runDir)
 	if err != nil {
@@ -230,6 +230,14 @@ func (ch *CloudHypervisor) ensureCloneCidata(vmID string, vmCfg *types.VMConfig,
 		})
 	}
 	return storageConfigs, nil
+}
+
+// cloneRestoreMode defaults clones of plain private-anon snapshots to the mmap fast path (zero eager copy, page cache shared across sibling clones); explicit modes win. Safe against snapshot GC: the extracted memory file is mapped at restore time and the mapping keeps its inode alive.
+func cloneRestoreMode(ctx context.Context, mode string, mem chMemory) string {
+	if mode == "" && !mem.HugePages && !mem.Shared {
+		return restoreModeMmap
+	}
+	return resolveRestoreMode(ctx, mode, mem)
 }
 
 func parseCHConfig(path string) (*chVMConfig, error) {

--- a/hypervisor/cloudhypervisor/clone_test.go
+++ b/hypervisor/cloudhypervisor/clone_test.go
@@ -505,3 +505,26 @@ func TestRestoreAndResumeCloneHotplugsCidataByRole(t *testing.T) {
 		t.Fatalf("vm.add-disk paths = %v, want %v", added, want)
 	}
 }
+
+func TestCloneRestoreMode(t *testing.T) {
+	tests := []struct {
+		name string
+		mode string
+		mem  chMemory
+		want string
+	}{
+		{"default plain gets mmap", "", chMemory{}, "mmap"},
+		{"default hugepages stays copy", "", chMemory{HugePages: true}, ""},
+		{"default shared stays copy", "", chMemory{Shared: true}, ""},
+		{"explicit copy wins", "copy", chMemory{}, "copy"},
+		{"explicit ondemand wins", "ondemand", chMemory{}, "ondemand"},
+		{"explicit mmap on hugepages degrades", "mmap", chMemory{HugePages: true}, "copy"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cloneRestoreMode(t.Context(), tt.mode, tt.mem); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Second half of #157, stacked on #158 (retarget to master after it merges).

Clones of plain private-anon snapshots (no hugepages, no shared) now restore via mmap (CH `CopyOnWrite`) by default: zero eager memory copy, and since the memory-range files are hardlinked per clone, sibling clones of one golden share page cache. This targets the known burst-clone latency blowup — eager copy is ~6x slower single-shot and memory-bandwidth-bound at burst64.

- `cloneRestoreMode` picks mmap only when no explicit `--restore-mode` was given and the snapshot's captured memory config qualifies; explicit modes always win; hugepages/shared snapshots keep eager copy via `resolveRestoreMode`
- `vm restore` (hibernate wake) keeps its eager-copy default — one VM, not a burst
- Snapshot-GC safe: the mapping taken at `vm.restore` holds the file's inode for the VM's lifetime (hardlink in the clone's own run dir; the cross-fs symlink fallback is covered by the read lease held through restore)
- An older CH without `memory_restore_mode` support ignores the field and restores by copy — behavior unchanged from today on stock builds

Validation: `TestCloneRestoreMode` covers the selection matrix; full suite and dual-GOOS lint green. Hardware burst benchmarks pending (testbeds powered off) per the plan in #157.