### PR TITLE
ch: default vm restore to the mmap fast path

### DIFF
--- a/cmd/vm/commands.go
+++ b/cmd/vm/commands.go
@@ -131,7 +131,7 @@ func Command(h Handler) *cobra.Command {
 		},
 		RunE: h.Restore,
 	}
-	restoreCmd.Flags().String("restore-mode", "", "memory restore mode: copy|ondemand|mmap (CH only; ondemand/mmap require the snapshot file to remain on disk; hugepages/shared snapshots degrade mmap to copy with a warning)")
+	restoreCmd.Flags().String("restore-mode", "", "memory restore mode: copy|ondemand|mmap (CH only; default mmap for plain private-anon snapshots, else copy; hugepages/shared degrade mmap to copy with a warning)")
 	restoreCmd.Flags().String("from-dir", "", "restore from a snapshot directory (must contain snapshot.json) instead of the local snapshot DB; mutually exclusive with positional SNAPSHOT")
 	restoreCmd.Flags().Bool("force", false, "skip the snapshot-belongs-to-VM check (only meaningful with --from-dir; risk of restoring to an unrelated lineage)")
 	cliutil.AddOutputFlag(restoreCmd)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -145,7 +145,7 @@ Applies to `cocoon vm restore`:
 
 | Flag          | Default | Description                                                                                            |
 | ------------- | ------- | ------------------------------------------------------------------------------------------------------ |
-| `--restore-mode` | `copy` | Memory restore mode: `copy`, `ondemand` (UFFD) or `mmap` (CoW map); CH only, non-copy modes require the snapshot file to remain on disk and a CH build with matching support — an older CH silently ignores the field and restores by copy; hugepages/shared snapshots degrade `mmap` to `copy` with a warning |
+| `--restore-mode` | `mmap` for plain private-anon snapshots, else `copy` | Memory restore mode: `copy`, `ondemand` (UFFD) or `mmap` (CoW map); CH only, non-copy modes require a CH build with matching support — an older CH silently ignores the field and restores by copy; hugepages/shared snapshots degrade `mmap` to `copy` with a warning |
 | `--from-dir`  | empty   | Restore from a snapshot directory (must contain `snapshot.json`); mutually exclusive with positional `SNAPSHOT` |
 | `--force`     | `false` | Skip the snapshot-belongs-to-VM check (only meaningful with `--from-dir`)                              |
 

--- a/hypervisor/cloudhypervisor/clone.go
+++ b/hypervisor/cloudhypervisor/clone.go
@@ -44,7 +44,7 @@ func (ch *CloudHypervisor) cloneAfterExtract(ctx context.Context, vmID string, v
 		return nil, fmt.Errorf("parse CH config: %w", err)
 	}
 
-	vmCfg.RestoreMode = cloneRestoreMode(ctx, vmCfg.RestoreMode, chCfg.Memory)
+	vmCfg.RestoreMode = resolveRestoreMode(ctx, vmCfg.RestoreMode, chCfg.Memory)
 
 	meta, err := ch.conf.LoadAndValidateMeta(runDir)
 	if err != nil {
@@ -230,14 +230,6 @@ func (ch *CloudHypervisor) ensureCloneCidata(vmID string, vmCfg *types.VMConfig,
 		})
 	}
 	return storageConfigs, nil
-}
-
-// cloneRestoreMode defaults clones of plain private-anon snapshots to mmap — the mapping vm.restore takes keeps the extracted file's inode alive past snapshot GC; explicit modes win.
-func cloneRestoreMode(ctx context.Context, mode string, mem chMemory) string {
-	if mode == "" && !mem.HugePages && !mem.Shared {
-		return restoreModeMmap
-	}
-	return resolveRestoreMode(ctx, mode, mem)
 }
 
 func parseCHConfig(path string) (*chVMConfig, error) {

--- a/hypervisor/cloudhypervisor/clone_test.go
+++ b/hypervisor/cloudhypervisor/clone_test.go
@@ -505,26 +505,3 @@ func TestRestoreAndResumeCloneHotplugsCidataByRole(t *testing.T) {
 		t.Fatalf("vm.add-disk paths = %v, want %v", added, want)
 	}
 }
