### PR TITLE
perf: skip fsync on clone/restore COW copies

### DIFF
--- a/hypervisor/utils.go
+++ b/hypervisor/utils.go
@@ -383,7 +383,7 @@ func CloneSnapshotFiles(ctx context.Context, dstDir, srcDir string, classify fun
 		case SnapshotFileSkip:
 		}
 	}
-	return copyPairs(ctx, cowPairs, utils.Sync)
+	return copyPairs(ctx, cowPairs, utils.NoSync)
 }
 
 // CleanSnapshotFiles removes snapshot-specific files from runDir.


### PR DESCRIPTION
One-line change: `CloneSnapshotFiles` copies COW disks with `utils.NoSync` instead of `utils.Sync`, covering both backends' DirectClone and DirectRestore paths.

Why the fsync is not owed here:

- The copied COW is derived data — at clone completion it holds only snapshot content, fully reproducible from the durable snapshot; nothing unique exists until the guest writes.
- Both clone and restore end with a running guest. Any journaled guest filesystem issues a virtio-blk flush within seconds, which CH/FC implement as fdatasync on the disk file — flushing all of its dirty pages, including the copy's. The unprotected window is seconds and closes itself.
- A power cut inside that window costs one broken clone; `vm rm` + re-clone converges. Process crashes don't lose page cache at all.
- The stream paths (`CloneFromStream`, snapshot import via `ExtractTar`) never fsynced these files — the direct paths were paying for a durability level the system as a whole never had.
- The existing Sync also never fsynced the parent directory, so even the paid-for guarantee was partial (content-if-visible only).

Snapshot save and export keep `Sync`: snapshots are the durable artifacts, and export relies on data landing before its `snapshot.json` all-data-ready marker.

Expected effect: on reflink filesystems (FICLONE) the removed fsync was a metadata-only commit, so little change; on non-reflink hosts every direct clone/restore previously stalled on a full-COW writeback at the tail — that stall is gone. Benchmark numbers to follow with the #157 testbed round.