### PR TITLE
meta: let each backend own its json namespace declaration

### DIFF
--- a/cmd/core/metastore.go
+++ b/cmd/core/metastore.go
@@ -43,14 +43,6 @@ var (
 		{Key: "names", Table: localfile.TableNames},
 		{Key: keyTombstones, Table: tombstone.TableName, Optional: true},
 	}}
-	netTables = metajson.TableCodec{Specs: []metajson.TableSpec{
-		{Key: "networks", Table: cni.TableRecords},
-		{Key: keyTombstones, Table: tombstone.TableName, Optional: true},
-	}}
-	imageTables = metajson.TableCodec{Specs: []metajson.TableSpec{
-		{Key: "images", Table: images.TableRecords},
-		{Key: keyTombstones, Table: tombstone.TableName, Optional: true},
-	}}
 )
 
 // MetaNamespaces lists every namespace with its tables — the engine-neutral
@@ -73,16 +65,13 @@ func MetaJSONNamespaces(conf *config.Config) []metajson.Namespace {
 	chCfg := cloudhypervisor.NewConfig(conf)
 	fcCfg := firecracker.NewConfig(conf)
 	snapCfg := localfile.NewConfig(conf)
-	cniCfg := cni.NewConfig(conf)
-	ociCfg := oci.NewConfig(conf.RootDir, 0)
-	cloudimgCfg := cloudimg.NewConfig(conf.RootDir, 0)
 	return []metajson.Namespace{
 		{Name: hypervisor.VMNamespaceName(string(config.HypervisorCloudHypervisor)), FilePath: chCfg.IndexFile(), LockPath: chCfg.IndexLock(), Codec: vmTables},
 		{Name: hypervisor.VMNamespaceName(string(config.HypervisorFirecracker)), FilePath: fcCfg.IndexFile(), LockPath: fcCfg.IndexLock(), Codec: vmTables},
 		{Name: localfile.NamespaceName, FilePath: snapCfg.IndexFile(), LockPath: snapCfg.IndexLock(), Codec: snapTables},
-		{Name: oci.NamespaceName, FilePath: ociCfg.IndexFile(), LockPath: ociCfg.IndexLock(), Codec: imageTables},
-		{Name: cloudimg.NamespaceName, FilePath: cloudimgCfg.IndexFile(), LockPath: cloudimgCfg.IndexLock(), Codec: imageTables},
-		{Name: cni.NamespaceName, FilePath: cniCfg.IndexFile(), LockPath: cniCfg.IndexLock(), Codec: netTables},
+		oci.NewConfig(conf.RootDir, 0).JSONNamespace(),
+		cloudimg.NewConfig(conf.RootDir, 0).JSONNamespace(),
+		cni.NewConfig(conf).JSONNamespace(),
 		{
 			Name:     metalog.NamespaceName,
 			FilePath: filepath.Join(conf.RootDir, meteringSubdir, "log.json"),

--- a/images/baseconfig.go
+++ b/images/baseconfig.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 
+	metajson "github.com/cocoonstack/cocoon/meta/json"
+	"github.com/cocoonstack/cocoon/meta/tombstone"
 	"github.com/cocoonstack/cocoon/utils"
 )
 
@@ -13,6 +15,7 @@ type BaseConfig struct {
 	RootDir string
 	Subdir  string
 	BlobExt string
+	Name    string
 }
 
 func (c *BaseConfig) BackendDir() string { return filepath.Join(c.RootDir, c.Subdir) }
@@ -27,6 +30,20 @@ func (c *BaseConfig) BlobLockPath(hex string) string {
 
 func (c *BaseConfig) IndexFile() string { return filepath.Join(c.DBDir(), "images.json") }
 func (c *BaseConfig) IndexLock() string { return filepath.Join(c.DBDir(), "images.lock") }
+
+// JSONNamespace is an image backend's json meta namespace; the codec is
+// shared by every image backend, so it lives here beside TableRecords.
+func (c *BaseConfig) JSONNamespace() metajson.Namespace {
+	return metajson.Namespace{
+		Name:     c.Name,
+		FilePath: c.IndexFile(),
+		LockPath: c.IndexLock(),
+		Codec: metajson.TableCodec{Specs: []metajson.TableSpec{
+			{Key: "images", Table: TableRecords},
+			{Key: tombstone.TableName, Table: tombstone.TableName, Optional: true},
+		}},
+	}
+}
 
 func (c *BaseConfig) BlobPath(hex string) string {
 	return filepath.Join(c.BlobsDir(), hex+c.BlobExt)

--- a/images/cloudimg/config.go
+++ b/images/cloudimg/config.go
@@ -21,7 +21,7 @@ type Config struct {
 
 func NewConfig(rootDir string, pullConns int) *Config {
 	return &Config{
-		BaseConfig: images.BaseConfig{RootDir: rootDir, Subdir: "cloudimg", BlobExt: ".qcow2"},
+		BaseConfig: images.BaseConfig{RootDir: rootDir, Subdir: "cloudimg", BlobExt: ".qcow2", Name: NamespaceName},
 		PullConns:  utils.OrDefault(pullConns, defaultPullConns),
 	}
 }

--- a/images/oci/config.go
+++ b/images/oci/config.go
@@ -18,7 +18,7 @@ type Config struct {
 
 func NewConfig(rootDir string, poolSize int) *Config {
 	return &Config{
-		BaseConfig: images.BaseConfig{RootDir: rootDir, Subdir: "oci", BlobExt: ".erofs"},
+		BaseConfig: images.BaseConfig{RootDir: rootDir, Subdir: "oci", BlobExt: ".erofs", Name: NamespaceName},
 		PoolSize:   utils.PoolSizeOrDefault(poolSize),
 	}
 }

--- a/network/cni/metans.go
+++ b/network/cni/metans.go
@@ -4,12 +4,27 @@ import (
 	"context"
 
 	"github.com/cocoonstack/cocoon/meta"
+	metajson "github.com/cocoonstack/cocoon/meta/json"
+	"github.com/cocoonstack/cocoon/meta/tombstone"
 )
 
 const (
 	NamespaceName = "networks"
 	TableRecords  = "records"
 )
+
+// JSONNamespace is the single source of truth for this backend's json meta layout.
+func (c *Config) JSONNamespace() metajson.Namespace {
+	return metajson.Namespace{
+		Name:     NamespaceName,
+		FilePath: c.IndexFile(),
+		LockPath: c.IndexLock(),
+		Codec: metajson.TableCodec{Specs: []metajson.TableSpec{
+			{Key: "networks", Table: TableRecords},
+			{Key: tombstone.TableName, Table: tombstone.TableName, Optional: true},
+		}},
+	}
+}
 
 // netTx is the CNI view of one meta transaction: a records-only namespace
 // with the vm_id secondary lookup served by scan.


### PR DESCRIPTION
The json meta namespace layout (name, index/lock paths, table codec) was declared inline in `cmd/core/metastore.go`. An out-of-tree reader of the same on-disk state (e.g. cocoon-macos, which opens `images.json`/`networks.json` directly) had no way to obtain that layout without importing the whole store-wiring tree (oci, firecracker, sqlite, containerregistry).

This moves the declaration into the backend that owns each namespace:

- `images.BaseConfig` gains `JSONNamespace()` — the image-namespace codec is shared by every image backend, so it lives here beside `TableRecords` it maps. `oci`/`cloudimg` carry their namespace name on the embedded `BaseConfig` and get the method by promotion.
- `network/cni` declares its own `(*Config).JSONNamespace()`.
- `cmd/core.MetaJSONNamespaces` composes those instead of inlining, and the now-dead `imageTables`/`netTables` codecs are deleted.

Scope: only the three backends read out-of-tree are moved. ch/fc use a distinct multi-table codec (`vmTables`) referenced once centrally, and localfile/metalog likewise — no external consumer, left inline. The sqlite-side `MetaNamespaces` stays centralized: it carries only engine-neutral table-name lists (no paths, no legacy field mapping) and doubles as the schema manifest for `cmd/meta/convert`.

Behavior is unchanged: verified the produced namespace set is field-identical to before (name, file/lock paths, codec specs) for every backend.

Gates: `go build`/`go test` on the affected packages, dual-platform `golangci-lint` (linux+darwin) clean on the changed files.