-
-func TestCloneRestoreMode(t *testing.T) {
-	tests := []struct {
-		name string
-		mode string
-		mem  chMemory
-		want string
-	}{
-		{"default plain gets mmap", "", chMemory{}, "mmap"},
-		{"default hugepages stays copy", "", chMemory{HugePages: true}, ""},
-		{"default shared stays copy", "", chMemory{Shared: true}, ""},
-		{"explicit copy wins", "copy", chMemory{}, "copy"},
-		{"explicit ondemand wins", "ondemand", chMemory{}, "ondemand"},
-		{"explicit mmap on hugepages degrades", "mmap", chMemory{HugePages: true}, "copy"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := cloneRestoreMode(t.Context(), tt.mode, tt.mem); got != tt.want {
-				t.Errorf("got %q, want %q", got, tt.want)
-			}
-		})
-	}
-}

--- a/hypervisor/cloudhypervisor/restore.go
+++ b/hypervisor/cloudhypervisor/restore.go
@@ -1,6 +1,7 @@
 package cloudhypervisor
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"io"
@@ -113,10 +114,10 @@ func (ch *CloudHypervisor) restoreAfterExtract(ctx context.Context, vmID string,
 	return ch.FinalizeRestore(ctx, vmID, vmCfg, rec, pid)
 }
 
-// resolveRestoreMode downgrades an explicit mmap request on a hugepages/shared snapshot to eager copy with a warning; CH would downgrade silently.
+// resolveRestoreMode defaults plain private-anon snapshots to mmap — the mapping vm.restore takes keeps the staged file's inode alive past snapshot GC — and downgrades an explicit mmap on hugepages/shared to eager copy with a warning; CH would downgrade silently.
 func resolveRestoreMode(ctx context.Context, mode string, mem chMemory) string {
 	if !mem.HugePages && !mem.Shared {
-		return mode
+		return cmp.Or(mode, restoreModeMmap)
 	}
 	logger := log.WithFunc("cloudhypervisor.resolveRestoreMode")
 	switch mode {

--- a/hypervisor/cloudhypervisor/restore_test.go
+++ b/hypervisor/cloudhypervisor/restore_test.go
@@ -41,8 +41,12 @@ func TestResolveRestoreMode(t *testing.T) {
 		mem  chMemory
 		want string
 	}{
-		{"empty mode any mem", "", chMemory{HugePages: true, Shared: true}, ""},
+		{"default plain gets mmap", "", chMemory{}, "mmap"},
+		{"default hugepages stays copy", "", chMemory{HugePages: true}, ""},
+		{"default shared stays copy", "", chMemory{Shared: true}, ""},
+		{"explicit copy wins", "copy", chMemory{}, "copy"},
 		{"copy any mem", "copy", chMemory{HugePages: true}, "copy"},
+		{"explicit ondemand wins", "ondemand", chMemory{}, "ondemand"},
 		{"ondemand hugepages", "ondemand", chMemory{HugePages: true}, "ondemand"},
 		{"mmap plain", "mmap", chMemory{}, "mmap"},
 		{"mmap hugepages degrades to copy", "mmap", chMemory{HugePages: true}, "copy"},


### PR DESCRIPTION
Fixes #162.

#159 defaulted `vm clone` to the mmap restore fast path but left `vm restore` on eager copy, so the two verbs resolved the same unset `--restore-mode` differently. This folds the mmap default from the clone-only `cloneRestoreMode` wrapper into the shared `resolveRestoreMode`, then deletes the wrapper — clone, streamed restore, and direct restore now resolve identically through one seam:

- unset flag + plain private-anon snapshot memory → `mmap`
- hugepages/shared → eager copy (existing warning/debug paths unchanged)
- explicit `--restore-mode` always wins
- an older CH without CopyOnWrite support ignores the field and restores by copy, unchanged

Evidence (issue #162, bare metal 16c/60G, `small` 512M guest, N=5): eager restore 53–188 ms (median ~65) vs mmap 40–67 ms (median ~55); the eager outliers come from cold page cache. Snapshot deletion right after wake stays safe under mmap — restore stages its own run-dir copy of the memory file and the mapping keeps its inode alive; verified with 5 consecutive hibernate→mmap-restore→snapshot-rm cycles, guest healthy throughout.

Net −26 lines. `TestCloneRestoreMode` merged into `TestResolveRestoreMode` (10 cases, default/explicit × plain/hugepages/shared); restore's flag help and docs row aligned with clone's, dropping the stale "snapshot file must remain on disk" claim.

Gates: build darwin+linux, `go test ./...` green, dual-platform lint 0 issues.