### PR TITLE
meta: default to sqlite with auto-resolution for existing roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Lightweight MicroVM engine with dual hypervisor backends: [Cloud Hypervisor](htt
 - **Windows guests** — UEFI + Hyper-V enlightenments via the cocoonstack CH/firmware forks
 - **Firecracker backend** — `--fc` for ~125ms boots and <5 MiB per-VM overhead (OCI images only)
 - **Daemon-optional architecture** — one hypervisor process per VM, every command standalone; `cocoon daemon` optionally adopts running VMs to converge crashes as they happen; modular lock-safe GC with snapshot LRU eviction
-- **Switchable metadata engine** — json files by default, opt-in sqlite (`meta_backend: sqlite`) for concurrent-create scale; crash-resumable offline conversion both ways (`cocoon meta convert`)
+- **Switchable metadata engine** — sqlite by default (fresh roots bootstrap themselves; flat performance at high VM counts), legacy json roots keep working as-is; crash-resumable offline conversion both ways (`cocoon meta convert`)
 
 ## Quick Start
 

--- a/cmd/core/init.go
+++ b/cmd/core/init.go
@@ -27,9 +27,18 @@ var hypervisorFactories = []hypervisorFactory{
 	{config.HypervisorFirecracker, wireHypervisor(firecracker.New)},
 }
 
+// hypervisorCtor builds a fully wired backend for one config.
+type hypervisorCtor func(context.Context, *config.Config) (hypervisor.Hypervisor, error)
+
 type hypervisorFactory struct {
 	typ  config.HypervisorType
-	ctor func(context.Context, *config.Config) (hypervisor.Hypervisor, error)
+	ctor hypervisorCtor
+}
+
+// networkedHypervisor is the constructor contract wireHypervisor adapts: a backend that accepts the network seam.
+type networkedHypervisor interface {
+	hypervisor.Hypervisor
+	SetNetwork(hypervisor.VMNetwork)
 }
 
 func InitImageBackends(ctx context.Context, conf *config.Config) ([]imagebackend.Images, error) {
@@ -149,10 +158,7 @@ func PinEnvelopeBlobs(ctx context.Context, conf *config.Config, blobIDs map[stri
 }
 
 // wireHypervisor builds a backend factory over the shared store and recorder.
-func wireHypervisor[H interface {
-	hypervisor.Hypervisor
-	SetNetwork(hypervisor.VMNetwork)
-}](newFn func(*config.Config, metering.Recorder, meta.Store) (H, error)) func(context.Context, *config.Config) (hypervisor.Hypervisor, error) {
+func wireHypervisor[H networkedHypervisor](newFn func(*config.Config, metering.Recorder, meta.Store) (H, error)) hypervisorCtor {
 	return func(ctx context.Context, c *config.Config) (hypervisor.Hypervisor, error) {
 		store, err := MetaStore(c)
 		if err != nil {

--- a/cmd/core/init.go
+++ b/cmd/core/init.go
@@ -27,25 +27,6 @@ var hypervisorFactories = []hypervisorFactory{
 	{config.HypervisorFirecracker, wireHypervisor(firecracker.New)},
 }
 
-// wireHypervisor builds a backend factory over the shared store and recorder.
-func wireHypervisor[H interface {
-	hypervisor.Hypervisor
-	SetNetwork(hypervisor.VMNetwork)
-}](newFn func(*config.Config, metering.Recorder, meta.Store) (H, error)) func(context.Context, *config.Config) (hypervisor.Hypervisor, error) {
-	return func(ctx context.Context, c *config.Config) (hypervisor.Hypervisor, error) {
-		store, err := MetaStore(c)
-		if err != nil {
-			return nil, err
-		}
-		h, err := newFn(c, MeteringRecorder(ctx, c), store)
-		if err != nil {
-			return nil, err
-		}
-		h.SetNetwork(NetworkSeam(c))
-		return h, nil
-	}
-}
-
 type hypervisorFactory struct {
 	typ  config.HypervisorType
 	ctor func(context.Context, *config.Config) (hypervisor.Hypervisor, error)
@@ -76,41 +57,6 @@ func InitImageBackendsForPull(ctx context.Context, conf *config.Config) (*oci.OC
 	ociStore.SetPinnedElsewhere(recheck)
 	cloudimgStore.SetPinnedElsewhere(recheck)
 	return ociStore, cloudimgStore, nil
-}
-
-// pinnedElsewhere unions VM and snapshot blob pins for image GC's under-lock recheck; backends build lazily, GC-path only.
-func pinnedElsewhere(conf *config.Config) func(context.Context) (map[string]struct{}, error) {
-	type pinner interface {
-		PinnedBlobIDs(context.Context) (map[string]struct{}, error)
-	}
-	return func(ctx context.Context) (map[string]struct{}, error) {
-		hypers, err := InitAllHypervisors(ctx, conf)
-		if err != nil {
-			return nil, err
-		}
-		snapBackend, err := InitSnapshot(ctx, conf)
-		if err != nil {
-			return nil, err
-		}
-		sources := make([]pinner, 0, len(hypers)+1)
-		for _, h := range hypers {
-			if p, ok := h.(pinner); ok {
-				sources = append(sources, p)
-			}
-		}
-		if p, ok := snapBackend.(pinner); ok {
-			sources = append(sources, p)
-		}
-		pins := map[string]struct{}{}
-		for _, s := range sources {
-			m, err := s.PinnedBlobIDs(ctx)
-			if err != nil {
-				return nil, err
-			}
-			maps.Copy(pins, m)
-		}
-		return pins, nil
-	}
 }
 
 func InitHypervisor(ctx context.Context, conf *config.Config) (hypervisor.Hypervisor, error) {
@@ -200,4 +146,58 @@ func PinEnvelopeBlobs(ctx context.Context, conf *config.Config, blobIDs map[stri
 		return nil, err
 	}
 	return func() { releaseOCI(); releaseCloudimg() }, nil
+}
+
+// wireHypervisor builds a backend factory over the shared store and recorder.
+func wireHypervisor[H interface {
+	hypervisor.Hypervisor
+	SetNetwork(hypervisor.VMNetwork)
+}](newFn func(*config.Config, metering.Recorder, meta.Store) (H, error)) func(context.Context, *config.Config) (hypervisor.Hypervisor, error) {
+	return func(ctx context.Context, c *config.Config) (hypervisor.Hypervisor, error) {
+		store, err := MetaStore(c)
+		if err != nil {
+			return nil, err
+		}
+		h, err := newFn(c, MeteringRecorder(ctx, c), store)
+		if err != nil {
+			return nil, err
+		}
+		h.SetNetwork(NetworkSeam(c))
+		return h, nil
+	}
+}
+
+// pinnedElsewhere unions VM and snapshot blob pins for image GC's under-lock recheck; backends build lazily, GC-path only.
+func pinnedElsewhere(conf *config.Config) func(context.Context) (map[string]struct{}, error) {
+	type pinner interface {
+		PinnedBlobIDs(context.Context) (map[string]struct{}, error)
+	}
+	return func(ctx context.Context) (map[string]struct{}, error) {
+		hypers, err := InitAllHypervisors(ctx, conf)
+		if err != nil {
+			return nil, err
+		}
+		snapBackend, err := InitSnapshot(ctx, conf)
+		if err != nil {
+			return nil, err
+		}
+		sources := make([]pinner, 0, len(hypers)+1)
+		for _, h := range hypers {
+			if p, ok := h.(pinner); ok {
+				sources = append(sources, p)
+			}
+		}
+		if p, ok := snapBackend.(pinner); ok {
+			sources = append(sources, p)
+		}
+		pins := map[string]struct{}{}
+		for _, s := range sources {
+			m, err := s.PinnedBlobIDs(ctx)
+			if err != nil {
+				return nil, err
+			}
+			maps.Copy(pins, m)
+		}
+		return pins, nil
+	}
 }

--- a/cmd/core/metastore.go
+++ b/cmd/core/metastore.go
@@ -169,10 +169,11 @@ func CloseMetaStore(ctx context.Context) {
 	}
 }
 
-// openSQLiteStore opens the sqlite engine, bootstrapping a completely fresh
-// root; a legacy json root never bootstraps — that would shadow its data.
+// openSQLiteStore opens the sqlite engine, bootstrapping a fresh root or
+// repairing a crashed bootstrap; a legacy json root never bootstraps — that
+// would shadow its data.
 func openSQLiteStore(ctx context.Context, conf *config.Config, dbPath string) (meta.Store, error) {
-	if !utils.FileExists(dbPath) && !LegacyJSONPresent(conf) {
+	if !LegacyJSONPresent(conf) {
 		if err := metasqlite.InitIfMissing(ctx, dbPath, MetaNamespaces()...); err != nil {
 			return nil, err
 		}

--- a/cmd/core/metastore.go
+++ b/cmd/core/metastore.go
@@ -102,13 +102,15 @@ func ResolveMetaBackend(conf *config.Config) string {
 	if utils.FileExists(MetaDBPath(conf)) {
 		return config.MetaBackendSQLite
 	}
-	if legacyJSONPresent(conf) {
+	if LegacyJSONPresent(conf) {
 		return config.MetaBackendJSON
 	}
 	return config.MetaBackendSQLite
 }
 
-func legacyJSONPresent(conf *config.Config) bool {
+// LegacyJSONPresent reports whether any json-engine namespace file exists
+// under the root — data a fresh sqlite store must never shadow.
+func LegacyJSONPresent(conf *config.Config) bool {
 	for _, ns := range MetaJSONNamespaces(conf) {
 		if utils.FileExists(ns.FilePath) {
 			return true
@@ -156,21 +158,6 @@ func MetaStore(conf *config.Config) (meta.Store, error) {
 	return metaStore, metaErr
 }
 
-// openSQLiteStore opens the sqlite engine, bootstrapping a completely fresh
-// root; a legacy json root never bootstraps — that would shadow its data.
-func openSQLiteStore(ctx context.Context, conf *config.Config, dbPath string) (meta.Store, error) {
-	if !utils.FileExists(dbPath) && !legacyJSONPresent(conf) {
-		if err := metasqlite.InitIfMissing(ctx, dbPath, MetaNamespaces()...); err != nil {
-			return nil, err
-		}
-	}
-	s, err := metasqlite.Open(dbPath, MetaNamespaces()...)
-	if err != nil {
-		return nil, err
-	}
-	return s, nil
-}
-
 // CloseMetaStore ends the store's unified lifecycle at command teardown
 // (design §10 P0); a process that never opened it is a no-op.
 func CloseMetaStore(ctx context.Context) {
@@ -180,4 +167,19 @@ func CloseMetaStore(ctx context.Context) {
 	if err := metaStore.Close(); err != nil {
 		log.WithFunc("core.CloseMetaStore").Warnf(ctx, "close meta store: %v", err)
 	}
+}
+
+// openSQLiteStore opens the sqlite engine, bootstrapping a completely fresh
+// root; a legacy json root never bootstraps — that would shadow its data.
+func openSQLiteStore(ctx context.Context, conf *config.Config, dbPath string) (meta.Store, error) {
+	if !utils.FileExists(dbPath) && !LegacyJSONPresent(conf) {
+		if err := metasqlite.InitIfMissing(ctx, dbPath, MetaNamespaces()...); err != nil {
+			return nil, err
+		}
+	}
+	s, err := metasqlite.Open(dbPath, MetaNamespaces()...)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
 }

--- a/cmd/core/metastore.go
+++ b/cmd/core/metastore.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/projecteru2/core/log"
 
@@ -21,9 +22,14 @@ import (
 	"github.com/cocoonstack/cocoon/metering/metalog"
 	"github.com/cocoonstack/cocoon/network/cni"
 	"github.com/cocoonstack/cocoon/snapshot/localfile"
+	"github.com/cocoonstack/cocoon/utils"
 )
 
-const keyTombstones = "tombstones"
+const (
+	keyTombstones = "tombstones"
+
+	metaBootstrapTimeout = 10 * time.Second
+)
 
 var (
 	metaOnce  sync.Once
@@ -86,26 +92,60 @@ func MetaDBPath(conf *config.Config) string {
 	return filepath.Join(conf.RootDir, "meta", metasqlite.DBFileName)
 }
 
+// ResolveMetaBackend returns the effective engine: an explicit setting wins,
+// then an existing store binds (meta.db → sqlite, legacy json files → json),
+// and a fresh root gets sqlite.
+func ResolveMetaBackend(conf *config.Config) string {
+	if conf.MetaBackend != "" {
+		return conf.MetaBackend
+	}
+	if utils.FileExists(MetaDBPath(conf)) {
+		return config.MetaBackendSQLite
+	}
+	if legacyJSONPresent(conf) {
+		return config.MetaBackendJSON
+	}
+	return config.MetaBackendSQLite
+}
+
+func legacyJSONPresent(conf *config.Config) bool {
+	for _, ns := range MetaJSONNamespaces(conf) {
+		if utils.FileExists(ns.FilePath) {
+			return true
+		}
+	}
+	return false
+}
+
 // MetaStore builds the process-wide meta store once — one store, every
 // namespace — and injects it into every backend (design §10 P0 boundary).
-// The engine follows conf.MetaBackend: json (default) or sqlite.
+// The engine follows ResolveMetaBackend; a fresh sqlite root bootstraps
+// itself.
 func MetaStore(conf *config.Config) (meta.Store, error) {
 	metaOnce.Do(func() {
+		// Bootstrap owns its context: the store outlives any single caller,
+		// and a canceled first caller must not poison the Once for everyone.
+		ctx, cancel := context.WithTimeout(context.Background(), metaBootstrapTimeout)
+		defer cancel()
 		// Ordinary opens of EITHER engine refuse while a conversion is in
 		// flight (§6); the json engine cannot see the manifest itself.
-		if err := metasqlite.RefuseManifest(MetaDBPath(conf)); err != nil {
+		dbPath := MetaDBPath(conf)
+		if err := metasqlite.RefuseManifest(dbPath); err != nil {
 			metaErr = err
 			return
 		}
 		// Assign the interface only on success: a typed-nil store would pass
 		// CloseMetaStore's nil check and panic.
-		if conf.MetaBackend == "sqlite" {
-			if s, err := metasqlite.Open(MetaDBPath(conf), MetaNamespaces()...); err != nil {
+		if ResolveMetaBackend(conf) == config.MetaBackendSQLite {
+			if s, err := openSQLiteStore(ctx, conf, dbPath); err != nil {
 				metaErr = err
 			} else {
 				metaStore = s
 			}
 			return
+		}
+		if conf.MetaBackend == "" {
+			log.WithFunc("core.MetaStore").Info(ctx, "legacy json meta store in use; `cocoon meta convert` upgrades it to sqlite")
 		}
 		if s, err := metajson.Open(MetaJSONNamespaces(conf)...); err != nil {
 			metaErr = err
@@ -114,6 +154,21 @@ func MetaStore(conf *config.Config) (meta.Store, error) {
 		}
 	})
 	return metaStore, metaErr
+}
+
+// openSQLiteStore opens the sqlite engine, bootstrapping a completely fresh
+// root; a legacy json root never bootstraps — that would shadow its data.
+func openSQLiteStore(ctx context.Context, conf *config.Config, dbPath string) (meta.Store, error) {
+	if !utils.FileExists(dbPath) && !legacyJSONPresent(conf) {
+		if err := metasqlite.InitIfMissing(ctx, dbPath, MetaNamespaces()...); err != nil {
+			return nil, err
+		}
+	}
+	s, err := metasqlite.Open(dbPath, MetaNamespaces()...)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
 }
 
 // CloseMetaStore ends the store's unified lifecycle at command teardown

--- a/cmd/core/metastore_test.go
+++ b/cmd/core/metastore_test.go
@@ -1,19 +1,105 @@
 package core
 
 import (
+	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/cocoonstack/cocoon/config"
+	"github.com/cocoonstack/cocoon/utils"
 )
+
+func resetMetaStore() {
+	metaOnce = sync.Once{}
+	metaStore = nil
+	metaErr = nil
+}
+
+func testConf(t *testing.T) *config.Config {
+	dir := t.TempDir()
+	return &config.Config{RootDir: dir, RunDir: filepath.Join(dir, "run"), LogDir: filepath.Join(dir, "log")}
+}
+
+func writeLegacyJSON(t *testing.T, conf *config.Config) {
+	p := MetaJSONNamespaces(conf)[0].FilePath
+	if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(`{"vms":{},"names":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
 
 // A failed engine open must leave the interface nil so CloseMetaStore's nil
 // check holds — a typed-nil store would panic at command teardown.
 func TestMetaStoreOpenErrorThenCloseNoPanic(t *testing.T) {
-	dir := t.TempDir()
-	conf := &config.Config{RootDir: dir, RunDir: filepath.Join(dir, "run"), LogDir: filepath.Join(dir, "log"), MetaBackend: "sqlite"}
+	resetMetaStore()
+	conf := testConf(t)
+	conf.MetaBackend = "sqlite"
+	writeLegacyJSON(t, conf)
 	if _, err := MetaStore(conf); err == nil {
-		t.Fatal("want open error on uninitialized sqlite root")
+		t.Fatal("want open error on explicit sqlite over an uninitialized legacy root")
 	}
 	CloseMetaStore(t.Context())
+	resetMetaStore()
+}
+
+func TestMetaStoreBootstrapsFreshRoot(t *testing.T) {
+	resetMetaStore()
+	conf := testConf(t)
+	s, err := MetaStore(conf)
+	if err != nil {
+		t.Fatalf("bootstrap fresh root: %v", err)
+	}
+	if s == nil {
+		t.Fatal("nil store")
+	}
+	if !utils.FileExists(MetaDBPath(conf)) {
+		t.Fatal("meta.db not created")
+	}
+	CloseMetaStore(t.Context())
+	resetMetaStore()
+}
+
+func TestMetaStoreKeepsLegacyJSON(t *testing.T) {
+	resetMetaStore()
+	conf := testConf(t)
+	writeLegacyJSON(t, conf)
+	s, err := MetaStore(conf)
+	if err != nil {
+		t.Fatalf("open legacy root: %v", err)
+	}
+	if s == nil {
+		t.Fatal("nil store")
+	}
+	if utils.FileExists(MetaDBPath(conf)) {
+		t.Fatal("legacy root must not grow a sqlite store")
+	}
+	CloseMetaStore(t.Context())
+	resetMetaStore()
+}
+
+func TestResolveMetaBackend(t *testing.T) {
+	conf := testConf(t)
+	if b := ResolveMetaBackend(conf); b != "sqlite" {
+		t.Fatalf("fresh root: want sqlite, got %q", b)
+	}
+	writeLegacyJSON(t, conf)
+	if b := ResolveMetaBackend(conf); b != "json" {
+		t.Fatalf("legacy root: want json, got %q", b)
+	}
+	if err := os.MkdirAll(filepath.Dir(MetaDBPath(conf)), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(MetaDBPath(conf), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if b := ResolveMetaBackend(conf); b != "sqlite" {
+		t.Fatalf("meta.db present: want sqlite, got %q", b)
+	}
+	conf.MetaBackend = "json"
+	if b := ResolveMetaBackend(conf); b != "json" {
+		t.Fatalf("explicit setting must win, got %q", b)
+	}
 }

--- a/cmd/core/metastore_test.go
+++ b/cmd/core/metastore_test.go
@@ -59,6 +59,26 @@ func TestMetaStoreKeepsLegacyJSON(t *testing.T) {
 	resetMetaStore()
 }
 
+func TestMetaStoreRepairsCrashedBootstrap(t *testing.T) {
+	resetMetaStore()
+	conf := testConf(t)
+	if err := os.MkdirAll(filepath.Dir(MetaDBPath(conf)), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(MetaDBPath(conf), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s, err := MetaStore(conf)
+	if err != nil {
+		t.Fatalf("repair crashed bootstrap: %v", err)
+	}
+	if s == nil {
+		t.Fatal("nil store")
+	}
+	CloseMetaStore(t.Context())
+	resetMetaStore()
+}
+
 func TestResolveMetaBackend(t *testing.T) {
 	conf := testConf(t)
 	if b := ResolveMetaBackend(conf); b != "sqlite" {

--- a/cmd/core/metastore_test.go
+++ b/cmd/core/metastore_test.go
@@ -10,27 +10,6 @@ import (
 	"github.com/cocoonstack/cocoon/utils"
 )
 
-func resetMetaStore() {
-	metaOnce = sync.Once{}
-	metaStore = nil
-	metaErr = nil
-}
-
-func testConf(t *testing.T) *config.Config {
-	dir := t.TempDir()
-	return &config.Config{RootDir: dir, RunDir: filepath.Join(dir, "run"), LogDir: filepath.Join(dir, "log")}
-}
-
-func writeLegacyJSON(t *testing.T, conf *config.Config) {
-	p := MetaJSONNamespaces(conf)[0].FilePath
-	if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(p, []byte(`{"vms":{},"names":{}}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-}
-
 // A failed engine open must leave the interface nil so CloseMetaStore's nil
 // check holds — a typed-nil store would panic at command teardown.
 func TestMetaStoreOpenErrorThenCloseNoPanic(t *testing.T) {
@@ -101,5 +80,26 @@ func TestResolveMetaBackend(t *testing.T) {
 	conf.MetaBackend = "json"
 	if b := ResolveMetaBackend(conf); b != "json" {
 		t.Fatalf("explicit setting must win, got %q", b)
+	}
+}
+
+func resetMetaStore() {
+	metaOnce = sync.Once{}
+	metaStore = nil
+	metaErr = nil
+}
+
+func testConf(t *testing.T) *config.Config {
+	dir := t.TempDir()
+	return &config.Config{RootDir: dir, RunDir: filepath.Join(dir, "run"), LogDir: filepath.Join(dir, "log")}
+}
+
+func writeLegacyJSON(t *testing.T, conf *config.Config) {
+	p := MetaJSONNamespaces(conf)[0].FilePath
+	if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(`{"vms":{},"names":{}}`), 0o644); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/cmd/core/network.go
+++ b/cmd/core/network.go
@@ -62,17 +62,6 @@ func (n *NetProviders) ForVM(vm *types.VM) (network.Network, error) {
 	return p, nil
 }
 
-func (n *NetProviders) cniLocked() (network.Network, error) {
-	if n.cni == nil {
-		p, err := InitNetwork(n.conf)
-		if err != nil {
-			return nil, err
-		}
-		n.cni = p
-	}
-	return n.cni, nil
-}
-
 // Recover verifies, rebuilds or un-quiesces the VM's plumbing; its error aborts the launch, since half-built networking strands the guest.
 func (n *NetProviders) Recover(ctx context.Context, vm *types.VM) error {
 	backend := vm.ResolvedNetBackend()
@@ -124,4 +113,15 @@ func (n *NetProviders) cniOnly() (network.Network, error) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	return n.cniLocked()
+}
+
+func (n *NetProviders) cniLocked() (network.Network, error) {
+	if n.cni == nil {
+		p, err := InitNetwork(n.conf)
+		if err != nil {
+			return nil, err
+		}
+		n.cni = p
+	}
+	return n.cni, nil
 }

--- a/cmd/core/utils.go
+++ b/cmd/core/utils.go
@@ -57,6 +57,13 @@ func RouteRefs(ctx context.Context, hypers []hypervisor.Hypervisor, refs []strin
 	return result, nil
 }
 
+func ReconcileState(vm *types.VM) string {
+	if vm.State == types.VMStateRunning && !utils.IsProcessAlive(vm.PID) {
+		return "stopped (stale)"
+	}
+	return string(vm.State)
+}
+
 func ResolveImage(ctx context.Context, backends []imagebackend.Images, vmCfg *types.VMConfig) ([]*types.StorageConfig, *types.BootConfig, error) {
 	vms := []*types.VMConfig{vmCfg}
 	var owner imagebackend.Images
@@ -140,13 +147,6 @@ func ResolveImageOwner(ctx context.Context, backends []imagebackend.Images, ref 
 	)
 }
 
-func ReconcileState(vm *types.VM) string {
-	if vm.State == types.VMStateRunning && !utils.IsProcessAlive(vm.PID) {
-		return "stopped (stale)"
-	}
-	return string(vm.State)
-}
-
 // CloseOnCancel closes c when ctx is canceled; callers `defer CloseOnCancel(ctx, c)()` to stop the watcher on return.
 func CloseOnCancel(ctx context.Context, c io.Closer) func() bool {
 	return context.AfterFunc(ctx, func() {
@@ -225,8 +225,11 @@ func PersistSnapshotStream(ctx context.Context, snapBackend snapshot.Snapshot, c
 	return snapID, nil
 }
 
+// typed is the backend constraint resolveOwner reports matches by.
+type typed interface{ Type() string }
+
 // resolveOwner returns the unique backend where found==true; notFound on zero, ambiguous wrapped on multi-match (lists matched types).
-func resolveOwner[T interface{ Type() string }](backends []T, ref string, found func(T) (bool, error), notFound, ambiguous error) (T, error) {
+func resolveOwner[T typed](backends []T, ref string, found func(T) (bool, error), notFound, ambiguous error) (T, error) {
 	var matches []T
 	var zero T
 	for _, b := range backends {
@@ -250,6 +253,27 @@ func resolveOwner[T interface{ Type() string }](backends []T, ref string, found 
 		}
 		return zero, fmt.Errorf("%w (backends: %s)", ambiguous, strings.Join(names, ", "))
 	}
+}
+
+// resolveVMOwner returns the owning hypervisor and resolved *types.VM so callers use vm.ID instead of re-resolving the raw ref.
+func resolveVMOwner(ctx context.Context, hypers []hypervisor.Hypervisor, ref string) (hypervisor.Hypervisor, *types.VM, error) {
+	var resolved *types.VM
+	owner, err := resolveOwner(
+		hypers, ref, func(h hypervisor.Hypervisor) (bool, error) {
+			vm, err := h.Inspect(ctx, ref)
+			if err == nil && vm != nil {
+				resolved = vm
+				return true, nil
+			}
+			if err != nil && !errors.Is(err, hypervisor.ErrNotFound) {
+				return false, err
+			}
+			return false, nil
+		},
+		fmt.Errorf("vm %s: %w", ref, hypervisor.ErrNotFound),
+		fmt.Errorf("vm %s: %w", ref, hypervisor.ErrAmbiguous),
+	)
+	return owner, resolved, err
 }
 
 // validateRefShape rejects URL/OCI ref mismatches early so backends don't surface misleading downstream errors.
@@ -278,25 +302,4 @@ func digestPullRef(image, digest, imageType string) string {
 		return image
 	}
 	return ref.Context().String() + "@" + digest
-}
-
-// resolveVMOwner returns the owning hypervisor and resolved *types.VM so callers use vm.ID instead of re-resolving the raw ref.
-func resolveVMOwner(ctx context.Context, hypers []hypervisor.Hypervisor, ref string) (hypervisor.Hypervisor, *types.VM, error) {
-	var resolved *types.VM
-	owner, err := resolveOwner(
-		hypers, ref, func(h hypervisor.Hypervisor) (bool, error) {
-			vm, err := h.Inspect(ctx, ref)
-			if err == nil && vm != nil {
-				resolved = vm
-				return true, nil
-			}
-			if err != nil && !errors.Is(err, hypervisor.ErrNotFound) {
-				return false, err
-			}
-			return false, nil
-		},
-		fmt.Errorf("vm %s: %w", ref, hypervisor.ErrNotFound),
-		fmt.Errorf("vm %s: %w", ref, hypervisor.ErrAmbiguous),
-	)
-	return owner, resolved, err
 }

--- a/cmd/core/utils.go
+++ b/cmd/core/utils.go
@@ -154,6 +154,77 @@ func CloseOnCancel(ctx context.Context, c io.Closer) func() bool {
 	})
 }
 
+// EnsureSnapshotNameFree validates name and rejects a duplicate; empty passes.
+func EnsureSnapshotNameFree(ctx context.Context, snapBackend snapshot.Snapshot, name string) error {
+	if err := (&types.SnapshotConfig{Name: name}).Validate(); err != nil {
+		return err
+	}
+	if name == "" {
+		return nil
+	}
+	if _, err := snapBackend.Inspect(ctx, name); err == nil {
+		return fmt.Errorf("snapshot name %q already exists", name)
+	} else if !errors.Is(err, snapshot.ErrNotFound) {
+		return fmt.Errorf("check snapshot name: %w", err)
+	}
+	return nil
+}
+
+// SnapshotNameFlags reads the --name/--description pair and rejects a taken name.
+func SnapshotNameFlags(ctx context.Context, cmd *cobra.Command, snapBackend snapshot.Snapshot) (name, description string, err error) {
+	name, _ = cmd.Flags().GetString("name")
+	description, _ = cmd.Flags().GetString("description")
+	if err = EnsureSnapshotNameFree(ctx, snapBackend, name); err != nil {
+		return "", "", err
+	}
+	return name, description, nil
+}
+
+// CaptureSnapshot checks the --name preflight, runs capture, and persists the capture dir, returning the stored snapshot id.
+func CaptureSnapshot(ctx context.Context, cmd *cobra.Command, snapBackend snapshot.Snapshot, capture func() (*types.SnapshotConfig, string, error)) (string, error) {
+	name, description, err := SnapshotNameFlags(ctx, cmd, snapBackend)
+	if err != nil {
+		return "", err
+	}
+	cfg, srcDir, err := capture()
+	if err != nil {
+		return "", err
+	}
+	return PersistSnapshotDir(ctx, snapBackend, cfg, srcDir, name, description)
+}
+
+// PersistSnapshotDir stores a finalized capture dir, preferring a direct in-place move (DirectCreator) when srcDir shares a filesystem with the backend's data dir, and falling back to a tar stream otherwise (cross-filesystem, or a backend without DirectCreator such as a remote store). srcDir is consumed on every path.
+func PersistSnapshotDir(ctx context.Context, snapBackend snapshot.Snapshot, cfg *types.SnapshotConfig, srcDir, name, description string) (string, error) {
+	cfg.Name = name
+	cfg.Description = description
+	if dc, ok := snapBackend.(snapshot.DirectCreator); ok {
+		id, done, err := dc.CreateFromDir(ctx, cfg, srcDir)
+		if err != nil {
+			os.RemoveAll(srcDir) //nolint:errcheck,gosec // consume srcDir on every path: a failed direct save must not leave the GB capture dir behind
+			return "", fmt.Errorf("save snapshot: %w", err)
+		}
+		if done {
+			log.WithFunc("core.PersistSnapshotDir").Info(ctx, "saved snapshot data (direct)")
+			return id, nil
+		}
+	}
+	return PersistSnapshotStream(ctx, snapBackend, cfg, utils.TarDirStreamWithRemove(srcDir), name, description)
+}
+
+// PersistSnapshotStream labels cfg and stores the stream, closing it either way.
+func PersistSnapshotStream(ctx context.Context, snapBackend snapshot.Snapshot, cfg *types.SnapshotConfig, stream io.ReadCloser, name, description string) (string, error) {
+	defer stream.Close() //nolint:errcheck
+	defer CloseOnCancel(ctx, stream)()
+	cfg.Name = name
+	cfg.Description = description
+	log.WithFunc("core.PersistSnapshotStream").Info(ctx, "saving snapshot data ...")
+	snapID, err := snapBackend.Create(ctx, cfg, stream)
+	if err != nil {
+		return "", fmt.Errorf("save snapshot: %w", err)
+	}
+	return snapID, nil
+}
+
 // resolveOwner returns the unique backend where found==true; notFound on zero, ambiguous wrapped on multi-match (lists matched types).
 func resolveOwner[T interface{ Type() string }](backends []T, ref string, found func(T) (bool, error), notFound, ambiguous error) (T, error) {
 	var matches []T
@@ -228,75 +299,4 @@ func resolveVMOwner(ctx context.Context, hypers []hypervisor.Hypervisor, ref str
 		fmt.Errorf("vm %s: %w", ref, hypervisor.ErrAmbiguous),
 	)
 	return owner, resolved, err
-}
-
-// EnsureSnapshotNameFree validates name and rejects a duplicate; empty passes.
-func EnsureSnapshotNameFree(ctx context.Context, snapBackend snapshot.Snapshot, name string) error {
-	if err := (&types.SnapshotConfig{Name: name}).Validate(); err != nil {
-		return err
-	}
-	if name == "" {
-		return nil
-	}
-	if _, err := snapBackend.Inspect(ctx, name); err == nil {
-		return fmt.Errorf("snapshot name %q already exists", name)
-	} else if !errors.Is(err, snapshot.ErrNotFound) {
-		return fmt.Errorf("check snapshot name: %w", err)
-	}
-	return nil
-}
-
-// SnapshotNameFlags reads the --name/--description pair and rejects a taken name.
-func SnapshotNameFlags(ctx context.Context, cmd *cobra.Command, snapBackend snapshot.Snapshot) (name, description string, err error) {
-	name, _ = cmd.Flags().GetString("name")
-	description, _ = cmd.Flags().GetString("description")
-	if err = EnsureSnapshotNameFree(ctx, snapBackend, name); err != nil {
-		return "", "", err
-	}
-	return name, description, nil
-}
-
-// CaptureSnapshot checks the --name preflight, runs capture, and persists the capture dir, returning the stored snapshot id.
-func CaptureSnapshot(ctx context.Context, cmd *cobra.Command, snapBackend snapshot.Snapshot, capture func() (*types.SnapshotConfig, string, error)) (string, error) {
-	name, description, err := SnapshotNameFlags(ctx, cmd, snapBackend)
-	if err != nil {
-		return "", err
-	}
-	cfg, srcDir, err := capture()
-	if err != nil {
-		return "", err
-	}
-	return PersistSnapshotDir(ctx, snapBackend, cfg, srcDir, name, description)
-}
-
-// PersistSnapshotDir stores a finalized capture dir, preferring a direct in-place move (DirectCreator) when srcDir shares a filesystem with the backend's data dir, and falling back to a tar stream otherwise (cross-filesystem, or a backend without DirectCreator such as a remote store). srcDir is consumed on every path.
-func PersistSnapshotDir(ctx context.Context, snapBackend snapshot.Snapshot, cfg *types.SnapshotConfig, srcDir, name, description string) (string, error) {
-	cfg.Name = name
-	cfg.Description = description
-	if dc, ok := snapBackend.(snapshot.DirectCreator); ok {
-		id, done, err := dc.CreateFromDir(ctx, cfg, srcDir)
-		if err != nil {
-			os.RemoveAll(srcDir) //nolint:errcheck,gosec // consume srcDir on every path: a failed direct save must not leave the GB capture dir behind
-			return "", fmt.Errorf("save snapshot: %w", err)
-		}
-		if done {
-			log.WithFunc("core.PersistSnapshotDir").Info(ctx, "saved snapshot data (direct)")
-			return id, nil
-		}
-	}
-	return PersistSnapshotStream(ctx, snapBackend, cfg, utils.TarDirStreamWithRemove(srcDir), name, description)
-}
-
-// PersistSnapshotStream labels cfg and stores the stream, closing it either way.
-func PersistSnapshotStream(ctx context.Context, snapBackend snapshot.Snapshot, cfg *types.SnapshotConfig, stream io.ReadCloser, name, description string) (string, error) {
-	defer stream.Close() //nolint:errcheck
-	defer CloseOnCancel(ctx, stream)()
-	cfg.Name = name
-	cfg.Description = description
-	log.WithFunc("core.PersistSnapshotStream").Info(ctx, "saving snapshot data ...")
-	snapID, err := snapBackend.Create(ctx, cfg, stream)
-	if err != nil {
-		return "", fmt.Errorf("save snapshot: %w", err)
-	}
-	return snapID, nil
 }

--- a/cmd/images/import.go
+++ b/cmd/images/import.go
@@ -207,7 +207,7 @@ func detectReader(r io.Reader) (io.Reader, imageType, func(), error) {
 	}
 
 	var inner *bufio.Reader
-	if peek[0] == 0x1f && peek[1] == 0x8b {
+	if bytes.HasPrefix(peek, utils.GzipMagic) {
 		gr, gzErr := gzip.NewReader(br)
 		if gzErr != nil {
 			return nil, 0, nil, fmt.Errorf("gzip: %w", gzErr)

--- a/cmd/meta/convert/convert.go
+++ b/cmd/meta/convert/convert.go
@@ -16,6 +16,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/cocoonstack/cocoon/config"
 	"github.com/cocoonstack/cocoon/lock/flock"
 	"github.com/cocoonstack/cocoon/meta"
 	metajson "github.com/cocoonstack/cocoon/meta/json"
@@ -23,13 +24,7 @@ import (
 	"github.com/cocoonstack/cocoon/utils"
 )
 
-const (
-	asideSuffix = ".converted-"
-
-	// EngineJSON/EngineSQLite are the meta_backend values.
-	EngineJSON   = "json"
-	EngineSQLite = "sqlite"
-)
+const asideSuffix = ".converted-"
 
 // testCrashStep injects crashes between protocol steps (§9 gate); nil in prod.
 var testCrashStep func(step string) error
@@ -66,7 +61,7 @@ type NSRecord struct {
 
 // Run performs (or resumes) the cutover to target ("sqlite" or "json").
 func Run(ctx context.Context, spec Spec, target string) error {
-	if target != EngineSQLite && target != EngineJSON {
+	if target != config.MetaBackendSQLite && target != config.MetaBackendJSON {
 		return fmt.Errorf("unknown target engine %q", target)
 	}
 	m, err := loadManifest(spec.MetaRoot)
@@ -150,7 +145,7 @@ func newManifest(ctx context.Context, spec Spec, target string, src meta.Store) 
 // means live cocoon processes, and converting under them could lose writes
 // landing on a namespace already marked done.
 func checkQuiesced(ctx context.Context, spec Spec, target string, src meta.Store) error {
-	if target == EngineJSON {
+	if target == config.MetaBackendJSON {
 		// sqlite source: an empty durable transaction fails ErrBusy while a
 		// writer is mid-flight.
 		probeCtx, cancel := context.WithTimeout(ctx, time.Second)
@@ -191,7 +186,7 @@ func ensureJSONDirs(spec Spec) error {
 
 // openSource opens the engine being converted FROM (the opposite of target).
 func openSource(spec Spec, target string) (meta.Store, error) {
-	if target == EngineSQLite {
+	if target == config.MetaBackendSQLite {
 		return metajson.Open(spec.JSON...)
 	}
 	// The driver would create an empty file on first touch; a missing source
@@ -203,7 +198,7 @@ func openSource(spec Spec, target string) (meta.Store, error) {
 }
 
 func openTarget(ctx context.Context, spec Spec, target string) (meta.Store, error) {
-	if target == EngineJSON {
+	if target == config.MetaBackendJSON {
 		return metajson.Open(spec.JSON...)
 	}
 	if !utils.FileExists(spec.DBPath) {
@@ -229,7 +224,7 @@ func convertNamespace(ctx context.Context, src, dst meta.Store, ns metasqlite.Na
 	if err := crashStep("ns-copied"); err != nil {
 		return err
 	}
-	if m.Target == EngineSQLite {
+	if m.Target == config.MetaBackendSQLite {
 		if err := metasqlite.MarkConverted(ctx, spec.DBPath, ns.Name, rec.Files[0], rec.SHA256, rec.Records); err != nil {
 			return err
 		}
@@ -382,7 +377,7 @@ func canonicalDigest(ctx context.Context, s meta.Store, ns metasqlite.Namespace)
 // sqlite source checkpoints to a single file first (§6). Runs with both
 // engines closed; already-renamed files are skipped, so a crash here reruns.
 func retireSources(ctx context.Context, spec Spec, target string) error {
-	if target == EngineJSON && utils.FileExists(spec.DBPath) {
+	if target == config.MetaBackendJSON && utils.FileExists(spec.DBPath) {
 		if err := metasqlite.Checkpoint(ctx, spec.DBPath); err != nil {
 			return err
 		}
@@ -411,7 +406,7 @@ func retireSources(ctx context.Context, spec Spec, target string) error {
 }
 
 func sourceFiles(spec Spec, target, nsName string) []string {
-	if target == EngineJSON {
+	if target == config.MetaBackendJSON {
 		return []string{spec.DBPath}
 	}
 	if jns, ok := findJSON(spec, nsName); ok {

--- a/cmd/meta/convert/convert.go
+++ b/cmd/meta/convert/convert.go
@@ -201,10 +201,8 @@ func openTarget(ctx context.Context, spec Spec, target string) (meta.Store, erro
 	if target == config.MetaBackendJSON {
 		return metajson.Open(spec.JSON...)
 	}
-	if !utils.FileExists(spec.DBPath) {
-		if err := metasqlite.InitForRecovery(ctx, spec.DBPath, spec.Decls...); err != nil {
-			return nil, err
-		}
+	if err := metasqlite.InitForRecoveryIfNeeded(ctx, spec.DBPath, spec.Decls...); err != nil {
+		return nil, err
 	}
 	return metasqlite.OpenForRecovery(spec.DBPath, spec.Decls...)
 }

--- a/cmd/meta/convert/convert.go
+++ b/cmd/meta/convert/convert.go
@@ -29,13 +29,6 @@ const asideSuffix = ".converted-"
 // testCrashStep injects crashes between protocol steps (§9 gate); nil in prod.
 var testCrashStep func(step string) error
 
-func crashStep(step string) error {
-	if testCrashStep == nil {
-		return nil
-	}
-	return testCrashStep(step)
-}
-
 // Spec carries both engines' declarations from the composition root.
 type Spec struct {
 	MetaRoot string // manifest directory (parent of the sqlite DB)
@@ -80,6 +73,13 @@ func Run(ctx context.Context, spec Spec, target string) error {
 		return err
 	}
 	return finishManifest(spec.MetaRoot)
+}
+
+func crashStep(step string) error {
+	if testCrashStep == nil {
+		return nil
+	}
+	return testCrashStep(step)
 }
 
 func convertAll(ctx context.Context, spec Spec, target string, m *Manifest) error {

--- a/cmd/meta/convert/convert_test.go
+++ b/cmd/meta/convert/convert_test.go
@@ -417,6 +417,40 @@ func TestConvertSkipsNeverWrittenNamespace(t *testing.T) {
 	}
 }
 
+func TestConvertRerunsAfterCrashedTargetInit(t *testing.T) {
+	errCrash := errors.New("injected crash")
+	spec := testSpec(t, "vms")
+	seedJSON(t, spec, "vms")
+	testCrashStep = func(at string) error {
+		if at == "manifest-saved" {
+			return errCrash
+		}
+		return nil
+	}
+	err := Run(t.Context(), spec, "sqlite")
+	testCrashStep = nil
+	if !errors.Is(err, errCrash) {
+		t.Fatalf("want injected crash, got %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(spec.DBPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(spec.DBPath, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Run(t.Context(), spec, "sqlite"); err != nil {
+		t.Fatalf("rerun over crashed target init: %v", err)
+	}
+	store, err := metasqlite.Open(spec.DBPath, spec.Decls...)
+	if err != nil {
+		t.Fatalf("open target: %v", err)
+	}
+	defer store.Close() //nolint:errcheck
+	if got := scanAll(t, store, "vms"); len(got) != 4 || got["records/id1"] != `{"v":1}` {
+		t.Fatalf("content after rerun: %v", got)
+	}
+}
+
 func testSpec(t *testing.T, nss ...string) Spec {
 	t.Helper()
 	root := t.TempDir()

--- a/cmd/meta/convert/convert_test.go
+++ b/cmd/meta/convert/convert_test.go
@@ -20,65 +20,6 @@ import (
 
 var testTables = []string{"records", "names", "tombstones"}
 
-func testSpec(t *testing.T, nss ...string) Spec {
-	t.Helper()
-	root := t.TempDir()
-	spec := Spec{MetaRoot: filepath.Join(root, "meta"), DBPath: filepath.Join(root, "meta", metasqlite.DBFileName)}
-	for _, ns := range nss {
-		spec.Decls = append(spec.Decls, metasqlite.Namespace{Name: ns, Tables: testTables})
-		spec.JSON = append(spec.JSON, metajson.Namespace{
-			Name:     ns,
-			FilePath: filepath.Join(root, ns+".json"),
-			LockPath: filepath.Join(root, ns+".lock"),
-			Codec:    metajson.GenericCodec{},
-		})
-	}
-	return spec
-}
-
-func seedJSON(t *testing.T, spec Spec, ns string) {
-	t.Helper()
-	s, err := metajson.Open(spec.JSON...)
-	if err != nil {
-		t.Fatalf("open json: %v", err)
-	}
-	defer s.Close() //nolint:errcheck
-	err = s.Update(t.Context(), meta.Scope{Write: ns}, meta.CommitDurable, func(w meta.Writer) error {
-		for id, raw := range map[string]string{"id1": `{"v":1}`, "id2": `{"v":2}`} {
-			if err := w.PutRaw(t.Context(), ns, "records", id, json.RawMessage(raw), false); err != nil {
-				return err
-			}
-		}
-		if err := w.PutRaw(t.Context(), ns, "names", "alpha", json.RawMessage(`"id1"`), false); err != nil {
-			return err
-		}
-		return w.PutRaw(t.Context(), ns, "tombstones", "id9", json.RawMessage(`{"dead":true}`), false)
-	})
-	if err != nil {
-		t.Fatalf("seed: %v", err)
-	}
-}
-
-func scanAll(t *testing.T, s meta.Store, ns string) map[string]string {
-	t.Helper()
-	got := map[string]string{}
-	err := s.View(t.Context(), []string{ns}, func(r meta.Reader) error {
-		for _, tbl := range testTables {
-			if err := r.ScanRaw(t.Context(), ns, tbl, func(id string, raw json.RawMessage) error {
-				got[tbl+"/"+id] = string(raw)
-				return nil
-			}); err != nil {
-				return err
-			}
-		}
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("scan %s: %v", ns, err)
-	}
-	return got
-}
-
 func TestRoundTrip(t *testing.T) {
 	ctx := t.Context()
 	spec := testSpec(t, "vms", "images")
@@ -474,4 +415,63 @@ func TestConvertSkipsNeverWrittenNamespace(t *testing.T) {
 	if err := Run(t.Context(), spec, "json"); err != nil {
 		t.Fatalf("reverse convert with never-written namespace: %v", err)
 	}
+}
+
+func testSpec(t *testing.T, nss ...string) Spec {
+	t.Helper()
+	root := t.TempDir()
+	spec := Spec{MetaRoot: filepath.Join(root, "meta"), DBPath: filepath.Join(root, "meta", metasqlite.DBFileName)}
+	for _, ns := range nss {
+		spec.Decls = append(spec.Decls, metasqlite.Namespace{Name: ns, Tables: testTables})
+		spec.JSON = append(spec.JSON, metajson.Namespace{
+			Name:     ns,
+			FilePath: filepath.Join(root, ns+".json"),
+			LockPath: filepath.Join(root, ns+".lock"),
+			Codec:    metajson.GenericCodec{},
+		})
+	}
+	return spec
+}
+
+func seedJSON(t *testing.T, spec Spec, ns string) {
+	t.Helper()
+	s, err := metajson.Open(spec.JSON...)
+	if err != nil {
+		t.Fatalf("open json: %v", err)
+	}
+	defer s.Close() //nolint:errcheck
+	err = s.Update(t.Context(), meta.Scope{Write: ns}, meta.CommitDurable, func(w meta.Writer) error {
+		for id, raw := range map[string]string{"id1": `{"v":1}`, "id2": `{"v":2}`} {
+			if err := w.PutRaw(t.Context(), ns, "records", id, json.RawMessage(raw), false); err != nil {
+				return err
+			}
+		}
+		if err := w.PutRaw(t.Context(), ns, "names", "alpha", json.RawMessage(`"id1"`), false); err != nil {
+			return err
+		}
+		return w.PutRaw(t.Context(), ns, "tombstones", "id9", json.RawMessage(`{"dead":true}`), false)
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+}
+
+func scanAll(t *testing.T, s meta.Store, ns string) map[string]string {
+	t.Helper()
+	got := map[string]string{}
+	err := s.View(t.Context(), []string{ns}, func(r meta.Reader) error {
+		for _, tbl := range testTables {
+			if err := r.ScanRaw(t.Context(), ns, tbl, func(id string, raw json.RawMessage) error {
+				got[tbl+"/"+id] = string(raw)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("scan %s: %v", ns, err)
+	}
+	return got
 }

--- a/cmd/meta/handler.go
+++ b/cmd/meta/handler.go
@@ -8,6 +8,7 @@ import (
 
 	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
 	"github.com/cocoonstack/cocoon/cmd/meta/convert"
+	"github.com/cocoonstack/cocoon/config"
 	metasqlite "github.com/cocoonstack/cocoon/meta/sqlite"
 )
 
@@ -21,8 +22,8 @@ func (h Handler) InitStore(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	if conf.MetaBackend != "sqlite" {
-		return fmt.Errorf("meta init applies to the sqlite backend; meta_backend is %q", conf.MetaBackend)
+	if b := cmdcore.ResolveMetaBackend(conf); b != config.MetaBackendSQLite {
+		return fmt.Errorf("meta init applies to the sqlite backend; effective meta_backend is %q", b)
 	}
 	dbPath := cmdcore.MetaDBPath(conf)
 	if err := metasqlite.Init(ctx, dbPath, cmdcore.MetaNamespaces()...); err != nil {
@@ -41,7 +42,7 @@ func (h Handler) Convert(cmd *cobra.Command, _ []string) error {
 	// always moves the OTHER engine's data into the effective backend.
 	target := conf.MetaBackend
 	if target == "" {
-		target = "json"
+		target = config.MetaBackendSQLite
 	}
 	dbPath := cmdcore.MetaDBPath(conf)
 	spec := convert.Spec{
@@ -62,8 +63,8 @@ func (h Handler) Backup(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if conf.MetaBackend != "sqlite" {
-		return fmt.Errorf("meta backup applies to the sqlite backend; meta_backend is %q", conf.MetaBackend)
+	if b := cmdcore.ResolveMetaBackend(conf); b != config.MetaBackendSQLite {
+		return fmt.Errorf("meta backup applies to the sqlite backend; effective meta_backend is %q", b)
 	}
 	if err := metasqlite.Backup(ctx, cmdcore.MetaDBPath(conf), args[0]); err != nil {
 		return err

--- a/cmd/meta/handler.go
+++ b/cmd/meta/handler.go
@@ -25,6 +25,9 @@ func (h Handler) InitStore(cmd *cobra.Command, _ []string) error {
 	if b := cmdcore.ResolveMetaBackend(conf); b != config.MetaBackendSQLite {
 		return fmt.Errorf("meta init applies to the sqlite backend; effective meta_backend is %q", b)
 	}
+	if cmdcore.LegacyJSONPresent(conf) {
+		return fmt.Errorf("legacy json metadata present; a fresh sqlite store would shadow it — run `cocoon meta convert`")
+	}
 	dbPath := cmdcore.MetaDBPath(conf)
 	if err := metasqlite.Init(ctx, dbPath, cmdcore.MetaNamespaces()...); err != nil {
 		return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -77,6 +77,9 @@ func newRootCmd() *cobra.Command {
 	viper.SetDefault("stop_timeout_seconds", 30)
 	viper.SetDefault("pool_size", runtime.NumCPU())
 	viper.SetDefault("pull_conns", 8)
+	// Empty default keeps the key registered so AutomaticEnv binds
+	// COCOON_META_BACKEND; the engine itself resolves via ResolveMetaBackend.
+	viper.SetDefault("meta_backend", "")
 	viper.SetDefault("log.level", "info")
 	viper.SetDefault("log.max_size", 500)
 	viper.SetDefault("log.max_age", 28)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -77,8 +77,7 @@ func newRootCmd() *cobra.Command {
 	viper.SetDefault("stop_timeout_seconds", 30)
 	viper.SetDefault("pool_size", runtime.NumCPU())
 	viper.SetDefault("pull_conns", 8)
-	// Empty default keeps the key registered so AutomaticEnv binds
-	// COCOON_META_BACKEND; the engine itself resolves via ResolveMetaBackend.
+	// Empty default keeps the key registered — AutomaticEnv only binds registered keys.
 	viper.SetDefault("meta_backend", "")
 	viper.SetDefault("log.level", "info")
 	viper.SetDefault("log.max_size", 500)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -77,7 +77,6 @@ func newRootCmd() *cobra.Command {
 	viper.SetDefault("stop_timeout_seconds", 30)
 	viper.SetDefault("pool_size", runtime.NumCPU())
 	viper.SetDefault("pull_conns", 8)
-	viper.SetDefault("meta_backend", "json")
 	viper.SetDefault("log.level", "info")
 	viper.SetDefault("log.max_size", 500)
 	viper.SetDefault("log.max_age", 28)

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cocoonstack/cocoon/extend/fs"
 	"github.com/cocoonstack/cocoon/extend/vfio"
 	"github.com/cocoonstack/cocoon/hypervisor"
-
 	"github.com/cocoonstack/cocoon/types"
 )
 

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,9 @@ const (
 	HypervisorCloudHypervisor HypervisorType = "cloud-hypervisor"
 	HypervisorFirecracker     HypervisorType = "firecracker"
 
+	MetaBackendJSON   = "json"
+	MetaBackendSQLite = "sqlite"
+
 	// defaultPullConns is the default concurrent Range connections per cloud-image download.
 	defaultPullConns = 8
 	// maxPullConns caps it so a misconfigured pull_conns can't exhaust file descriptors.
@@ -43,7 +46,8 @@ type Config struct {
 	PoolSize int `json:"pool_size" mapstructure:"pool_size"`
 	// PullConns: concurrent HTTP Range connections per cloud-image download; <=0 = 8.
 	PullConns int `json:"pull_conns" mapstructure:"pull_conns"`
-	// MetaBackend selects the metadata engine: "json" (default) or "sqlite".
+	// MetaBackend selects the metadata engine: "json" or "sqlite"; empty
+	// auto-resolves (an existing store binds its engine, fresh roots get sqlite).
 	MetaBackend string `json:"meta_backend,omitempty" mapstructure:"meta_backend"`
 	// CNIConfDir: CNI plugin configuration dir. Default: /etc/cni/net.d.
 	CNIConfDir string `json:"cni_conf_dir" mapstructure:"cni_conf_dir"`
@@ -99,7 +103,7 @@ func (c *Config) Validate() error {
 	if err := c.Metering.Validate(); err != nil {
 		return err
 	}
-	if c.MetaBackend != "" && c.MetaBackend != "json" && c.MetaBackend != "sqlite" {
+	if c.MetaBackend != "" && c.MetaBackend != MetaBackendJSON && c.MetaBackend != MetaBackendSQLite {
 		return fmt.Errorf("meta_backend %q is not one of json|sqlite", c.MetaBackend)
 	}
 	return nil

--- a/daemon/cache_test.go
+++ b/daemon/cache_test.go
@@ -8,24 +8,6 @@ import (
 	"github.com/cocoonstack/cocoon/types"
 )
 
-func statusOf(id string, state types.VMState, gen uint64, live bool) VMStatus {
-	rec := &hypervisor.VMRecord{VM: types.VM{ID: id, State: state, TransitionGeneration: gen}}
-	return newVMStatus("fake-hv", rec, live, 0, time.Now())
-}
-
-func collect(t *testing.T, ch <-chan changeEvent) []changeEvent {
-	t.Helper()
-	var got []changeEvent
-	for {
-		select {
-		case ev := <-ch:
-			got = append(got, ev)
-		default:
-			return got
-		}
-	}
-}
-
 func TestCachePublishesAddedThenModified(t *testing.T) {
 	c := newCache()
 	events, release := c.subscribe()
@@ -101,5 +83,23 @@ func TestCacheReleaseStopsDelivery(t *testing.T) {
 	c.publish([]VMStatus{statusOf("vm1", types.VMStateRunning, 1, true)}, true, 0, time.Now())
 	if got := collect(t, events); len(got) != 0 {
 		t.Errorf("got %+v, want nothing after release", got)
+	}
+}
+
+func statusOf(id string, state types.VMState, gen uint64, live bool) VMStatus {
+	rec := &hypervisor.VMRecord{VM: types.VM{ID: id, State: state, TransitionGeneration: gen}}
+	return newVMStatus("fake-hv", rec, live, 0, time.Now())
+}
+
+func collect(t *testing.T, ch <-chan changeEvent) []changeEvent {
+	t.Helper()
+	var got []changeEvent
+	for {
+		select {
+		case ev := <-ch:
+			got = append(got, ev)
+		default:
+			return got
+		}
 	}
 }

--- a/daemon/reconcile_test.go
+++ b/daemon/reconcile_test.go
@@ -37,15 +37,6 @@ type fakeSupervisor struct {
 	resumed   []string
 }
 
-func newFake() *fakeSupervisor {
-	return &fakeSupervisor{
-		records:    map[string]*hypervisor.VMRecord{},
-		tombstoned: map[string]struct{}{},
-		live:       map[string]utils.ProcRef{},
-		busy:       map[string]struct{}{},
-	}
-}
-
 func (f *fakeSupervisor) put(rec *hypervisor.VMRecord) *fakeSupervisor {
 	f.records[rec.ID] = rec
 	return f
@@ -150,19 +141,6 @@ func (f *fakeSupervisor) CollectStaleCreate(_ context.Context, vmID string, _ *h
 	f.collected = append(f.collected, vmID)
 	delete(f.records, vmID)
 	return nil
-}
-
-func newTestDaemon(t *testing.T, f *fakeSupervisor) *Daemon {
-	t.Helper()
-	d, err := New(Config{RootDir: t.TempDir()}, nil, []Supervisor{f})
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-	return d
-}
-
-func runningRec(id string, gen uint64) *hypervisor.VMRecord {
-	return &hypervisor.VMRecord{VM: types.VM{ID: id, State: types.VMStateRunning, TransitionGeneration: gen}}
 }
 
 func TestReconcileConvergesDeadRunningRecord(t *testing.T) {
@@ -392,4 +370,26 @@ func TestPassUnreadyWhenABackendCannotBeScanned(t *testing.T) {
 	if _, h := d.state.snapshot(); h.ok {
 		t.Error("a backend that could not be scanned still reported ready")
 	}
+}
+
+func newFake() *fakeSupervisor {
+	return &fakeSupervisor{
+		records:    map[string]*hypervisor.VMRecord{},
+		tombstoned: map[string]struct{}{},
+		live:       map[string]utils.ProcRef{},
+		busy:       map[string]struct{}{},
+	}
+}
+
+func newTestDaemon(t *testing.T, f *fakeSupervisor) *Daemon {
+	t.Helper()
+	d, err := New(Config{RootDir: t.TempDir()}, nil, []Supervisor{f})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return d
+}
+
+func runningRec(id string, gen uint64) *hypervisor.VMRecord {
+	return &hypervisor.VMRecord{VM: types.VM{ID: id, State: types.VMStateRunning, TransitionGeneration: gen}}
 }

--- a/daemon/reconcile_test.go
+++ b/daemon/reconcile_test.go
@@ -12,137 +12,6 @@ import (
 	"github.com/cocoonstack/cocoon/utils"
 )
 
-type convergeCall struct {
-	vmID string
-	gen  uint64
-}
-
-// fakeSupervisor scripts one backend's record set, liveness and lock state.
-type fakeSupervisor struct {
-	mu         sync.Mutex
-	records    map[string]*hypervisor.VMRecord
-	tombstoned map[string]struct{}
-	live       map[string]utils.ProcRef
-	busy       map[string]struct{}
-	lockErr    error
-	observeErr error
-
-	resumeErr error
-	scanErr   error
-
-	converged []convergeCall
-	adopted   []string
-	collected []string
-	quiesced  []string
-	resumed   []string
-}
-
-func (f *fakeSupervisor) put(rec *hypervisor.VMRecord) *fakeSupervisor {
-	f.records[rec.ID] = rec
-	return f
-}
-
-func (f *fakeSupervisor) Type() string { return "fake-hv" }
-
-func (f *fakeSupervisor) ScanSupervision(context.Context) (hypervisor.SupervisionScan, error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	if f.scanErr != nil {
-		return hypervisor.SupervisionScan{}, f.scanErr
-	}
-	scan := hypervisor.SupervisionScan{Tombstoned: f.tombstoned}
-	for _, rec := range f.records {
-		scan.Records = append(scan.Records, rec)
-	}
-	return scan, nil
-}
-
-func (f *fakeSupervisor) ObserveVMMIn(ctx context.Context, rec *hypervisor.VMRecord, _ utils.ProcScan) (utils.ProcRef, error) {
-	return f.ObserveVMM(ctx, rec)
-}
-
-func (f *fakeSupervisor) ObserveVMM(_ context.Context, rec *hypervisor.VMRecord) (utils.ProcRef, error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	if f.observeErr != nil {
-		return utils.ProcRef{}, f.observeErr
-	}
-	proc, ok := f.live[rec.ID]
-	if !ok {
-		return utils.ProcRef{}, hypervisor.ErrNotRunning
-	}
-	return proc, nil
-}
-
-func (f *fakeSupervisor) TryLockVMOps(_ context.Context, vmID string) (func(), bool, error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	if f.lockErr != nil {
-		return nil, false, f.lockErr
-	}
-	if _, held := f.busy[vmID]; held {
-		return nil, false, nil
-	}
-	return func() {}, true, nil
-}
-
-func (f *fakeSupervisor) PeekRecord(_ context.Context, vmID string) (*hypervisor.VMRecord, error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	return f.records[vmID], nil
-}
-
-// ConvergeDead mirrors the real composition: the record transition when one is
-// due, then the pending quiesce.
-func (f *fakeSupervisor) ConvergeDead(_ context.Context, vmID string, gen uint64, _ time.Time) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	rec := f.records[vmID]
-	if rec != nil && hypervisor.NeedsDeadConvergence(rec) && rec.TransitionGeneration == gen {
-		f.converged = append(f.converged, convergeCall{vmID: vmID, gen: gen})
-		rec.State = types.VMStateStopped
-		rec.TransitionGeneration++
-	}
-	if rec != nil && rec.QuiescePending {
-		f.quiesced = append(f.quiesced, vmID)
-		rec.QuiescePending = false
-	}
-	return nil
-}
-
-func (f *fakeSupervisor) ReconcileToRunning(_ context.Context, vmID string) (uint64, error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	rec := f.records[vmID]
-	if rec == nil || rec.Quarantine != "" || rec.State == types.VMStateCreating {
-		return 0, nil
-	}
-	f.adopted = append(f.adopted, vmID)
-	rec.State = types.VMStateRunning
-	rec.TransitionGeneration++
-	return rec.TransitionGeneration, nil
-}
-
-func (f *fakeSupervisor) RecoverTombstone(_ context.Context, vmID string) (bool, error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.resumed = append(f.resumed, vmID)
-	if f.resumeErr != nil {
-		return false, f.resumeErr
-	}
-	delete(f.records, vmID)
-	delete(f.tombstoned, vmID)
-	return true, nil
-}
-
-func (f *fakeSupervisor) CollectStaleCreate(_ context.Context, vmID string, _ *hypervisor.VMRecord) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.collected = append(f.collected, vmID)
-	delete(f.records, vmID)
-	return nil
-}
-
 func TestReconcileConvergesDeadRunningRecord(t *testing.T) {
 	f := newFake().put(runningRec("vm1", 7))
 	newTestDaemon(t, f).reconcile(t.Context())
@@ -370,6 +239,137 @@ func TestPassUnreadyWhenABackendCannotBeScanned(t *testing.T) {
 	if _, h := d.state.snapshot(); h.ok {
 		t.Error("a backend that could not be scanned still reported ready")
 	}
+}
+
+type convergeCall struct {
+	vmID string
+	gen  uint64
+}
+
+// fakeSupervisor scripts one backend's record set, liveness and lock state.
+type fakeSupervisor struct {
+	mu         sync.Mutex
+	records    map[string]*hypervisor.VMRecord
+	tombstoned map[string]struct{}
+	live       map[string]utils.ProcRef
+	busy       map[string]struct{}
+	lockErr    error
+	observeErr error
+
+	resumeErr error
+	scanErr   error
+
+	converged []convergeCall
+	adopted   []string
+	collected []string
+	quiesced  []string
+	resumed   []string
+}
+
+func (f *fakeSupervisor) put(rec *hypervisor.VMRecord) *fakeSupervisor {
+	f.records[rec.ID] = rec
+	return f
+}
+
+func (f *fakeSupervisor) Type() string { return "fake-hv" }
+
+func (f *fakeSupervisor) ScanSupervision(context.Context) (hypervisor.SupervisionScan, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.scanErr != nil {
+		return hypervisor.SupervisionScan{}, f.scanErr
+	}
+	scan := hypervisor.SupervisionScan{Tombstoned: f.tombstoned}
+	for _, rec := range f.records {
+		scan.Records = append(scan.Records, rec)
+	}
+	return scan, nil
+}
+
+func (f *fakeSupervisor) ObserveVMMIn(ctx context.Context, rec *hypervisor.VMRecord, _ utils.ProcScan) (utils.ProcRef, error) {
+	return f.ObserveVMM(ctx, rec)
+}
+
+func (f *fakeSupervisor) ObserveVMM(_ context.Context, rec *hypervisor.VMRecord) (utils.ProcRef, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.observeErr != nil {
+		return utils.ProcRef{}, f.observeErr
+	}
+	proc, ok := f.live[rec.ID]
+	if !ok {
+		return utils.ProcRef{}, hypervisor.ErrNotRunning
+	}
+	return proc, nil
+}
+
+func (f *fakeSupervisor) TryLockVMOps(_ context.Context, vmID string) (func(), bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.lockErr != nil {
+		return nil, false, f.lockErr
+	}
+	if _, held := f.busy[vmID]; held {
+		return nil, false, nil
+	}
+	return func() {}, true, nil
+}
+
+func (f *fakeSupervisor) PeekRecord(_ context.Context, vmID string) (*hypervisor.VMRecord, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.records[vmID], nil
+}
+
+// ConvergeDead mirrors the real composition: the record transition when one is
+// due, then the pending quiesce.
+func (f *fakeSupervisor) ConvergeDead(_ context.Context, vmID string, gen uint64, _ time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	rec := f.records[vmID]
+	if rec != nil && hypervisor.NeedsDeadConvergence(rec) && rec.TransitionGeneration == gen {
+		f.converged = append(f.converged, convergeCall{vmID: vmID, gen: gen})
+		rec.State = types.VMStateStopped
+		rec.TransitionGeneration++
+	}
+	if rec != nil && rec.QuiescePending {
+		f.quiesced = append(f.quiesced, vmID)
+		rec.QuiescePending = false
+	}
+	return nil
+}
+
+func (f *fakeSupervisor) ReconcileToRunning(_ context.Context, vmID string) (uint64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	rec := f.records[vmID]
+	if rec == nil || rec.Quarantine != "" || rec.State == types.VMStateCreating {
+		return 0, nil
+	}
+	f.adopted = append(f.adopted, vmID)
+	rec.State = types.VMStateRunning
+	rec.TransitionGeneration++
+	return rec.TransitionGeneration, nil
+}
+
+func (f *fakeSupervisor) RecoverTombstone(_ context.Context, vmID string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.resumed = append(f.resumed, vmID)
+	if f.resumeErr != nil {
+		return false, f.resumeErr
+	}
+	delete(f.records, vmID)
+	delete(f.tombstoned, vmID)
+	return true, nil
+}
+
+func (f *fakeSupervisor) CollectStaleCreate(_ context.Context, vmID string, _ *hypervisor.VMRecord) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.collected = append(f.collected, vmID)
+	delete(f.records, vmID)
+	return nil
 }
 
 func newFake() *fakeSupervisor {

--- a/daemon/watch_linux_test.go
+++ b/daemon/watch_linux_test.go
@@ -12,34 +12,6 @@ import (
 
 const exitWaitBudget = 5 * time.Second
 
-// startVictim launches a process the test can kill, returning its generation.
-func startVictim(t *testing.T) (*exec.Cmd, utils.ProcRef) {
-	t.Helper()
-	cmd := exec.Command("sleep", "30")
-	if err := cmd.Start(); err != nil {
-		t.Skipf("cannot start a victim process: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = cmd.Process.Kill()
-		_ = cmd.Wait()
-	})
-	proc, err := utils.ProcRefOf(cmd.Process.Pid)
-	if err != nil {
-		t.Fatalf("ProcRefOf: %v", err)
-	}
-	return cmd, proc
-}
-
-func startWatcher(t *testing.T) *procWatcher {
-	t.Helper()
-	w := newProcWatcher()
-	if err := w.start(t.Context()); err != nil {
-		t.Fatalf("start watcher: %v", err)
-	}
-	t.Cleanup(w.close)
-	return w
-}
-
 func TestWatcherReportsProcessExit(t *testing.T) {
 	cmd, proc := startVictim(t)
 	w := startWatcher(t)
@@ -115,4 +87,32 @@ func TestWatcherKeepsOtherBackendsOnDropAbsent(t *testing.T) {
 	if got := w.pidOf(key); got != proc.PID {
 		t.Errorf("got watched pid %d, want another backend's scan to leave this watch alone", got)
 	}
+}
+
+// startVictim launches a process the test can kill, returning its generation.
+func startVictim(t *testing.T) (*exec.Cmd, utils.ProcRef) {
+	t.Helper()
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Skipf("cannot start a victim process: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+	proc, err := utils.ProcRefOf(cmd.Process.Pid)
+	if err != nil {
+		t.Fatalf("ProcRefOf: %v", err)
+	}
+	return cmd, proc
+}
+
+func startWatcher(t *testing.T) *procWatcher {
+	t.Helper()
+	w := newProcWatcher()
+	if err := w.start(t.Context()); err != nil {
+		t.Fatalf("start watcher: %v", err)
+	}
+	t.Cleanup(w.close)
+	return w
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -48,7 +48,7 @@ cocoon
 │   └── import [flags] [FILE]      Import snapshot from archive (or stdin)
 ├── gc [flags]                     Remove unreferenced blobs, VM dirs; --snapshot for LRU snapshot eviction
 ├── meta
-│   ├── init                       Initialize a fresh sqlite meta store (requires meta_backend=sqlite)
+│   ├── init                       Initialize a fresh sqlite meta store (normally automatic on fresh roots)
 │   ├── convert                    Convert existing metadata to the configured meta_backend (crash-resumable)
 │   └── backup DEST                Back up the sqlite meta store to a single consistent file
 ├── daemon [flags]                 Supervise cocoon-managed VMs (optional resident process)
@@ -58,7 +58,7 @@ cocoon
 
 `daemon` is optional: every other command works standalone with no daemon running. See [Daemon](daemon.md).
 
-The meta engine is selected by `meta_backend` in the config: `json` (default) or `sqlite`; `meta convert` always converts TO the effective backend.
+The meta engine is selected by `meta_backend` in the config; unset auto-resolves — an existing store binds its engine (legacy json roots keep json), fresh roots get `sqlite` and bootstrap themselves. `meta convert` always converts TO the effective backend (default sqlite).
 
 ## Global Flags
 

--- a/doctor/check.sh
+++ b/doctor/check.sh
@@ -16,7 +16,7 @@ COCOON_RUN_DIR="${COCOON_RUN_DIR:-/var/lib/cocoon/run}"
 COCOON_LOG_DIR="${COCOON_LOG_DIR:-/var/log/cocoon}"
 COCOON_CNI_CONF_DIR="${COCOON_CNI_CONF_DIR:-/etc/cni/net.d}"
 COCOON_CNI_BIN_DIR="${COCOON_CNI_BIN_DIR:-/opt/cni/bin}"
-COCOON_META_BACKEND="${COCOON_META_BACKEND:-json}"
+COCOON_META_BACKEND="${COCOON_META_BACKEND:-}"
 
 # Dependency versions
 CH_VERSION="${CH_VERSION:-v53.0}"
@@ -64,7 +64,7 @@ Environment variables:
   CNI_VERSION   CNI plugins version         (default: ${CNI_VERSION})
   COCOON_ROOT_DIR / COCOON_RUN_DIR / COCOON_LOG_DIR
   COCOON_CNI_CONF_DIR / COCOON_CNI_BIN_DIR
-  COCOON_META_BACKEND Metadata engine       (default: ${COCOON_META_BACKEND})
+  COCOON_META_BACKEND Metadata engine       (default: auto — existing store wins, fresh roots get sqlite)
 EOF
             exit 0
             ;;
@@ -260,6 +260,18 @@ check_dir() {
 }
 
 check_dir "$COCOON_ROOT_DIR"
+
+# Mirror cocoon's auto-resolution: an existing store binds its engine, fresh
+# roots get sqlite.
+if [ -z "$COCOON_META_BACKEND" ]; then
+    if [ -e "$COCOON_ROOT_DIR/meta/meta.db" ]; then
+        COCOON_META_BACKEND=sqlite
+    elif [ -e "$COCOON_ROOT_DIR/cloudhypervisor/db/vms.json" ] || [ -e "$COCOON_ROOT_DIR/firecracker/db/vms.json" ]; then
+        COCOON_META_BACKEND=json
+    else
+        COCOON_META_BACKEND=sqlite
+    fi
+fi
 
 if [ "$COCOON_META_BACKEND" = "sqlite" ]; then
     # SQLite WAL needs coherent shared memory; report the same filesystem

--- a/doctor/check.sh
+++ b/doctor/check.sh
@@ -262,11 +262,17 @@ check_dir() {
 check_dir "$COCOON_ROOT_DIR"
 
 # Mirror cocoon's auto-resolution: an existing store binds its engine, fresh
-# roots get sqlite.
+# roots get sqlite. The json probe list matches MetaJSONNamespaces.
+legacy_json_present() {
+    for f in cloudhypervisor/db/vms.json firecracker/db/vms.json \
+        snapshot/db/snapshots.json oci/db/images.json cloudimg/db/images.json \
+        cni/db/networks.json metering/log.json; do
+        [ -e "$COCOON_ROOT_DIR/$f" ] && return 0
+    done
+    return 1
+}
 if [ -z "$COCOON_META_BACKEND" ]; then
-    if [ -e "$COCOON_ROOT_DIR/meta/meta.db" ]; then
-        COCOON_META_BACKEND=sqlite
-    elif [ -e "$COCOON_ROOT_DIR/cloudhypervisor/db/vms.json" ] || [ -e "$COCOON_ROOT_DIR/firecracker/db/vms.json" ]; then
+    if [ ! -e "$COCOON_ROOT_DIR/meta/meta.db" ] && legacy_json_present; then
         COCOON_META_BACKEND=json
     else
         COCOON_META_BACKEND=sqlite

--- a/hypervisor/choreo_trace_test.go
+++ b/hypervisor/choreo_trace_test.go
@@ -13,19 +13,6 @@ import (
 	"github.com/cocoonstack/cocoon/types"
 )
 
-type choreoStep struct {
-	Op       string   `json:"op"`
-	ErrClass string   `json:"err_class"`
-	ErrMsg   string   `json:"err_msg,omitempty"`
-	Result   string   `json:"result,omitempty"`
-	Metering []string `json:"metering,omitempty"`
-}
-
-type choreoTrace struct {
-	Steps      []choreoStep `json:"steps"`
-	FinalBytes string       `json:"final_bytes"`
-}
-
 // TestLegacyChoreographyTrace is the P0 differential gate (design §10): the
 // legacy implementation ran this exact op sequence and recorded returned
 // values, error identities and final bytes; the migrated boundary must
@@ -171,4 +158,17 @@ func TestLegacyChoreographyTrace(t *testing.T) {
 	if got := string(final); got != golden.FinalBytes {
 		t.Errorf("final namespace bytes drift:\n got: %s\nwant: %s", got, golden.FinalBytes)
 	}
+}
+
+type choreoStep struct {
+	Op       string   `json:"op"`
+	ErrClass string   `json:"err_class"`
+	ErrMsg   string   `json:"err_msg,omitempty"`
+	Result   string   `json:"result,omitempty"`
+	Metering []string `json:"metering,omitempty"`
+}
+
+type choreoTrace struct {
+	Steps      []choreoStep `json:"steps"`
+	FinalBytes string       `json:"final_bytes"`
 }

--- a/hypervisor/cloudhypervisor/clone_test.go
+++ b/hypervisor/cloudhypervisor/clone_test.go
@@ -331,6 +331,65 @@ func TestRestorePatchStorageConfigs_KeepsAllWhenSnapshotHadCidata(t *testing.T) 
 	}
 }
 
+func TestRestoreAndResumeCloneHotplugsCidataByRole(t *testing.T) {
+	// Short dir: t.TempDir embeds the test name and busts the unix sockaddr limit.
+	sockDir, err := os.MkdirTemp("", "ch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sockDir) })
+	sock := filepath.Join(sockDir, "a.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	var (
+		mu    sync.Mutex
+		added []string
+	)
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "vm.add-disk") {
+			var d chDisk
+			if err := json.NewDecoder(r.Body).Decode(&d); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			added = append(added, d.Path)
+			mu.Unlock()
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})}
+	go srv.Serve(ln) //nolint:errcheck
+	t.Cleanup(func() { _ = srv.Close() })
+
+	// Snapshot lacked cidata, so ensureCloneCidata appended one — and the clone's
+	// new --data-disk config landed after it. The hot-plug must pick the Role
+	// match, not the last element (which double-attached the data disk and never
+	// attached cidata).
+	storageConfigs := []*types.StorageConfig{
+		{Path: "/store/cow.raw", Role: types.StorageRoleCOW, Serial: "cocoon-cow"},
+		{Path: "/run/cidata.img", RO: true, Role: types.StorageRoleCidata},
+		{Path: "/run/extra.raw", Role: types.StorageRoleData, Serial: "extra"},
+	}
+	ch := &CloudHypervisor{}
+	if err := ch.restoreAndResumeClone(t.Context(), 0, sock, t.TempDir(), &cloneResumeOpts{
+		vmCfg:          &types.VMConfig{Config: types.Config{CPU: 2}},
+		storageConfigs: storageConfigs,
+		dataDisks:      storageConfigs[2:],
+		snapshotCfg:    &chVMConfig{},
+	}); err != nil {
+		t.Fatalf("restoreAndResumeClone: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	want := []string{"/run/cidata.img", "/run/extra.raw"}
+	if !slices.Equal(added, want) {
+		t.Fatalf("vm.add-disk paths = %v, want %v", added, want)
+	}
+}
+
 func writeCHConfig(t *testing.T, dir string, cfg map[string]any) string {
 	t.Helper()
 	path := filepath.Join(dir, "config.json")
@@ -444,64 +503,5 @@ func basePatchOpts() *patchOptions {
 		},
 		consoleSock: "/new/console.sock",
 		directBoot:  true,
-	}
-}
-
-func TestRestoreAndResumeCloneHotplugsCidataByRole(t *testing.T) {
-	// Short dir: t.TempDir embeds the test name and busts the unix sockaddr limit.
-	sockDir, err := os.MkdirTemp("", "ch")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(sockDir) })
-	sock := filepath.Join(sockDir, "a.sock")
-	ln, err := net.Listen("unix", sock)
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	var (
-		mu    sync.Mutex
-		added []string
-	)
-	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasSuffix(r.URL.Path, "vm.add-disk") {
-			var d chDisk
-			if err := json.NewDecoder(r.Body).Decode(&d); err != nil {
-				w.WriteHeader(http.StatusBadRequest)
-				return
-			}
-			mu.Lock()
-			added = append(added, d.Path)
-			mu.Unlock()
-		}
-		w.WriteHeader(http.StatusNoContent)
-	})}
-	go srv.Serve(ln) //nolint:errcheck
-	t.Cleanup(func() { _ = srv.Close() })
-
-	// Snapshot lacked cidata, so ensureCloneCidata appended one — and the clone's
-	// new --data-disk config landed after it. The hot-plug must pick the Role
-	// match, not the last element (which double-attached the data disk and never
-	// attached cidata).
-	storageConfigs := []*types.StorageConfig{
-		{Path: "/store/cow.raw", Role: types.StorageRoleCOW, Serial: "cocoon-cow"},
-		{Path: "/run/cidata.img", RO: true, Role: types.StorageRoleCidata},
-		{Path: "/run/extra.raw", Role: types.StorageRoleData, Serial: "extra"},
-	}
-	ch := &CloudHypervisor{}
-	if err := ch.restoreAndResumeClone(t.Context(), 0, sock, t.TempDir(), &cloneResumeOpts{
-		vmCfg:          &types.VMConfig{Config: types.Config{CPU: 2}},
-		storageConfigs: storageConfigs,
-		dataDisks:      storageConfigs[2:],
-		snapshotCfg:    &chVMConfig{},
-	}); err != nil {
-		t.Fatalf("restoreAndResumeClone: %v", err)
-	}
-
-	mu.Lock()
-	defer mu.Unlock()
-	want := []string{"/run/cidata.img", "/run/extra.raw"}
-	if !slices.Equal(added, want) {
-		t.Fatalf("vm.add-disk paths = %v, want %v", added, want)
 	}
 }

--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -32,6 +32,20 @@ type bindRedirectPlan struct {
 	leases []*vmlock.SharedLease
 }
 
+func (p *bindRedirectPlan) files() []*os.File {
+	files := make([]*os.File, 0, len(p.leases))
+	for _, lease := range p.leases {
+		files = append(files, lease.File())
+	}
+	return files
+}
+
+func (p *bindRedirectPlan) close() {
+	for _, lease := range slices.Backward(p.leases) {
+		_ = lease.Close()
+	}
+}
+
 func (fc *Firecracker) Clone(ctx context.Context, vmID string, vmCfg *types.VMConfig, net types.NetSetup, snapshotConfig *types.SnapshotConfig, snapshot io.Reader) (*types.VM, error) {
 	return fc.CloneFromStream(ctx, vmID, vmCfg, net, snapshotConfig, snapshot, fc.cloneAfterExtract)
 }
@@ -351,20 +365,6 @@ func classifySource(path string) (bool, error) {
 		return false, nil
 	default:
 		return false, fmt.Errorf("inspect source %s: %w", path, err)
-	}
-}
-
-func (p *bindRedirectPlan) files() []*os.File {
-	files := make([]*os.File, 0, len(p.leases))
-	for _, lease := range p.leases {
-		files = append(files, lease.File())
-	}
-	return files
-}
-
-func (p *bindRedirectPlan) close() {
-	for _, lease := range slices.Backward(p.leases) {
-		_ = lease.Close()
 	}
 }
 

--- a/hypervisor/firecracker/clone_test.go
+++ b/hypervisor/firecracker/clone_test.go
@@ -312,6 +312,30 @@ func TestRedirectBinds(t *testing.T) {
 	}
 }
 
+// A symlink source is unusable outright: the legacy redirect residue it could represent is no longer healed.
+func TestHoldBindableRedirectsRejectsSymlinkSource(t *testing.T) {
+	fc := newTestFC(t)
+	srcDir := fc.Conf.VMRunDir("SRC")
+	if err := os.MkdirAll(srcDir, 0o750); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	target := writeTestFile(t, srcDir, "real.raw")
+	link := filepath.Join(srcDir, "cow.raw")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	src := []*types.StorageConfig{{Path: link, Role: types.StorageRoleCOW}}
+	dst := []*types.StorageConfig{{Path: filepath.Join(t.TempDir(), "clone.raw"), Role: types.StorageRoleCOW}}
+	_, err := holdBindableRedirects(t.Context(), fc.Conf.RootDirPath(), fc.Conf.RunDir(), src, dst, func(string) (bool, error) {
+		t.Fatal("record lookup must not run for a symlink source")
+		return false, nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "not a regular file") {
+		t.Fatalf("got %v, want a not-a-regular-file rejection", err)
+	}
+}
+
 func newTestFC(t *testing.T) *Firecracker {
 	t.Helper()
 	dir := t.TempDir()
@@ -348,28 +372,4 @@ func writeTestFile(t *testing.T, dir, name string) string {
 		t.Fatalf("setup %s: %v", name, err)
 	}
 	return p
-}
-
-// A symlink source is unusable outright: the legacy redirect residue it could represent is no longer healed.
-func TestHoldBindableRedirectsRejectsSymlinkSource(t *testing.T) {
-	fc := newTestFC(t)
-	srcDir := fc.Conf.VMRunDir("SRC")
-	if err := os.MkdirAll(srcDir, 0o750); err != nil {
-		t.Fatalf("setup: %v", err)
-	}
-	target := writeTestFile(t, srcDir, "real.raw")
-	link := filepath.Join(srcDir, "cow.raw")
-	if err := os.Symlink(target, link); err != nil {
-		t.Fatalf("symlink: %v", err)
-	}
-
-	src := []*types.StorageConfig{{Path: link, Role: types.StorageRoleCOW}}
-	dst := []*types.StorageConfig{{Path: filepath.Join(t.TempDir(), "clone.raw"), Role: types.StorageRoleCOW}}
-	_, err := holdBindableRedirects(t.Context(), fc.Conf.RootDirPath(), fc.Conf.RunDir(), src, dst, func(string) (bool, error) {
-		t.Fatal("record lookup must not run for a symlink source")
-		return false, nil
-	})
-	if err == nil || !strings.Contains(err.Error(), "not a regular file") {
-		t.Fatalf("got %v, want a not-a-regular-file rejection", err)
-	}
 }

--- a/hypervisor/firecracker/create_test.go
+++ b/hypervisor/firecracker/create_test.go
@@ -91,6 +91,26 @@ func TestDecompressKernel(t *testing.T) {
 	}
 }
 
+func TestCreateRejectsUnsupportedMemoryConfig(t *testing.T) {
+	fc := &Firecracker{}
+	tests := []struct {
+		name string
+		cfg  types.Config
+		want string
+	}{
+		{"shared memory", types.Config{SharedMemory: true}, "shared memory"},
+		{"hugepages", types.Config{HugePages: true}, "hugepages"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := fc.Create(t.Context(), "vm1", &types.VMConfig{Config: tt.cfg}, nil, types.NetSetup{}, nil)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("got %v, want a %q rejection", err, tt.want)
+			}
+		})
+	}
+}
+
 func fakeELF() []byte {
 	out := []byte{0x7f, 'E', 'L', 'F'}
 	out = append(out, bytes.Repeat([]byte{0x00}, 60)...)
@@ -121,24 +141,4 @@ func zstdCompress(t *testing.T, data []byte) []byte {
 		t.Fatalf("zstd close: %v", err)
 	}
 	return out
-}
-
-func TestCreateRejectsUnsupportedMemoryConfig(t *testing.T) {
-	fc := &Firecracker{}
-	tests := []struct {
-		name string
-		cfg  types.Config
-		want string
-	}{
-		{"shared memory", types.Config{SharedMemory: true}, "shared memory"},
-		{"hugepages", types.Config{HugePages: true}, "hugepages"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := fc.Create(t.Context(), "vm1", &types.VMConfig{Config: tt.cfg}, nil, types.NetSetup{}, nil)
-			if err == nil || !strings.Contains(err.Error(), tt.want) {
-				t.Fatalf("got %v, want a %q rejection", err, tt.want)
-			}
-		})
-	}
 }

--- a/hypervisor/hibernate_test.go
+++ b/hypervisor/hibernate_test.go
@@ -16,11 +16,6 @@ import (
 	"github.com/cocoonstack/cocoon/utils"
 )
 
-type hibernateCalls struct {
-	resumed    bool
-	terminated bool
-}
-
 func TestHibernateSequencePersistFailureResumesAndRollsBack(t *testing.T) {
 	b, id := newHibernateTestVM(t)
 	calls := &hibernateCalls{}
@@ -113,6 +108,11 @@ func TestHibernateSequenceTerminateFailureMarksError(t *testing.T) {
 	if len(rec.SnapshotIDs) != 1 {
 		t.Errorf("persisted snapshot id missing from record: %v", rec.SnapshotIDs)
 	}
+}
+
+type hibernateCalls struct {
+	resumed    bool
+	terminated bool
 }
 
 // newHibernateTestVM seeds a running VM whose RunDir holds a live stub VMM process, so WithRunningVM lets the sequence proceed.

--- a/hypervisor/meta_test.go
+++ b/hypervisor/meta_test.go
@@ -22,57 +22,6 @@ var testVMTables = metajson.TableCodec{Specs: []metajson.TableSpec{
 	{Key: "tombstones", Table: tombstone.TableName, Optional: true},
 }}
 
-// VMIndex mirrors the legacy whole-index shape for shim-based tests.
-type VMIndex struct {
-	VMs        map[string]*VMRecord `json:"vms"`
-	Names      map[string]string    `json:"names"`
-	OrphanDirs []string             `json:"orphan_dirs,omitempty"`
-}
-
-func (idx *VMIndex) Init() {
-	if idx.VMs == nil {
-		idx.VMs = map[string]*VMRecord{}
-	}
-	if idx.Names == nil {
-		idx.Names = map[string]string{}
-	}
-}
-
-// dbUpdate is the test-only whole-index shim: materialize, run fn, write the
-// difference back. Production code never uses it.
-func (b *Backend) dbUpdate(ctx context.Context, fn func(*VMIndex) error) error {
-	return b.update(ctx, func(t *vmTx) error {
-		before, idx, err := materialize(t)
-		if err != nil {
-			return err
-		}
-		if err := fn(idx); err != nil {
-			return err
-		}
-		return writeBack(t, before, idx)
-	})
-}
-
-// dbRead is the test-only whole-index read shim.
-func (b *Backend) dbRead(ctx context.Context, fn func(*VMIndex) error) error {
-	return b.view(ctx, func(t *vmTx) error {
-		_, idx, err := materialize(t)
-		if err != nil {
-			return err
-		}
-		return fn(idx)
-	})
-}
-
-// addOrphanDir survives only for fixtures/shims: production writes cleanup
-// intent through tombstone payloads now.
-func (t *vmTx) addOrphanDir(dir string) error {
-	if _, ok, err := t.w.GetRaw(t.ctx, t.ns, TableOrphanDirs, dir); err != nil || ok {
-		return err
-	}
-	return t.w.PutRaw(t.ctx, t.ns, TableOrphanDirs, dir, json.RawMessage(`{}`), false)
-}
-
 // TestLegacyDifferentialTrace replays the fixture op sequence over meta-json
 // and requires byte-identical output to what the LEGACY storage layer wrote
 // for the same operations (fixtures generated at master by cmd/fixturegen).
@@ -175,6 +124,57 @@ func TestCrossComponentVMLockPath(t *testing.T) {
 	if _, statErr := os.Stat(vmlock.Path(b.Conf.RootDirPath(), id)); statErr != nil {
 		t.Fatalf("lock file not at the shared path: %v", statErr)
 	}
+}
+
+// VMIndex mirrors the legacy whole-index shape for shim-based tests.
+type VMIndex struct {
+	VMs        map[string]*VMRecord `json:"vms"`
+	Names      map[string]string    `json:"names"`
+	OrphanDirs []string             `json:"orphan_dirs,omitempty"`
+}
+
+func (idx *VMIndex) Init() {
+	if idx.VMs == nil {
+		idx.VMs = map[string]*VMRecord{}
+	}
+	if idx.Names == nil {
+		idx.Names = map[string]string{}
+	}
+}
+
+// dbUpdate is the test-only whole-index shim: materialize, run fn, write the
+// difference back. Production code never uses it.
+func (b *Backend) dbUpdate(ctx context.Context, fn func(*VMIndex) error) error {
+	return b.update(ctx, func(t *vmTx) error {
+		before, idx, err := materialize(t)
+		if err != nil {
+			return err
+		}
+		if err := fn(idx); err != nil {
+			return err
+		}
+		return writeBack(t, before, idx)
+	})
+}
+
+// dbRead is the test-only whole-index read shim.
+func (b *Backend) dbRead(ctx context.Context, fn func(*VMIndex) error) error {
+	return b.view(ctx, func(t *vmTx) error {
+		_, idx, err := materialize(t)
+		if err != nil {
+			return err
+		}
+		return fn(idx)
+	})
+}
+
+// addOrphanDir survives only for fixtures/shims: production writes cleanup
+// intent through tombstone payloads now.
+func (t *vmTx) addOrphanDir(dir string) error {
+	if _, ok, err := t.w.GetRaw(t.ctx, t.ns, TableOrphanDirs, dir); err != nil || ok {
+		return err
+	}
+	return t.w.PutRaw(t.ctx, t.ns, TableOrphanDirs, dir, json.RawMessage(`{}`), false)
 }
 
 // newTestMetaStore opens a meta store over the given index paths for one backend type.

--- a/hypervisor/meta_test.go
+++ b/hypervisor/meta_test.go
@@ -22,28 +22,6 @@ var testVMTables = metajson.TableCodec{Specs: []metajson.TableSpec{
 	{Key: "tombstones", Table: tombstone.TableName, Optional: true},
 }}
 
-// newTestMetaStore opens a meta store over the given index paths for one backend type.
-func newTestMetaStore(t *testing.T, typ, indexFile, lockPath string) *metajson.Store {
-	t.Helper()
-	store, err := metajson.Open(metajson.Namespace{Name: VMNamespaceName(typ), FilePath: indexFile, LockPath: lockPath, Codec: testVMTables})
-	if err != nil {
-		t.Fatalf("open meta store: %v", err)
-	}
-	t.Cleanup(func() { _ = store.Close() })
-	return store
-}
-
-// testNamespace builds a standalone namespace under dir for shim-level tests.
-func testNamespace(t *testing.T, typ, dir string) *metajson.Store {
-	t.Helper()
-	store, err := metajson.Open(metajson.Namespace{Name: VMNamespaceName(typ), FilePath: filepath.Join(dir, "index.json"), LockPath: filepath.Join(dir, "index.lock"), Codec: testVMTables})
-	if err != nil {
-		t.Fatalf("open meta store: %v", err)
-	}
-	t.Cleanup(func() { _ = store.Close() })
-	return store
-}
-
 // VMIndex mirrors the legacy whole-index shape for shim-based tests.
 type VMIndex struct {
 	VMs        map[string]*VMRecord `json:"vms"`
@@ -84,71 +62,6 @@ func (b *Backend) dbRead(ctx context.Context, fn func(*VMIndex) error) error {
 		}
 		return fn(idx)
 	})
-}
-
-func materialize(t *vmTx) (*VMIndex, *VMIndex, error) {
-	idx := &VMIndex{}
-	idx.Init()
-	var err error
-	if idx.VMs, err = t.All(); err != nil {
-		return nil, nil, err
-	}
-	if err := t.r.ScanRaw(t.ctx, t.ns, TableNames, func(name string, _ json.RawMessage) error {
-		id, ok, err := t.NameGet(name)
-		if err != nil || !ok {
-			return err
-		}
-		idx.Names[name] = id
-		return nil
-	}); err != nil {
-		return nil, nil, err
-	}
-	if idx.OrphanDirs, err = t.orphanDirs(); err != nil {
-		return nil, nil, err
-	}
-	snapshot := &VMIndex{VMs: maps.Clone(idx.VMs), Names: maps.Clone(idx.Names), OrphanDirs: append([]string(nil), idx.OrphanDirs...)}
-	return snapshot, idx, nil
-}
-
-func writeBack(t *vmTx, before, after *VMIndex) error {
-	for id := range before.VMs {
-		if after.VMs[id] == nil {
-			if err := t.Del(id); err != nil {
-				return err
-			}
-		}
-	}
-	for id, rec := range after.VMs {
-		if rec == nil {
-			continue
-		}
-		if err := t.Put(id, rec); err != nil {
-			return err
-		}
-	}
-	for name := range before.Names {
-		if _, ok := after.Names[name]; !ok {
-			if err := t.NameDel(name); err != nil {
-				return err
-			}
-		}
-	}
-	for name, id := range after.Names {
-		if err := t.NameSet(name, id); err != nil {
-			return err
-		}
-	}
-	for _, dir := range before.OrphanDirs {
-		if err := t.removeOrphanDir(dir); err != nil {
-			return err
-		}
-	}
-	for _, dir := range after.OrphanDirs {
-		if err := t.addOrphanDir(dir); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // addOrphanDir survives only for fixtures/shims: production writes cleanup
@@ -262,4 +175,91 @@ func TestCrossComponentVMLockPath(t *testing.T) {
 	if _, statErr := os.Stat(vmlock.Path(b.Conf.RootDirPath(), id)); statErr != nil {
 		t.Fatalf("lock file not at the shared path: %v", statErr)
 	}
+}
+
+// newTestMetaStore opens a meta store over the given index paths for one backend type.
+func newTestMetaStore(t *testing.T, typ, indexFile, lockPath string) *metajson.Store {
+	t.Helper()
+	store, err := metajson.Open(metajson.Namespace{Name: VMNamespaceName(typ), FilePath: indexFile, LockPath: lockPath, Codec: testVMTables})
+	if err != nil {
+		t.Fatalf("open meta store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// testNamespace builds a standalone namespace under dir for shim-level tests.
+func testNamespace(t *testing.T, typ, dir string) *metajson.Store {
+	t.Helper()
+	store, err := metajson.Open(metajson.Namespace{Name: VMNamespaceName(typ), FilePath: filepath.Join(dir, "index.json"), LockPath: filepath.Join(dir, "index.lock"), Codec: testVMTables})
+	if err != nil {
+		t.Fatalf("open meta store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func materialize(t *vmTx) (*VMIndex, *VMIndex, error) {
+	idx := &VMIndex{}
+	idx.Init()
+	var err error
+	if idx.VMs, err = t.All(); err != nil {
+		return nil, nil, err
+	}
+	if err := t.r.ScanRaw(t.ctx, t.ns, TableNames, func(name string, _ json.RawMessage) error {
+		id, ok, err := t.NameGet(name)
+		if err != nil || !ok {
+			return err
+		}
+		idx.Names[name] = id
+		return nil
+	}); err != nil {
+		return nil, nil, err
+	}
+	if idx.OrphanDirs, err = t.orphanDirs(); err != nil {
+		return nil, nil, err
+	}
+	snapshot := &VMIndex{VMs: maps.Clone(idx.VMs), Names: maps.Clone(idx.Names), OrphanDirs: append([]string(nil), idx.OrphanDirs...)}
+	return snapshot, idx, nil
+}
+
+func writeBack(t *vmTx, before, after *VMIndex) error {
+	for id := range before.VMs {
+		if after.VMs[id] == nil {
+			if err := t.Del(id); err != nil {
+				return err
+			}
+		}
+	}
+	for id, rec := range after.VMs {
+		if rec == nil {
+			continue
+		}
+		if err := t.Put(id, rec); err != nil {
+			return err
+		}
+	}
+	for name := range before.Names {
+		if _, ok := after.Names[name]; !ok {
+			if err := t.NameDel(name); err != nil {
+				return err
+			}
+		}
+	}
+	for name, id := range after.Names {
+		if err := t.NameSet(name, id); err != nil {
+			return err
+		}
+	}
+	for _, dir := range before.OrphanDirs {
+		if err := t.removeOrphanDir(dir); err != nil {
+			return err
+		}
+	}
+	for _, dir := range after.OrphanDirs {
+		if err := t.addOrphanDir(dir); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/hypervisor/restore.go
+++ b/hypervisor/restore.go
@@ -45,14 +45,6 @@ func (b *Backend) ResolveForRestore(ctx context.Context, vmRef string) (string, 
 	return vmID, &rec, nil
 }
 
-// restorableState allows Running, Stopped and Error origins. Stopped restores too (hibernate resume): the sequence cold-spawns a fresh VMM either way and the kill step tolerates a dead one. Error VMs are allowed through (quarantine sets Error too) — restore rebuilds the run dir, so it is the recovery path start.go redirects a crashed restore to; failRestore leaves a running-origin failure in Error with no quarantine reason, and rejecting it here would dead-end at vm rm.
-func restorableState(vmID string, rec *VMRecord) error {
-	if rec.State != types.VMStateRunning && rec.State != types.VMStateStopped && rec.State != types.VMStateError {
-		return fmt.Errorf("vm %s is %s and cannot be restored", vmID, rec.State)
-	}
-	return nil
-}
-
 func (b *Backend) FinalizeRestore(ctx context.Context, vmID string, vmCfg *types.VMConfig, rec *VMRecord, pid int) (*types.VM, error) {
 	now := timeNow()
 	if err := b.UpdateRecord(ctx, vmID, func(r *VMRecord) error {
@@ -258,6 +250,14 @@ func PrepareStagingDir(runDir string, snapshot io.Reader) (stagingDir string, cl
 		return "", nil, fmt.Errorf("extract snapshot: %w", err)
 	}
 	return stagingDir, cleanup, nil
+}
+
+// restorableState allows Running, Stopped and Error origins. Stopped restores too (hibernate resume): the sequence cold-spawns a fresh VMM either way and the kill step tolerates a dead one. Error VMs are allowed through (quarantine sets Error too) — restore rebuilds the run dir, so it is the recovery path start.go redirects a crashed restore to; failRestore leaves a running-origin failure in Error with no quarantine reason, and rejecting it here would dead-end at vm rm.
+func restorableState(vmID string, rec *VMRecord) error {
+	if rec.State != types.VMStateRunning && rec.State != types.VMStateStopped && rec.State != types.VMStateError {
+		return fmt.Errorf("vm %s is %s and cannot be restored", vmID, rec.State)
+	}
+	return nil
 }
 
 func markRestoreDirty(runDir string) error {

--- a/hypervisor/state_test.go
+++ b/hypervisor/state_test.go
@@ -537,6 +537,95 @@ func TestNewBackendNilRecorderDefaultsToNop(t *testing.T) {
 	}
 }
 
+func TestPrepareStartRefusesQuarantined(t *testing.T) {
+	b, _ := newMeteringTestBackend(t)
+	ctx := t.Context()
+	seedVMRecord(t, b, "vm1", 1, 1<<30, 10<<30, true)
+
+	b.QuarantineVM(ctx, "vm1", "partial snapshot merge")
+	if _, err := b.PrepareStart(ctx, "vm1", nil); err == nil {
+		t.Fatal("PrepareStart must refuse a quarantined VM")
+	}
+
+	// Stop's state flip must not lift the quarantine.
+	if err := b.UpdateStates(ctx, []string{"vm1"}, types.VMStateStopped); err != nil {
+		t.Fatalf("UpdateStates: %v", err)
+	}
+	if _, err := b.PrepareStart(ctx, "vm1", nil); err == nil {
+		t.Fatal("PrepareStart must refuse a quarantined VM after stop rewrote the state")
+	}
+}
+
+func TestPrepareStartRefusesInterruptedRestore(t *testing.T) {
+	b, _ := newMeteringTestBackend(t)
+	ctx := t.Context()
+	const id = "vm-staging"
+	seedVMRecord(t, b, id, 1, 1<<30, 10<<30, true)
+	runDir := t.TempDir()
+	if err := b.dbUpdate(ctx, func(idx *VMIndex) error {
+		idx.VMs[id].State = types.VMStateStopped
+		idx.VMs[id].RunDir = runDir
+		idx.VMs[id].LogDir = runDir
+		return nil
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(runDir, restoreDirtyName), nil, 0o600); err != nil {
+		t.Fatalf("mk tombstone: %v", err)
+	}
+	if _, err := b.PrepareStart(ctx, id, nil); err == nil {
+		t.Fatal("PrepareStart must refuse a run dir with a restore-dirty tombstone")
+	}
+}
+
+func TestPrepareStartRefusesCreating(t *testing.T) {
+	b, _ := newMeteringTestBackend(t)
+	ctx := t.Context()
+	if err := b.ReserveVM(ctx, "vm1", &types.VMConfig{Name: "n1"}, nil, t.TempDir(), t.TempDir()); err != nil {
+		t.Fatalf("ReserveVM: %v", err)
+	}
+	if _, err := b.PrepareStart(ctx, "vm1", nil); err == nil {
+		t.Fatal("PrepareStart must refuse a creating placeholder")
+	}
+}
+
+// TestForcedRetryStateOps is the design §10 gate: the migrated
+// UpdateStates/BatchMarkStarted run on a forced-retry engine (every closure
+// executes twice) and must emit each metering entry exactly once.
+func TestForcedRetryStateOps(t *testing.T) {
+	const typ = "test-hv"
+	dir := t.TempDir()
+	rec := meteringcapture.New()
+	b := &Backend{
+		Typ:      typ,
+		NS:       VMNamespaceName(typ),
+		Conf:     meteringStubConfig{stubBackendConfig: stubBackendConfig{rootDir: dir}, vmRunRoot: dir},
+		Meta:     contracttest.ForcedRetry(testNamespace(t, typ, dir)),
+		Metering: rec,
+	}
+	ctx := t.Context()
+	seedVMRecord(t, b, "vm1", 2, 1<<30, 10<<30, false)
+
+	if err := b.BatchMarkStarted(ctx, []string{"vm1"}); err != nil {
+		t.Fatalf("BatchMarkStarted under forced retry: %v", err)
+	}
+	if starts := rec.Entries(); len(starts) != 1 || starts[0].Kind != metering.KindVMComputeStart {
+		t.Fatalf("want exactly one compute.start, got %+v", starts)
+	}
+	rec.Reset()
+
+	if err := b.UpdateStates(ctx, []string{"vm1"}, types.VMStateStopped); err != nil {
+		t.Fatalf("UpdateStates under forced retry: %v", err)
+	}
+	if stops := rec.Entries(); len(stops) != 1 || stops[0].Kind != metering.KindVMComputeStop {
+		t.Fatalf("want exactly one compute.stop, got %+v", stops)
+	}
+	loaded, err := b.LoadRecord(ctx, "vm1")
+	if err != nil || loaded.State != types.VMStateStopped {
+		t.Fatalf("state after forced-retry ops: %+v %v", loaded, err)
+	}
+}
+
 func newDiskStubConfig(t *testing.T) stubBackendConfig {
 	dir := t.TempDir()
 	return stubBackendConfig{
@@ -630,94 +719,5 @@ func seedRunningVM(t *testing.T, b *Backend, id string, cpu int, mem, storage in
 		return nil
 	}); err != nil {
 		t.Fatalf("set running: %v", err)
-	}
-}
-
-func TestPrepareStartRefusesQuarantined(t *testing.T) {
-	b, _ := newMeteringTestBackend(t)
-	ctx := t.Context()
-	seedVMRecord(t, b, "vm1", 1, 1<<30, 10<<30, true)
-
-	b.QuarantineVM(ctx, "vm1", "partial snapshot merge")
-	if _, err := b.PrepareStart(ctx, "vm1", nil); err == nil {
-		t.Fatal("PrepareStart must refuse a quarantined VM")
-	}
-
-	// Stop's state flip must not lift the quarantine.
-	if err := b.UpdateStates(ctx, []string{"vm1"}, types.VMStateStopped); err != nil {
-		t.Fatalf("UpdateStates: %v", err)
-	}
-	if _, err := b.PrepareStart(ctx, "vm1", nil); err == nil {
-		t.Fatal("PrepareStart must refuse a quarantined VM after stop rewrote the state")
-	}
-}
-
-func TestPrepareStartRefusesInterruptedRestore(t *testing.T) {
-	b, _ := newMeteringTestBackend(t)
-	ctx := t.Context()
-	const id = "vm-staging"
-	seedVMRecord(t, b, id, 1, 1<<30, 10<<30, true)
-	runDir := t.TempDir()
-	if err := b.dbUpdate(ctx, func(idx *VMIndex) error {
-		idx.VMs[id].State = types.VMStateStopped
-		idx.VMs[id].RunDir = runDir
-		idx.VMs[id].LogDir = runDir
-		return nil
-	}); err != nil {
-		t.Fatalf("seed: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(runDir, restoreDirtyName), nil, 0o600); err != nil {
-		t.Fatalf("mk tombstone: %v", err)
-	}
-	if _, err := b.PrepareStart(ctx, id, nil); err == nil {
-		t.Fatal("PrepareStart must refuse a run dir with a restore-dirty tombstone")
-	}
-}
-
-func TestPrepareStartRefusesCreating(t *testing.T) {
-	b, _ := newMeteringTestBackend(t)
-	ctx := t.Context()
-	if err := b.ReserveVM(ctx, "vm1", &types.VMConfig{Name: "n1"}, nil, t.TempDir(), t.TempDir()); err != nil {
-		t.Fatalf("ReserveVM: %v", err)
-	}
-	if _, err := b.PrepareStart(ctx, "vm1", nil); err == nil {
-		t.Fatal("PrepareStart must refuse a creating placeholder")
-	}
-}
-
-// TestForcedRetryStateOps is the design §10 gate: the migrated
-// UpdateStates/BatchMarkStarted run on a forced-retry engine (every closure
-// executes twice) and must emit each metering entry exactly once.
-func TestForcedRetryStateOps(t *testing.T) {
-	const typ = "test-hv"
-	dir := t.TempDir()
-	rec := meteringcapture.New()
-	b := &Backend{
-		Typ:      typ,
-		NS:       VMNamespaceName(typ),
-		Conf:     meteringStubConfig{stubBackendConfig: stubBackendConfig{rootDir: dir}, vmRunRoot: dir},
-		Meta:     contracttest.ForcedRetry(testNamespace(t, typ, dir)),
-		Metering: rec,
-	}
-	ctx := t.Context()
-	seedVMRecord(t, b, "vm1", 2, 1<<30, 10<<30, false)
-
-	if err := b.BatchMarkStarted(ctx, []string{"vm1"}); err != nil {
-		t.Fatalf("BatchMarkStarted under forced retry: %v", err)
-	}
-	if starts := rec.Entries(); len(starts) != 1 || starts[0].Kind != metering.KindVMComputeStart {
-		t.Fatalf("want exactly one compute.start, got %+v", starts)
-	}
-	rec.Reset()
-
-	if err := b.UpdateStates(ctx, []string{"vm1"}, types.VMStateStopped); err != nil {
-		t.Fatalf("UpdateStates under forced retry: %v", err)
-	}
-	if stops := rec.Entries(); len(stops) != 1 || stops[0].Kind != metering.KindVMComputeStop {
-		t.Fatalf("want exactly one compute.stop, got %+v", stops)
-	}
-	loaded, err := b.LoadRecord(ctx, "vm1")
-	if err != nil || loaded.State != types.VMStateStopped {
-		t.Fatalf("state after forced-retry ops: %+v %v", loaded, err)
 	}
 }

--- a/hypervisor/stop_test.go
+++ b/hypervisor/stop_test.go
@@ -186,18 +186,6 @@ func TestDeleteAllRefusesLiveAPISocket(t *testing.T) {
 	}
 }
 
-// shortTempDir is a /tmp-based TempDir: unix socket paths built under
-// t.TempDir() can exceed the ~104-byte sockaddr cap (EINVAL on dial).
-func shortTempDir(t *testing.T) string {
-	t.Helper()
-	dir, err := os.MkdirTemp("/tmp", "cocoon-test-")
-	if err != nil {
-		t.Fatalf("temp dir: %v", err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
-	return dir
-}
-
 func TestDeleteMigratedVMClearsCleanupIntent(t *testing.T) {
 	b, _ := newMeteringTestBackend(t)
 	ctx := t.Context()
@@ -260,4 +248,16 @@ func TestDeleteForceEmitsOneComputeStop(t *testing.T) {
 	if stops != 1 {
 		t.Errorf("got %d vm.compute.stop for one start, want 1: %+v", stops, rec.Entries())
 	}
+}
+
+// shortTempDir is a /tmp-based TempDir: unix socket paths built under
+// t.TempDir() can exceed the ~104-byte sockaddr cap (EINVAL on dial).
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "cocoon-test-")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
 }

--- a/hypervisor/supervisor_test.go
+++ b/hypervisor/supervisor_test.go
@@ -10,33 +10,6 @@ import (
 	"github.com/cocoonstack/cocoon/types"
 )
 
-// seedPlumbedVM gives a running VM the persisted network state a stop must quiesce.
-func seedPlumbedVM(t *testing.T, b *Backend, id string) {
-	t.Helper()
-	seedRunningVM(t, b, id, 1, 1<<30, 10<<30)
-	if err := b.dbUpdate(t.Context(), func(idx *VMIndex) error {
-		idx.VMs[id].NetSetup = types.NetSetup{
-			NetBackend:     types.BackendCNI,
-			NetworkConfigs: []*types.NetworkConfig{{}},
-		}
-		return nil
-	}); err != nil {
-		t.Fatalf("seed network: %v", err)
-	}
-}
-
-func recordOf(t *testing.T, b *Backend, id string) *VMRecord {
-	t.Helper()
-	rec, err := b.PeekRecord(t.Context(), id)
-	if err != nil {
-		t.Fatalf("peek %s: %v", id, err)
-	}
-	if rec == nil {
-		t.Fatalf("record %s is gone", id)
-	}
-	return rec
-}
-
 func TestConvergeDeadMarksUnexpectedExit(t *testing.T) {
 	b, rec := newMeteringTestBackend(t)
 	ctx := t.Context()
@@ -359,4 +332,31 @@ func TestUpdateStatesLeavesACreatedRecordUndated(t *testing.T) {
 	if got := recordOf(t, b, "vm1"); got.StoppedAt != nil {
 		t.Errorf("got StoppedAt %v for a VM that never ran, want nil", got.StoppedAt)
 	}
+}
+
+// seedPlumbedVM gives a running VM the persisted network state a stop must quiesce.
+func seedPlumbedVM(t *testing.T, b *Backend, id string) {
+	t.Helper()
+	seedRunningVM(t, b, id, 1, 1<<30, 10<<30)
+	if err := b.dbUpdate(t.Context(), func(idx *VMIndex) error {
+		idx.VMs[id].NetSetup = types.NetSetup{
+			NetBackend:     types.BackendCNI,
+			NetworkConfigs: []*types.NetworkConfig{{}},
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("seed network: %v", err)
+	}
+}
+
+func recordOf(t *testing.T, b *Backend, id string) *VMRecord {
+	t.Helper()
+	rec, err := b.PeekRecord(t.Context(), id)
+	if err != nil {
+		t.Fatalf("peek %s: %v", id, err)
+	}
+	if rec == nil {
+		t.Fatalf("record %s is gone", id)
+	}
+	return rec
 }

--- a/hypervisor/teardown_test.go
+++ b/hypervisor/teardown_test.go
@@ -11,28 +11,6 @@ import (
 	"github.com/cocoonstack/cocoon/types"
 )
 
-func seedProtoVM(t *testing.T, b *Backend, id string) *VMRecord {
-	t.Helper()
-	runDir, logDir := t.TempDir(), t.TempDir()
-	if err := os.WriteFile(filepath.Join(runDir, "cow.raw"), []byte("x"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := b.ReserveVM(t.Context(), id, &types.VMConfig{Name: "proto-" + id}, nil, runDir, logDir); err != nil {
-		t.Fatalf("reserve: %v", err)
-	}
-	if err := b.UpdateRecord(t.Context(), id, func(r *VMRecord) error {
-		r.State = types.VMStateStopped
-		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
-	rec, err := b.LoadRecord(t.Context(), id)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return &rec
-}
-
 func TestDeleteProtocolFullRun(t *testing.T) {
 	b, _ := newMeteringTestBackend(t)
 	ctx := t.Context()
@@ -307,6 +285,28 @@ func TestPrepareStartRefusesMidDeleting(t *testing.T) {
 	if len(netTorn) != 1 || netTorn[0] != "vmentry1" {
 		t.Fatalf("entry-driven recovery skipped the injected network cleanup: %v", netTorn)
 	}
+}
+
+func seedProtoVM(t *testing.T, b *Backend, id string) *VMRecord {
+	t.Helper()
+	runDir, logDir := t.TempDir(), t.TempDir()
+	if err := os.WriteFile(filepath.Join(runDir, "cow.raw"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.ReserveVM(t.Context(), id, &types.VMConfig{Name: "proto-" + id}, nil, runDir, logDir); err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if err := b.UpdateRecord(t.Context(), id, func(r *VMRecord) error {
+		r.State = types.VMStateStopped
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	rec, err := b.LoadRecord(t.Context(), id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &rec
 }
 
 // stubNetwork stands in for the injected host-networking seam; unset hooks are no-ops.

--- a/images/gc_test.go
+++ b/images/gc_test.go
@@ -13,10 +13,6 @@ import (
 	"github.com/cocoonstack/cocoon/meta/tombstone"
 )
 
-type gcTestEntry struct {
-	Digest string `json:"digest"`
-}
-
 var testImageTables = metajson.TableCodec{Specs: []metajson.TableSpec{
 	{Key: "images", Table: TableRecords},
 	{Key: "tombstones", Table: tombstone.TableName, Optional: true},
@@ -79,13 +75,6 @@ func TestGCCollectSkipsRepublishedBlob(t *testing.T) {
 	if len(removed) != 1 || removed[0] != "deadbeef" {
 		t.Fatalf("unreferenced blob not collected: %v", removed)
 	}
-}
-
-type fixtureEntry struct {
-	Ref       string    `json:"ref"`
-	Digest    string    `json:"manifest_digest"`
-	Size      int64     `json:"size"`
-	CreatedAt time.Time `json:"created_at"`
 }
 
 // TestLegacyDifferentialTrace replays the fixture op sequence over meta-json
@@ -215,4 +204,15 @@ func TestPinBlobs(t *testing.T) {
 	if _, err := PinBlobs(cfg, map[string]struct{}{"cafebabe": {}}); err == nil {
 		t.Fatal("pin of a missing blob must fail")
 	}
+}
+
+type gcTestEntry struct {
+	Digest string `json:"digest"`
+}
+
+type fixtureEntry struct {
+	Ref       string    `json:"ref"`
+	Digest    string    `json:"manifest_digest"`
+	Size      int64     `json:"size"`
+	CreatedAt time.Time `json:"created_at"`
 }

--- a/images/index.go
+++ b/images/index.go
@@ -58,21 +58,6 @@ func LookupOne[E Entry](images map[string]*E, id string, normalizers ...func(str
 	return refs[0], images[refs[0]], true
 }
 
-// refsShareDigest reports whether every ref names the same digest (tag aliases of one image).
-func refsShareDigest[E Entry](images map[string]*E, refs []string) bool {
-	first := images[refs[0]]
-	if first == nil {
-		return false
-	}
-	for _, ref := range refs[1:] {
-		e := images[ref]
-		if e == nil || (*e).EntryID() != (*first).EntryID() {
-			return false
-		}
-	}
-	return true
-}
-
 // LookupRefs returns all ref keys matching id by exact key, normalizer, or digest prefix.
 func LookupRefs[E Entry](images map[string]*E, id string, normalizers ...func(string) (string, bool)) []string {
 	if entry, ok := images[id]; ok && entry != nil {
@@ -105,6 +90,21 @@ func LookupRefs[E Entry](images map[string]*E, id string, normalizers ...func(st
 		}
 	}
 	return refs
+}
+
+// refsShareDigest reports whether every ref names the same digest (tag aliases of one image).
+func refsShareDigest[E Entry](images map[string]*E, refs []string) bool {
+	first := images[refs[0]]
+	if first == nil {
+		return false
+	}
+	for _, ref := range refs[1:] {
+		e := images[ref]
+		if e == nil || (*e).EntryID() != (*first).EntryID() {
+			return false
+		}
+	}
+	return true
 }
 
 // deleteByID removes every ref returned by lookup, so "delete <digest>" sweeps

--- a/lock/flock/flock.go
+++ b/lock/flock/flock.go
@@ -121,6 +121,12 @@ func (l *Lock) pathBound() bool {
 	return BoundToPath(held, l.path)
 }
 
+// dropFlock releases the kernel lock while keeping the in-process token, for requeueing on a fresh inode.
+func (l *Lock) dropFlock() {
+	_ = l.fl.Close()
+	l.fl = nil
+}
+
 // BoundToPath reports whether held still describes the inode bound to path — the shared half of every transient acquirer's stale-inode check.
 func BoundToPath(held fs.FileInfo, path string) bool {
 	cur, err := os.Stat(path)
@@ -138,10 +144,4 @@ func ReclaimTransient(ctx context.Context, path string) (bool, error) {
 		return false, err
 	}
 	return true, nil
-}
-
-// dropFlock releases the kernel lock while keeping the in-process token, for requeueing on a fresh inode.
-func (l *Lock) dropFlock() {
-	_ = l.fl.Close()
-	l.fl = nil
 }

--- a/lock/vmlock/gc_test.go
+++ b/lock/vmlock/gc_test.go
@@ -5,10 +5,6 @@ import (
 	"testing"
 )
 
-type fakeActive map[string]struct{}
-
-func (f fakeActive) ActiveVMIDs() map[string]struct{} { return f }
-
 func TestGCModuleSweepsOnlyUnknownUnheldLocks(t *testing.T) {
 	root := t.TempDir()
 	ctx := t.Context()
@@ -74,3 +70,7 @@ func TestOpsLockUnlinksOnRelease(t *testing.T) {
 		t.Errorf("lock file survived release: %v", err)
 	}
 }
+
+type fakeActive map[string]struct{}
+
+func (f fakeActive) ActiveVMIDs() map[string]struct{} { return f }

--- a/lock/vmlock/vmlock.go
+++ b/lock/vmlock/vmlock.go
@@ -15,10 +15,6 @@ func Path(rootDir, vmID string) string {
 	return filepath.Join(lockDir(rootDir), vmID+lockSuffix)
 }
 
-func lockDir(rootDir string) string {
-	return filepath.Join(rootDir, "locks", "vm")
-}
-
 // New returns vmID's operation lock, creating the lock directory on demand.
 func New(rootDir, vmID string) (*flock.Lock, error) {
 	p := Path(rootDir, vmID)
@@ -26,4 +22,8 @@ func New(rootDir, vmID string) (*flock.Lock, error) {
 		return nil, err
 	}
 	return flock.NewTransient(p), nil
+}
+
+func lockDir(rootDir string) string {
+	return filepath.Join(rootDir, "locks", "vm")
 }

--- a/meta/contracttest/suite.go
+++ b/meta/contracttest/suite.go
@@ -379,30 +379,6 @@ func testEvents(t *testing.T, factory Factory) {
 	}
 }
 
-type retryStore struct {
-	meta.Store
-}
-
-func (r *retryStore) Update(ctx context.Context, sc meta.Scope, mode meta.CommitMode, fn func(meta.Writer) error) error {
-	err := r.Store.Update(ctx, sc, mode, func(w meta.Writer) error {
-		if err := fn(w); err != nil {
-			return err
-		}
-		return errForcedRollback
-	})
-	if err != nil && !errors.Is(err, errForcedRollback) {
-		return err
-	}
-	return r.Store.Update(ctx, sc, mode, fn)
-}
-
-func update(t *testing.T, s meta.Store, ns string, fn func(meta.Writer) error) {
-	t.Helper()
-	if err := s.Update(t.Context(), meta.Scope{Write: ns}, meta.CommitDurable, fn); err != nil {
-		t.Fatal(err)
-	}
-}
-
 // testLogCursor asserts §9's log contract: committed Seq unique and strictly
 // increasing, a rolled-back append never surfaces in Scan (its number may be
 // reused or left as a gap), Scan(after) exclusive and in order.
@@ -457,5 +433,29 @@ func testLogCursor(t *testing.T, factory Factory) {
 	}
 	if seqs[0] != s2 || seqs[1] != s3 {
 		t.Fatalf("scan seqs: want [%d %d], got %v", s2, s3, seqs)
+	}
+}
+
+type retryStore struct {
+	meta.Store
+}
+
+func (r *retryStore) Update(ctx context.Context, sc meta.Scope, mode meta.CommitMode, fn func(meta.Writer) error) error {
+	err := r.Store.Update(ctx, sc, mode, func(w meta.Writer) error {
+		if err := fn(w); err != nil {
+			return err
+		}
+		return errForcedRollback
+	})
+	if err != nil && !errors.Is(err, errForcedRollback) {
+		return err
+	}
+	return r.Store.Update(ctx, sc, mode, fn)
+}
+
+func update(t *testing.T, s meta.Store, ns string, fn func(meta.Writer) error) {
+	t.Helper()
+	if err := s.Update(t.Context(), meta.Scope{Write: ns}, meta.CommitDurable, fn); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/meta/json/multiprocess_test.go
+++ b/meta/json/multiprocess_test.go
@@ -21,15 +21,6 @@ const (
 	inverseOps     = 10
 )
 
-// stormWorkers is the design's 256-process gate by default; constrained CI
-// runners dial it down via COCOON_STORM_WORKERS (full scale runs offline).
-func stormWorkers() int {
-	if v, err := strconv.Atoi(os.Getenv("COCOON_STORM_WORKERS")); err == nil && v > 0 {
-		return v
-	}
-	return 256
-}
-
 // TestMultiProcessCorrectness is the design §9 gate with real processes, not
 // goroutines: every worker's acknowledged insert must be present afterwards,
 // every failure a mapped taxonomy error, and the reopened store uncorrupted.
@@ -255,4 +246,13 @@ func TestEventsWriterWorker(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// stormWorkers is the design's 256-process gate by default; constrained CI
+// runners dial it down via COCOON_STORM_WORKERS (full scale runs offline).
+func stormWorkers() int {
+	if v, err := strconv.Atoi(os.Getenv("COCOON_STORM_WORKERS")); err == nil && v > 0 {
+		return v
+	}
+	return 256
 }

--- a/meta/json/store_test.go
+++ b/meta/json/store_test.go
@@ -12,18 +12,6 @@ import (
 	"github.com/cocoonstack/cocoon/meta/contracttest"
 )
 
-type crashPoint struct {
-	step string
-	err  error
-}
-
-func (c *crashPoint) hook(step string) error {
-	if step == c.step {
-		return c.err
-	}
-	return nil
-}
-
 func TestContract(t *testing.T) {
 	contracttest.Run(t, func(t *testing.T, nss []string) meta.Store {
 		return newStore(t, t.TempDir(), nss...)
@@ -380,6 +368,18 @@ func TestTrailingDataFallsBackToPrev(t *testing.T) {
 	if err != nil || (*got)["gen"] != 1 {
 		t.Fatalf("trailing-data main was served instead of .prev: %v, %v", got, err)
 	}
+}
+
+type crashPoint struct {
+	step string
+	err  error
+}
+
+func (c *crashPoint) hook(step string) error {
+	if step == c.step {
+		return c.err
+	}
+	return nil
 }
 
 func mustGet(t *testing.T, s *Store, ns, id string) (*map[string]int, error) {

--- a/meta/json/store_test.go
+++ b/meta/json/store_test.go
@@ -24,37 +24,6 @@ func (c *crashPoint) hook(step string) error {
 	return nil
 }
 
-func mustGet(t *testing.T, s *Store, ns, id string) (*map[string]int, error) {
-	t.Helper()
-	c := meta.NewCollection[map[string]int](s, ns, "records")
-	var rec *map[string]int
-	err := s.View(t.Context(), []string{ns}, func(r meta.Reader) error {
-		var err error
-		rec, err = c.Get(t.Context(), r, id)
-		return err
-	})
-	return rec, err
-}
-
-func newStore(t *testing.T, dir string, nss ...string) *Store {
-	t.Helper()
-	defs := make([]Namespace, 0, len(nss))
-	for _, ns := range nss {
-		defs = append(defs, Namespace{
-			Name:     ns,
-			FilePath: filepath.Join(dir, ns+".json"),
-			LockPath: filepath.Join(dir, ns+".lock"),
-			Codec:    GenericCodec{},
-		})
-	}
-	s, err := Open(defs...)
-	if err != nil {
-		t.Fatalf("open: %v", err)
-	}
-	t.Cleanup(func() { _ = s.Close() })
-	return s
-}
-
 func TestContract(t *testing.T) {
 	contracttest.Run(t, func(t *testing.T, nss []string) meta.Store {
 		return newStore(t, t.TempDir(), nss...)
@@ -411,4 +380,35 @@ func TestTrailingDataFallsBackToPrev(t *testing.T) {
 	if err != nil || (*got)["gen"] != 1 {
 		t.Fatalf("trailing-data main was served instead of .prev: %v, %v", got, err)
 	}
+}
+
+func mustGet(t *testing.T, s *Store, ns, id string) (*map[string]int, error) {
+	t.Helper()
+	c := meta.NewCollection[map[string]int](s, ns, "records")
+	var rec *map[string]int
+	err := s.View(t.Context(), []string{ns}, func(r meta.Reader) error {
+		var err error
+		rec, err = c.Get(t.Context(), r, id)
+		return err
+	})
+	return rec, err
+}
+
+func newStore(t *testing.T, dir string, nss ...string) *Store {
+	t.Helper()
+	defs := make([]Namespace, 0, len(nss))
+	for _, ns := range nss {
+		defs = append(defs, Namespace{
+			Name:     ns,
+			FilePath: filepath.Join(dir, ns+".json"),
+			LockPath: filepath.Join(dir, ns+".lock"),
+			Codec:    GenericCodec{},
+		})
+	}
+	s, err := Open(defs...)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
 }

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -1,5 +1,5 @@
 // Package meta is the unified metadata layer: record-granularity
-// transactions over per-deployment engines (json today, sqlite planned).
+// transactions over per-deployment engines (sqlite default, json legacy).
 package meta
 
 import (

--- a/meta/sqlite/events_test.go
+++ b/meta/sqlite/events_test.go
@@ -11,15 +11,6 @@ import (
 	"github.com/cocoonstack/cocoon/meta"
 )
 
-func waitEvent(t *testing.T, ch <-chan struct{}, within time.Duration, what string) {
-	t.Helper()
-	select {
-	case <-ch:
-	case <-time.After(within):
-		t.Fatalf("no event within %s (%s)", within, what)
-	}
-}
-
 // TestEventsExternalProcess is §9's cross-process signal gate: a commit by
 // ANOTHER process must reach this process's subscribers.
 func TestEventsExternalProcess(t *testing.T) {
@@ -106,4 +97,13 @@ func TestEventsSeveredWatchPollFallback(t *testing.T) {
 		t.Fatal(err)
 	}
 	waitEvent(t, ch, 8*time.Second, "poll fallback after severed watch")
+}
+
+func waitEvent(t *testing.T, ch <-chan struct{}, within time.Duration, what string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(within):
+		t.Fatalf("no event within %s (%s)", within, what)
+	}
 }

--- a/meta/sqlite/init.go
+++ b/meta/sqlite/init.go
@@ -9,9 +9,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/cocoonstack/cocoon/lock/flock"
 	"github.com/cocoonstack/cocoon/meta"
 	"github.com/cocoonstack/cocoon/utils"
 )
+
+const initLockName = "init.lock"
 
 // Init creates a fresh store: schema DDL, identity pragmas and one
 // initialized meta_state row per namespace, all in ONE transaction — a crash
@@ -28,6 +31,23 @@ func Init(ctx context.Context, dbPath string, namespaces ...Namespace) error {
 // creates its target while the manifest is necessarily present (§6).
 func InitForRecovery(ctx context.Context, dbPath string, namespaces ...Namespace) error {
 	return initStore(ctx, dbPath, namespaces)
+}
+
+// InitIfMissing bootstraps a fresh store, serializing racing processes
+// behind a transient flock; an existing database is a no-op.
+func InitIfMissing(ctx context.Context, dbPath string, namespaces ...Namespace) (err error) {
+	if merr := os.MkdirAll(filepath.Dir(dbPath), 0o750); merr != nil {
+		return merr
+	}
+	lk := flock.NewTransient(filepath.Join(filepath.Dir(dbPath), initLockName))
+	if lerr := lk.Lock(ctx); lerr != nil {
+		return lerr
+	}
+	defer func() { err = errors.Join(err, lk.Unlock(ctx)) }()
+	if utils.FileExists(dbPath) {
+		return nil
+	}
+	return Init(ctx, dbPath, namespaces...)
 }
 
 func initStore(ctx context.Context, dbPath string, namespaces []Namespace) (err error) {

--- a/meta/sqlite/init.go
+++ b/meta/sqlite/init.go
@@ -35,6 +35,10 @@ func InitForRecovery(ctx context.Context, dbPath string, namespaces ...Namespace
 
 // InitIfMissing bootstraps a fresh store or repairs a crashed one, serializing racing processes behind a transient flock.
 func InitIfMissing(ctx context.Context, dbPath string, namespaces ...Namespace) error {
+	// Fast path: a healthy store skips the lock entirely.
+	if need, err := initNeeded(dbPath); err != nil || !need {
+		return err
+	}
 	if merr := os.MkdirAll(filepath.Dir(dbPath), 0o750); merr != nil {
 		return merr
 	}

--- a/meta/sqlite/init.go
+++ b/meta/sqlite/init.go
@@ -35,19 +35,16 @@ func InitForRecovery(ctx context.Context, dbPath string, namespaces ...Namespace
 
 // InitIfMissing bootstraps a fresh store, serializing racing processes
 // behind a transient flock; an existing database is a no-op.
-func InitIfMissing(ctx context.Context, dbPath string, namespaces ...Namespace) (err error) {
+func InitIfMissing(ctx context.Context, dbPath string, namespaces ...Namespace) error {
 	if merr := os.MkdirAll(filepath.Dir(dbPath), 0o750); merr != nil {
 		return merr
 	}
-	lk := flock.NewTransient(filepath.Join(filepath.Dir(dbPath), initLockName))
-	if lerr := lk.Lock(ctx); lerr != nil {
-		return lerr
-	}
-	defer func() { err = errors.Join(err, lk.Unlock(ctx)) }()
-	if utils.FileExists(dbPath) {
-		return nil
-	}
-	return Init(ctx, dbPath, namespaces...)
+	return withFlock(ctx, flock.NewTransient(filepath.Join(filepath.Dir(dbPath), initLockName)), func() error {
+		if utils.FileExists(dbPath) {
+			return nil
+		}
+		return Init(ctx, dbPath, namespaces...)
+	})
 }
 
 func initStore(ctx context.Context, dbPath string, namespaces []Namespace) (err error) {

--- a/meta/sqlite/init.go
+++ b/meta/sqlite/init.go
@@ -33,18 +33,27 @@ func InitForRecovery(ctx context.Context, dbPath string, namespaces ...Namespace
 	return initStore(ctx, dbPath, namespaces)
 }
 
-// InitIfMissing bootstraps a fresh store, serializing racing processes
-// behind a transient flock; an existing database is a no-op.
+// InitIfMissing bootstraps a fresh store or repairs a crashed one, serializing racing processes behind a transient flock.
 func InitIfMissing(ctx context.Context, dbPath string, namespaces ...Namespace) error {
 	if merr := os.MkdirAll(filepath.Dir(dbPath), 0o750); merr != nil {
 		return merr
 	}
 	return withFlock(ctx, flock.NewTransient(filepath.Join(filepath.Dir(dbPath), initLockName)), func() error {
-		if utils.FileExists(dbPath) {
-			return nil
+		need, err := initNeeded(dbPath)
+		if err != nil || !need {
+			return err
 		}
 		return Init(ctx, dbPath, namespaces...)
 	})
+}
+
+// InitForRecoveryIfNeeded creates or repairs the conversion target, passing a completed one through.
+func InitForRecoveryIfNeeded(ctx context.Context, dbPath string, namespaces ...Namespace) error {
+	need, err := initNeeded(dbPath)
+	if err != nil || !need {
+		return err
+	}
+	return InitForRecovery(ctx, dbPath, namespaces...)
 }
 
 func initStore(ctx context.Context, dbPath string, namespaces []Namespace) (err error) {
@@ -108,6 +117,13 @@ func createSchema(ctx context.Context, tx *sql.Tx, namespaces []Namespace) error
 		}
 	}
 	return nil
+}
+
+func initNeeded(dbPath string) (bool, error) {
+	if !utils.FileExists(dbPath) {
+		return true, nil
+	}
+	return failedInit(dbPath)
 }
 
 // failedInit reports whether dbPath is a crashed init. Init is atomic, so

--- a/meta/sqlite/init_test.go
+++ b/meta/sqlite/init_test.go
@@ -10,10 +10,6 @@ import (
 	"github.com/cocoonstack/cocoon/utils"
 )
 
-func testDecls() []Namespace {
-	return []Namespace{{Name: "vms", Tables: []string{"records", "names"}}}
-}
-
 func TestInitRefusesExisting(t *testing.T) {
 	path := filepath.Join(t.TempDir(), DBFileName)
 	if err := Init(t.Context(), path, testDecls()...); err != nil {
@@ -165,4 +161,8 @@ func TestUnsupportedFSRefused(t *testing.T) {
 	if utils.FileExists(fresh) {
 		t.Fatal("init created WAL state on refused filesystem")
 	}
+}
+
+func testDecls() []Namespace {
+	return []Namespace{{Name: "vms", Tables: []string{"records", "names"}}}
 }

--- a/meta/sqlite/init_test.go
+++ b/meta/sqlite/init_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/cocoonstack/cocoon/utils"
@@ -106,6 +107,34 @@ func TestUninitializedNamespaceRefused(t *testing.T) {
 	extra := append(testDecls(), Namespace{Name: "late", Tables: []string{"records"}})
 	if _, err := Open(path, extra...); err == nil || !strings.Contains(err.Error(), "uninitialized") {
 		t.Fatalf("want uninitialized refusal, got %v", err)
+	}
+}
+
+func TestInitIfMissingRaces(t *testing.T) {
+	path := filepath.Join(t.TempDir(), DBFileName)
+	var wg sync.WaitGroup
+	errs := make([]error, 4)
+	for i := range errs {
+		wg.Go(func() {
+			errs[i] = InitIfMissing(t.Context(), path, testDecls()...)
+		})
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("racer %d: %v", i, err)
+		}
+	}
+	if err := InitIfMissing(t.Context(), path, testDecls()...); err != nil {
+		t.Fatalf("idempotent recheck: %v", err)
+	}
+	s, err := Open(path, testDecls()...)
+	if err != nil {
+		t.Fatalf("open bootstrapped store: %v", err)
+	}
+	_ = s.Close()
+	if utils.FileExists(filepath.Join(filepath.Dir(path), initLockName)) {
+		t.Fatal("transient init lock left behind")
 	}
 }
 

--- a/meta/sqlite/init_test.go
+++ b/meta/sqlite/init_test.go
@@ -134,6 +134,19 @@ func TestInitIfMissingRaces(t *testing.T) {
 	}
 }
 
+func TestInitIfMissingRepairsCrashedInit(t *testing.T) {
+	path := filepath.Join(t.TempDir(), DBFileName)
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := InitIfMissing(t.Context(), path, testDecls()...); err != nil {
+		t.Fatalf("bootstrap over crashed init: %v", err)
+	}
+	if _, err := Open(path, testDecls()...); err != nil {
+		t.Fatalf("open repaired store: %v", err)
+	}
+}
+
 func TestOpenDoesNotCreate(t *testing.T) {
 	path := filepath.Join(t.TempDir(), DBFileName)
 	if _, err := Open(path, testDecls()...); err == nil || !strings.Contains(err.Error(), "meta init") {

--- a/meta/sqlite/maintenance.go
+++ b/meta/sqlite/maintenance.go
@@ -35,17 +35,18 @@ func Checkpoint(ctx context.Context, dbPath string) error {
 // Backup replaces destPath with a consistent single-file copy: VACUUM INTO
 // a temp file, integrity-check, fsync, atomic rename, parent-dir sync (§4).
 // A previously published backup stays intact until the rename commits (§9).
-func Backup(ctx context.Context, dbPath, destPath string) (err error) {
+func Backup(ctx context.Context, dbPath, destPath string) error {
 	if merr := os.MkdirAll(filepath.Dir(destPath), 0o750); merr != nil {
 		return merr
 	}
 	// Concurrent backups to one destination share the tmp path; without
 	// mutual exclusion one run's cleanup yanks the other's tmp mid-verify.
-	l := flock.New(destPath + ".lock")
-	if lerr := l.Lock(ctx); lerr != nil {
-		return lerr
-	}
-	defer func() { err = errors.Join(err, l.Unlock(ctx)) }()
+	return withFlock(ctx, flock.New(destPath+".lock"), func() error {
+		return backupLocked(ctx, dbPath, destPath)
+	})
+}
+
+func backupLocked(ctx context.Context, dbPath, destPath string) (err error) {
 	tmp := destPath + ".tmp"
 	// A stale temp from a crashed run would block VACUUM INTO; the published
 	// backup is untouched, so clearing it is safe.
@@ -110,4 +111,12 @@ func withDB(dbPath string, fn func(*sql.DB) error) (err error) {
 	}
 	defer func() { err = errors.Join(err, db.Close()) }()
 	return fn(db)
+}
+
+func withFlock(ctx context.Context, l *flock.Lock, fn func() error) (err error) {
+	if lerr := l.Lock(ctx); lerr != nil {
+		return lerr
+	}
+	defer func() { err = errors.Join(err, l.Unlock(ctx)) }()
+	return fn()
 }

--- a/meta/sqlite/maintenance.go
+++ b/meta/sqlite/maintenance.go
@@ -42,6 +42,11 @@ func Backup(ctx context.Context, dbPath, destPath string) error {
 	if err := RefuseManifest(dbPath); err != nil {
 		return err
 	}
+	if partial, err := failedInit(dbPath); err != nil {
+		return err
+	} else if partial {
+		return fmt.Errorf("%s is an uninitialized store; nothing to back up", dbPath)
+	}
 	if merr := os.MkdirAll(filepath.Dir(destPath), 0o750); merr != nil {
 		return merr
 	}

--- a/meta/sqlite/maintenance.go
+++ b/meta/sqlite/maintenance.go
@@ -36,6 +36,12 @@ func Checkpoint(ctx context.Context, dbPath string) error {
 // a temp file, integrity-check, fsync, atomic rename, parent-dir sync (§4).
 // A previously published backup stays intact until the rename commits (§9).
 func Backup(ctx context.Context, dbPath, destPath string) error {
+	if !utils.FileExists(dbPath) {
+		return fmt.Errorf("no sqlite store at %s to back up", dbPath)
+	}
+	if err := RefuseManifest(dbPath); err != nil {
+		return err
+	}
 	if merr := os.MkdirAll(filepath.Dir(destPath), 0o750); merr != nil {
 		return merr
 	}

--- a/meta/sqlite/maintenance_test.go
+++ b/meta/sqlite/maintenance_test.go
@@ -111,8 +111,14 @@ func TestBackupRefusals(t *testing.T) {
 	if utils.FileExists(missing) {
 		t.Fatal("backup created the missing source")
 	}
+	if err := os.WriteFile(missing, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Backup(t.Context(), missing, filepath.Join(dir, "out.db")); err == nil || !strings.Contains(err.Error(), "uninitialized store") {
+		t.Fatalf("want uninitialized refusal, got %v", err)
+	}
 	if err := Init(t.Context(), missing, testDecls()...); err != nil {
-		t.Fatalf("init: %v", err)
+		t.Fatalf("init over crashed file: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, ManifestName), []byte("{}"), 0o644); err != nil {
 		t.Fatal(err)

--- a/meta/sqlite/maintenance_test.go
+++ b/meta/sqlite/maintenance_test.go
@@ -11,25 +11,6 @@ import (
 	"github.com/cocoonstack/cocoon/meta"
 )
 
-func backupGet(t *testing.T, dest, id string) (string, bool) {
-	t.Helper()
-	b, err := Open(dest, Namespace{Name: "vms", Tables: []string{"records", "names", "tombstones"}})
-	if err != nil {
-		t.Fatalf("open backup %s: %v", dest, err)
-	}
-	defer b.Close() //nolint:errcheck
-	var raw json.RawMessage
-	var ok bool
-	err = b.View(t.Context(), []string{"vms"}, func(r meta.Reader) error {
-		raw, ok, err = r.GetRaw(t.Context(), "vms", "records", id)
-		return err
-	})
-	if err != nil {
-		t.Fatalf("view backup: %v", err)
-	}
-	return string(raw), ok
-}
-
 func TestBackupFidelity(t *testing.T) {
 	ctx := t.Context()
 	dir := t.TempDir()
@@ -182,4 +163,23 @@ func TestBackupConcurrentSameDest(t *testing.T) {
 	if raw, ok := backupGet(t, dest, "id1"); !ok || raw != `{"v":1}` {
 		t.Fatalf("published backup invalid after concurrent runs: %q ok=%v", raw, ok)
 	}
+}
+
+func backupGet(t *testing.T, dest, id string) (string, bool) {
+	t.Helper()
+	b, err := Open(dest, Namespace{Name: "vms", Tables: []string{"records", "names", "tombstones"}})
+	if err != nil {
+		t.Fatalf("open backup %s: %v", dest, err)
+	}
+	defer b.Close() //nolint:errcheck
+	var raw json.RawMessage
+	var ok bool
+	err = b.View(t.Context(), []string{"vms"}, func(r meta.Reader) error {
+		raw, ok, err = r.GetRaw(t.Context(), "vms", "records", id)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("view backup: %v", err)
+	}
+	return string(raw), ok
 }

--- a/meta/sqlite/maintenance_test.go
+++ b/meta/sqlite/maintenance_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/cocoonstack/cocoon/meta"
+	"github.com/cocoonstack/cocoon/utils"
 )
 
 func TestBackupFidelity(t *testing.T) {
@@ -96,6 +99,26 @@ func TestBackupCrashSteps(t *testing.T) {
 		if err := Backup(ctx, filepath.Join(dir, DBFileName), dest); err != nil {
 			t.Fatalf("rerun after %s: %v", step, err)
 		}
+	}
+}
+
+func TestBackupRefusals(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, DBFileName)
+	if err := Backup(t.Context(), missing, filepath.Join(dir, "out.db")); err == nil || !strings.Contains(err.Error(), "no sqlite store") {
+		t.Fatalf("want missing-store refusal, got %v", err)
+	}
+	if utils.FileExists(missing) {
+		t.Fatal("backup created the missing source")
+	}
+	if err := Init(t.Context(), missing, testDecls()...); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ManifestName), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Backup(t.Context(), missing, filepath.Join(dir, "out.db")); err == nil || !strings.Contains(err.Error(), "conversion is in flight") {
+		t.Fatalf("want manifest refusal, got %v", err)
 	}
 }
 

--- a/meta/sqlite/multiprocess_test.go
+++ b/meta/sqlite/multiprocess_test.go
@@ -25,41 +25,6 @@ const (
 	inverseOps     = 10
 )
 
-// updateRetry retries on ErrBusy — the mapped, retryable-by-contract outcome
-// under extreme oversubscription (§4); reconciliation still demands exact counts.
-func updateRetry(t *testing.T, s *Store, sc meta.Scope, fn func(meta.Writer) error) {
-	t.Helper()
-	for {
-		err := s.Update(t.Context(), sc, meta.CommitDurable, fn)
-		if err == nil {
-			return
-		}
-		if !errors.Is(err, meta.ErrBusy) {
-			t.Fatalf("update: %v", err)
-		}
-	}
-}
-
-func stormWorkers() int {
-	if v, err := strconv.Atoi(os.Getenv("COCOON_STORM_WORKERS")); err == nil && v > 0 {
-		return v
-	}
-	return 256
-}
-
-func integrityCheck(t *testing.T, dir string) {
-	t.Helper()
-	db, err := open(filepath.Join(dir, DBFileName), "FULL", false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close() //nolint:errcheck
-	var result string
-	if err := db.QueryRow("PRAGMA integrity_check").Scan(&result); err != nil || result != "ok" {
-		t.Fatalf("integrity check: %q err=%v", result, err)
-	}
-}
-
 // TestMultiProcessCorrectness is §9's real-process storm for the sqlite
 // engine: acknowledged inserts and their name rows all present, names
 // referentially consistent, zero corruption on reopen.
@@ -275,5 +240,40 @@ func TestKillStormWorker(t *testing.T) {
 			return nil
 		})
 		fmt.Printf("ACK %s\n", txn)
+	}
+}
+
+// updateRetry retries on ErrBusy — the mapped, retryable-by-contract outcome
+// under extreme oversubscription (§4); reconciliation still demands exact counts.
+func updateRetry(t *testing.T, s *Store, sc meta.Scope, fn func(meta.Writer) error) {
+	t.Helper()
+	for {
+		err := s.Update(t.Context(), sc, meta.CommitDurable, fn)
+		if err == nil {
+			return
+		}
+		if !errors.Is(err, meta.ErrBusy) {
+			t.Fatalf("update: %v", err)
+		}
+	}
+}
+
+func stormWorkers() int {
+	if v, err := strconv.Atoi(os.Getenv("COCOON_STORM_WORKERS")); err == nil && v > 0 {
+		return v
+	}
+	return 256
+}
+
+func integrityCheck(t *testing.T, dir string) {
+	t.Helper()
+	db, err := open(filepath.Join(dir, DBFileName), "FULL", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close() //nolint:errcheck
+	var result string
+	if err := db.QueryRow("PRAGMA integrity_check").Scan(&result); err != nil || result != "ok" {
+		t.Fatalf("integrity check: %q err=%v", result, err)
 	}
 }

--- a/meta/sqlite/store.go
+++ b/meta/sqlite/store.go
@@ -91,6 +91,15 @@ func OpenForRecovery(dbPath string, namespaces ...Namespace) (*Store, error) {
 	return openStore(dbPath, namespaces)
 }
 
+// RefuseManifest fails when a conversion manifest sits beside dbPath, meaning an offline conversion is unfinished.
+func RefuseManifest(dbPath string) error {
+	manifest := filepath.Join(filepath.Dir(dbPath), ManifestName)
+	if utils.FileExists(manifest) {
+		return fmt.Errorf("%s exists: a conversion is in flight, run `cocoon meta convert` to finish it", manifest)
+	}
+	return nil
+}
+
 func openStore(dbPath string, namespaces []Namespace) (*Store, error) {
 	// The driver creates a file on first touch; Open never creates — that is
 	// Init's job (§6) — and §4 refuses network filesystems before WAL work.
@@ -286,15 +295,6 @@ func (s *Store) verifyIdentity() error {
 		if err != nil {
 			return mapErr(err)
 		}
-	}
-	return nil
-}
-
-// RefuseManifest fails when a conversion manifest sits beside dbPath, meaning an offline conversion is unfinished.
-func RefuseManifest(dbPath string) error {
-	manifest := filepath.Join(filepath.Dir(dbPath), ManifestName)
-	if utils.FileExists(manifest) {
-		return fmt.Errorf("%s exists: a conversion is in flight, run `cocoon meta convert` to finish it", manifest)
 	}
 	return nil
 }

--- a/meta/sqlite/store_test.go
+++ b/meta/sqlite/store_test.go
@@ -9,6 +9,18 @@ import (
 	"github.com/cocoonstack/cocoon/utils"
 )
 
+func TestContract(t *testing.T) {
+	contracttest.Run(t, func(t *testing.T, nss []string) meta.Store {
+		return newStore(t, t.TempDir(), nss...)
+	})
+}
+
+func TestContractForcedRetryEngine(t *testing.T) {
+	contracttest.Run(t, func(t *testing.T, nss []string) meta.Store {
+		return contracttest.ForcedRetry(newStore(t, t.TempDir(), nss...))
+	})
+}
+
 func newStore(t *testing.T, dir string, nss ...string) *Store {
 	t.Helper()
 	decls := make([]Namespace, 0, len(nss))
@@ -27,16 +39,4 @@ func newStore(t *testing.T, dir string, nss ...string) *Store {
 	}
 	t.Cleanup(func() { _ = s.Close() })
 	return s
-}
-
-func TestContract(t *testing.T) {
-	contracttest.Run(t, func(t *testing.T, nss []string) meta.Store {
-		return newStore(t, t.TempDir(), nss...)
-	})
-}
-
-func TestContractForcedRetryEngine(t *testing.T) {
-	contracttest.Run(t, func(t *testing.T, nss []string) meta.Store {
-		return contracttest.ForcedRetry(newStore(t, t.TempDir(), nss...))
-	})
 }

--- a/meta/tombstone/tombstone.go
+++ b/meta/tombstone/tombstone.go
@@ -139,17 +139,6 @@ func (t *Table) Finalize(ctx context.Context, w meta.Writer, id, leaseID string)
 	return t.recs.Delete(ctx, w, id)
 }
 
-func (t *Table) fenced(ctx context.Context, w meta.Writer, id, leaseID string) (*Record, error) {
-	rec, err := t.Get(ctx, w, id)
-	if err != nil {
-		return nil, err
-	}
-	if rec == nil || rec.LeaseID != leaseID {
-		return nil, fmt.Errorf("tombstone %s/%s: %w", t.ns, id, ErrLost)
-	}
-	return rec, nil
-}
-
 // PendingIDs lists every tombstoned id (the recovery sweep's work list).
 func (t *Table) PendingIDs(ctx context.Context, r meta.Reader) ([]string, error) {
 	var ids []string
@@ -200,6 +189,17 @@ func (t *Table) Resume(ctx context.Context, w meta.Writer, id string) (rec *Reco
 		return rec, taken.LeaseID, t.Rollback(ctx, w, id, taken.LeaseID)
 	}
 	return rec, taken.LeaseID, nil
+}
+
+func (t *Table) fenced(ctx context.Context, w meta.Writer, id, leaseID string) (*Record, error) {
+	rec, err := t.Get(ctx, w, id)
+	if err != nil {
+		return nil, err
+	}
+	if rec == nil || rec.LeaseID != leaseID {
+		return nil, fmt.Errorf("tombstone %s/%s: %w", t.ns, id, ErrLost)
+	}
+	return rec, nil
 }
 
 // MarshalCleanup encodes a namespace-defined cleanup payload.

--- a/metadata/fat12.go
+++ b/metadata/fat12.go
@@ -31,17 +31,6 @@ const (
 	writeBufSize = 64 << 10
 )
 
-// fat12Builder constructs a FAT12 image in memory (FAT + root dir only) and streams the full image on writeTo.
-type fat12Builder struct {
-	label       string
-	fat         []byte   // single FAT copy (written twice)
-	rootDir     []byte   // root directory area
-	data        [][]byte // file data in cluster-allocation order
-	nextCluster uint16   // next free cluster (starts at 2)
-	rootUsed    int      // root directory entries consumed
-	shortSeq    int      // counter for ~N short-name suffixes
-}
-
 // CreateFAT12 streams a 1 MiB FAT12 image with VFAT long-filename support to w.
 func CreateFAT12(w io.Writer, label string, files map[string][]byte) error {
 	b := newFAT12Builder(label)
@@ -52,6 +41,17 @@ func CreateFAT12(w io.Writer, label string, files map[string][]byte) error {
 		}
 	}
 	return b.writeTo(w)
+}
+
+// fat12Builder constructs a FAT12 image in memory (FAT + root dir only) and streams the full image on writeTo.
+type fat12Builder struct {
+	label       string
+	fat         []byte   // single FAT copy (written twice)
+	rootDir     []byte   // root directory area
+	data        [][]byte // file data in cluster-allocation order
+	nextCluster uint16   // next free cluster (starts at 2)
+	rootUsed    int      // root directory entries consumed
+	shortSeq    int      // counter for ~N short-name suffixes
 }
 
 func newFAT12Builder(label string) *fat12Builder {

--- a/network/cni/db.go
+++ b/network/cni/db.go
@@ -4,8 +4,7 @@ import (
 	"github.com/cocoonstack/cocoon/types"
 )
 
-// networkRecord is one NIC's persisted network state.
-// Keyed by a generated network ID (unique per NIC, not per VM).
+// networkRecord is one NIC's persisted network state, keyed by a generated ID unique per NIC (not per VM).
 type networkRecord struct {
 	types.Network `json:"network"`
 	ID            string `json:"id"`

--- a/network/cni/lifecycle.go
+++ b/network/cni/lifecycle.go
@@ -176,18 +176,6 @@ func (c *CNI) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, specs
 	})
 }
 
-// guardAdd finishes an interrupted teardown before new NICs are plumbed; a completed deleting roll-forward refuses the Add.
-func (c *CNI) guardAdd(ctx context.Context, vmID string) error {
-	rolledForward, err := c.recoverTombstone(ctx, vmID)
-	if err != nil {
-		return fmt.Errorf("recover interrupted teardown for %s: %w", vmID, err)
-	}
-	if rolledForward {
-		return fmt.Errorf("vm %s network teardown was interrupted; recovery completed, retry the operation: %w", vmID, meta.ErrConflict)
-	}
-	return nil
-}
-
 // Remove tears down NIC plumbing for the given indices; preserves the netns. A failed NIC keeps its DB record so retry / vm rm / GC can still release its CNI resources.
 func (c *CNI) Remove(ctx context.Context, vmID string, indices ...int) error {
 	if len(indices) == 0 {
@@ -225,6 +213,18 @@ func (c *CNI) Remove(ctx context.Context, vmID string, indices ...int) error {
 		subset = append(subset, r.ID)
 	}
 	return c.teardownProtocol(ctx, vmID, subset, true)
+}
+
+// guardAdd finishes an interrupted teardown before new NICs are plumbed; a completed deleting roll-forward refuses the Add.
+func (c *CNI) guardAdd(ctx context.Context, vmID string) error {
+	rolledForward, err := c.recoverTombstone(ctx, vmID)
+	if err != nil {
+		return fmt.Errorf("recover interrupted teardown for %s: %w", vmID, err)
+	}
+	if rolledForward {
+		return fmt.Errorf("vm %s network teardown was interrupted; recovery completed, retry the operation: %w", vmID, meta.ErrConflict)
+	}
+	return nil
 }
 
 // stageNICIntents reclaims stale slots and lands every fresh NIC's intent record in one write before any plugin ADD: GC gets per-NIC release context at the cost of a single fsync on the claim path.
@@ -371,8 +371,7 @@ func extractNetworkInfo(ctx context.Context, result cnitypes.Result) (*types.Net
 			return info, nil
 		}
 	}
-	// IPv6-only plugin results are not persisted; surface the drop instead of
-	// silently recording Network: nil.
+	// IPv6-only plugin results are not persisted; log the drop instead of silently recording nil.
 	log.WithFunc("cni.extractNetworkInfo").Warnf(ctx,
 		"CNI result has %d IPs but no IPv4; skipping network info (IPv6-only is unsupported)", len(newResult.IPs))
 	return nil, nil

--- a/network/cni/lifecycle_linux.go
+++ b/network/cni/lifecycle_linux.go
@@ -117,7 +117,6 @@ func setupTCRedirect(nsPath, ifName, tapName string, queues int, overrideMAC str
 	return mac, err
 }
 
-// tcRedirectInNS runs TC redirect setup inside target netns.
 func tcRedirectInNS(ifName, tapName string, queues int, overrideMAC string) (string, error) {
 	link, err := netlink.LinkByName(ifName)
 	if err != nil {

--- a/snapshot/localfile/localfile_test.go
+++ b/snapshot/localfile/localfile_test.go
@@ -297,7 +297,6 @@ func TestCreate(t *testing.T) {
 		t.Fatal("expected non-empty ID")
 	}
 
-	// Verify data files were extracted.
 	dataDir := lf.conf.SnapshotDataDir(id)
 	for _, name := range []string{"cow.raw", "state.json"} {
 		if _, err := os.Stat(filepath.Join(dataDir, name)); err != nil {
@@ -491,17 +490,14 @@ func TestDelete(t *testing.T) {
 		t.Errorf("deleted: got %v, want [%s]", deleted, id)
 	}
 
-	// Data dir should be gone.
 	if _, err := os.Stat(lf.conf.SnapshotDataDir(id)); !errors.Is(err, fs.ErrNotExist) {
 		t.Error("expected data dir to be removed")
 	}
 
-	// Inspect should fail.
 	if _, err := lf.Inspect(ctx, id); !errors.Is(err, snapshot.ErrNotFound) {
 		t.Errorf("expected ErrNotFound after delete, got %v", err)
 	}
 
-	// List should be empty.
 	list, _ := lf.List(ctx)
 	if len(list) != 0 {
 		t.Errorf("expected 0 after delete, got %d", len(list))
@@ -546,7 +542,6 @@ func TestDelete_Multiple(t *testing.T) {
 		t.Errorf("expected 2 deleted, got %d", len(deleted))
 	}
 
-	// m2 should still exist.
 	list, _ := lf.List(ctx)
 	if len(list) != 1 || list[0].Name != "m2" {
 		t.Errorf("expected only m2 remaining, got %v", list)
@@ -563,7 +558,6 @@ func TestDelete_DuplicateRefs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Pass the same ref twice — should deduplicate.
 	deleted, err := lf.Delete(ctx, []string{id, "dedup"})
 	if err != nil {
 		t.Fatalf("Delete: %v", err)
@@ -714,14 +708,12 @@ func TestDataDir_ImageBlobIDsIsolation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Get config via DataDir, mutate the returned ImageBlobIDs.
 	_, got1, _, err := lf.DataDir(ctx, id)
 	if err != nil {
 		t.Fatal(err)
 	}
 	got1.ImageBlobIDs["injected"] = struct{}{}
 
-	// Get config again — mutation should NOT be visible.
 	_, got2, _, err := lf.DataDir(ctx, id)
 	if err != nil {
 		t.Fatal(err)
@@ -808,7 +800,6 @@ func TestRestore_DataStream(t *testing.T) {
 	}
 	defer rc.Close()
 
-	// Read the tar stream and find state.json.
 	tr := tar.NewReader(rc)
 	found := false
 	for {
@@ -892,7 +883,6 @@ func TestRestore_ImageBlobIDsIsolation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Get config via Restore, mutate returned ImageBlobIDs.
 	got1, rc1, err := lf.Restore(ctx, id)
 	if err != nil {
 		t.Fatal(err)
@@ -900,7 +890,6 @@ func TestRestore_ImageBlobIDsIsolation(t *testing.T) {
 	rc1.Close()
 	got1.ImageBlobIDs["injected"] = struct{}{}
 
-	// Get config again — mutation should NOT be visible.
 	got2, rc2, err := lf.Restore(ctx, id)
 	if err != nil {
 		t.Fatal(err)
@@ -939,7 +928,6 @@ func TestExportImport_Roundtrip(t *testing.T) {
 		t.Error("imported snapshot should get a new ID")
 	}
 
-	// Verify metadata was preserved (except overridden name and ID).
 	s, err := lf.Inspect(ctx, importedID)
 	if err != nil {
 		t.Fatalf("Inspect imported: %v", err)
@@ -957,7 +945,6 @@ func TestExportImport_Roundtrip(t *testing.T) {
 		t.Errorf("Memory: got %d, want %d", s.Memory, int64(1<<30))
 	}
 
-	// Verify data files were imported.
 	dataDir := lf.conf.SnapshotDataDir(importedID)
 	for name, wantContent := range origFiles {
 		got, readErr := os.ReadFile(filepath.Join(dataDir, name))
@@ -1010,7 +997,6 @@ func TestImport_FromGzipTarReader(t *testing.T) {
 	lf := newTestLF(t)
 	ctx := t.Context()
 
-	// Build a gzip-compressed tar archive with snapshot.json + data files.
 	wantCfg := types.SnapshotExport{
 		Version: 1,
 		Config: types.SnapshotConfig{
@@ -1053,7 +1039,6 @@ func TestImport_FromGzipTarReader(t *testing.T) {
 	tw.Close()
 	gw.Close()
 
-	// Import from the in-memory reader.
 	importedID, err := lf.Import(ctx, &buf, "", "")
 	if err != nil {
 		t.Fatalf("Import: %v", err)
@@ -1070,7 +1055,6 @@ func TestImport_FromGzipTarReader(t *testing.T) {
 		t.Errorf("CPU: got %d, want 2", s.CPU)
 	}
 
-	// Verify data file.
 	dataDir := lf.conf.SnapshotDataDir(importedID)
 	got, err := os.ReadFile(filepath.Join(dataDir, "state.json"))
 	if err != nil {
@@ -1119,7 +1103,6 @@ func TestImport_FromRawTarReader(t *testing.T) {
 	lf := newTestLF(t)
 	ctx := t.Context()
 
-	// Build a raw (uncompressed) tar archive with snapshot.json + data files.
 	wantCfg := types.SnapshotExport{
 		Version: 1,
 		Config: types.SnapshotConfig{
@@ -1266,12 +1249,10 @@ func TestImport_InvalidStream(t *testing.T) {
 	lf := newTestLF(t)
 	ctx := t.Context()
 
-	// Too short to peek.
 	if _, err := lf.Import(ctx, strings.NewReader("x"), "", ""); err == nil {
 		t.Fatal("expected error for 1-byte input")
 	}
 
-	// Peekable but not a valid tar.
 	if _, err := lf.Import(ctx, strings.NewReader("this is not a tar archive"), "", ""); err == nil {
 		t.Fatal("expected error for non-tar input")
 	}
@@ -1406,6 +1387,42 @@ func TestDeleteRejectsLeasedSnapshot(t *testing.T) {
 	}
 }
 
+// TestImportPinsEnvelopeBlobs pins the digest-lock hook: Import must hold the
+// injected pinner over exactly the envelope's blob IDs while committing.
+func TestImportPinsEnvelopeBlobs(t *testing.T) {
+	src := newTestLF(t)
+	ctx := t.Context()
+	id := makeExportableSnapshot(t, src, "pin-src", map[string][]byte{"cow.raw": []byte("x")})
+	stream, err := src.Export(ctx, id)
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	defer stream.Close()
+
+	var pinned []string
+	released := false
+	dir := t.TempDir()
+	conf := &config.Config{RootDir: dir}
+	dst, err := New(conf, metering.NopRecorder{}, newTestMetaStore(t, conf),
+		WithBlobPinner(func(_ context.Context, blobIDs map[string]struct{}) (func(), error) {
+			pinned = slices.Sorted(maps.Keys(blobIDs))
+			return func() { released = true }, nil
+		}))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if _, err := dst.Import(ctx, stream, "pin-dst", ""); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if want := []string{"blob1"}; !slices.Equal(pinned, want) {
+		t.Fatalf("pinner got %v, want %v", pinned, want)
+	}
+	if !released {
+		t.Fatal("pin never released")
+	}
+}
+
 func testID(t *testing.T) string {
 	t.Helper()
 	return utils.GenerateID()
@@ -1534,40 +1551,4 @@ func newTestMetaStore(t *testing.T, conf *config.Config) *metajson.Store {
 	}
 	t.Cleanup(func() { _ = store.Close() })
 	return store
-}
-
-// TestImportPinsEnvelopeBlobs pins the digest-lock hook: Import must hold the
-// injected pinner over exactly the envelope's blob IDs while committing.
-func TestImportPinsEnvelopeBlobs(t *testing.T) {
-	src := newTestLF(t)
-	ctx := t.Context()
-	id := makeExportableSnapshot(t, src, "pin-src", map[string][]byte{"cow.raw": []byte("x")})
-	stream, err := src.Export(ctx, id)
-	if err != nil {
-		t.Fatalf("export: %v", err)
-	}
-	defer stream.Close()
-
-	var pinned []string
-	released := false
-	dir := t.TempDir()
-	conf := &config.Config{RootDir: dir}
-	dst, err := New(conf, metering.NopRecorder{}, newTestMetaStore(t, conf),
-		WithBlobPinner(func(_ context.Context, blobIDs map[string]struct{}) (func(), error) {
-			pinned = slices.Sorted(maps.Keys(blobIDs))
-			return func() { released = true }, nil
-		}))
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-
-	if _, err := dst.Import(ctx, stream, "pin-dst", ""); err != nil {
-		t.Fatalf("import: %v", err)
-	}
-	if want := []string{"blob1"}; !slices.Equal(pinned, want) {
-		t.Fatalf("pinner got %v, want %v", pinned, want)
-	}
-	if !released {
-		t.Fatal("pin never released")
-	}
 }

--- a/snapshot/localfile/meta_shim_test.go
+++ b/snapshot/localfile/meta_shim_test.go
@@ -53,57 +53,6 @@ func (lf *LocalFile) dbRead(ctx context.Context, fn func(*snapshotIndex) error) 
 	})
 }
 
-func materializeSnapIndex(t *snapTx) (*snapshotIndex, *snapshotIndex, error) {
-	idx := &snapshotIndex{}
-	idx.Init()
-	var err error
-	if idx.Snapshots, err = t.All(); err != nil {
-		return nil, nil, err
-	}
-	for _, rec := range idx.Snapshots {
-		if rec != nil && rec.Name != "" {
-			if id, ok, err := t.NameGet(rec.Name); err != nil {
-				return nil, nil, err
-			} else if ok {
-				idx.Names[rec.Name] = id
-			}
-		}
-	}
-	before := &snapshotIndex{Snapshots: maps.Clone(idx.Snapshots), Names: maps.Clone(idx.Names)}
-	return before, idx, nil
-}
-
-func writeBackSnapIndex(t *snapTx, before, after *snapshotIndex) error {
-	for id := range before.Snapshots {
-		if after.Snapshots[id] == nil {
-			if err := t.Del(id); err != nil {
-				return err
-			}
-		}
-	}
-	for id, rec := range after.Snapshots {
-		if rec == nil {
-			continue
-		}
-		if err := t.Put(id, rec); err != nil {
-			return err
-		}
-	}
-	for name := range before.Names {
-		if _, ok := after.Names[name]; !ok {
-			if err := t.NameDel(name); err != nil {
-				return err
-			}
-		}
-	}
-	for name, id := range after.Names {
-		if err := t.NameSet(name, id); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // TestLegacyDifferentialTrace replays the fixture op sequence over meta-json
 // and requires byte-identical output to the legacy storage layer's writes.
 func TestLegacyDifferentialTrace(t *testing.T) {
@@ -172,4 +121,55 @@ func TestLegacyDifferentialTrace(t *testing.T) {
 	if string(got) != string(after) {
 		t.Fatalf("differential trace diverged:\n got: %s\nwant: %s", got, after)
 	}
+}
+
+func materializeSnapIndex(t *snapTx) (*snapshotIndex, *snapshotIndex, error) {
+	idx := &snapshotIndex{}
+	idx.Init()
+	var err error
+	if idx.Snapshots, err = t.All(); err != nil {
+		return nil, nil, err
+	}
+	for _, rec := range idx.Snapshots {
+		if rec != nil && rec.Name != "" {
+			if id, ok, err := t.NameGet(rec.Name); err != nil {
+				return nil, nil, err
+			} else if ok {
+				idx.Names[rec.Name] = id
+			}
+		}
+	}
+	before := &snapshotIndex{Snapshots: maps.Clone(idx.Snapshots), Names: maps.Clone(idx.Names)}
+	return before, idx, nil
+}
+
+func writeBackSnapIndex(t *snapTx, before, after *snapshotIndex) error {
+	for id := range before.Snapshots {
+		if after.Snapshots[id] == nil {
+			if err := t.Del(id); err != nil {
+				return err
+			}
+		}
+	}
+	for id, rec := range after.Snapshots {
+		if rec == nil {
+			continue
+		}
+		if err := t.Put(id, rec); err != nil {
+			return err
+		}
+	}
+	for name := range before.Names {
+		if _, ok := after.Names[name]; !ok {
+			if err := t.NameDel(name); err != nil {
+				return err
+			}
+		}
+	}
+	for name, id := range after.Names {
+		if err := t.NameSet(name, id); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/snapshot/localfile/meta_shim_test.go
+++ b/snapshot/localfile/meta_shim_test.go
@@ -12,47 +12,6 @@ import (
 	"github.com/cocoonstack/cocoon/snapshot"
 )
 
-// snapshotIndex mirrors the legacy top-level DB shape for shim-based tests.
-type snapshotIndex struct {
-	Snapshots map[string]*snapshot.SnapshotRecord `json:"snapshots"`
-	Names     map[string]string                   `json:"names"`
-}
-
-func (idx *snapshotIndex) Init() {
-	if idx.Snapshots == nil {
-		idx.Snapshots = map[string]*snapshot.SnapshotRecord{}
-	}
-	if idx.Names == nil {
-		idx.Names = map[string]string{}
-	}
-}
-
-// dbUpdate is the test-only whole-index shim: materialize, run fn, write the
-// difference back. Production code never uses it.
-func (lf *LocalFile) dbUpdate(ctx context.Context, fn func(*snapshotIndex) error) error {
-	return lf.update(ctx, func(t *snapTx) error {
-		before, idx, err := materializeSnapIndex(t)
-		if err != nil {
-			return err
-		}
-		if err := fn(idx); err != nil {
-			return err
-		}
-		return writeBackSnapIndex(t, before, idx)
-	})
-}
-
-// dbRead is the test-only whole-index read shim.
-func (lf *LocalFile) dbRead(ctx context.Context, fn func(*snapshotIndex) error) error {
-	return lf.view(ctx, func(t *snapTx) error {
-		_, idx, err := materializeSnapIndex(t)
-		if err != nil {
-			return err
-		}
-		return fn(idx)
-	})
-}
-
 // TestLegacyDifferentialTrace replays the fixture op sequence over meta-json
 // and requires byte-identical output to the legacy storage layer's writes.
 func TestLegacyDifferentialTrace(t *testing.T) {
@@ -121,6 +80,47 @@ func TestLegacyDifferentialTrace(t *testing.T) {
 	if string(got) != string(after) {
 		t.Fatalf("differential trace diverged:\n got: %s\nwant: %s", got, after)
 	}
+}
+
+// snapshotIndex mirrors the legacy top-level DB shape for shim-based tests.
+type snapshotIndex struct {
+	Snapshots map[string]*snapshot.SnapshotRecord `json:"snapshots"`
+	Names     map[string]string                   `json:"names"`
+}
+
+func (idx *snapshotIndex) Init() {
+	if idx.Snapshots == nil {
+		idx.Snapshots = map[string]*snapshot.SnapshotRecord{}
+	}
+	if idx.Names == nil {
+		idx.Names = map[string]string{}
+	}
+}
+
+// dbUpdate is the test-only whole-index shim: materialize, run fn, write the
+// difference back. Production code never uses it.
+func (lf *LocalFile) dbUpdate(ctx context.Context, fn func(*snapshotIndex) error) error {
+	return lf.update(ctx, func(t *snapTx) error {
+		before, idx, err := materializeSnapIndex(t)
+		if err != nil {
+			return err
+		}
+		if err := fn(idx); err != nil {
+			return err
+		}
+		return writeBackSnapIndex(t, before, idx)
+	})
+}
+
+// dbRead is the test-only whole-index read shim.
+func (lf *LocalFile) dbRead(ctx context.Context, fn func(*snapshotIndex) error) error {
+	return lf.view(ctx, func(t *snapTx) error {
+		_, idx, err := materializeSnapIndex(t)
+		if err != nil {
+			return err
+		}
+		return fn(idx)
+	})
 }
 
 func materializeSnapIndex(t *snapTx) (*snapshotIndex, *snapshotIndex, error) {

--- a/snapshot/localfile/teardown_test.go
+++ b/snapshot/localfile/teardown_test.go
@@ -9,46 +9,6 @@ import (
 	"github.com/cocoonstack/cocoon/snapshot"
 )
 
-// injectSnapTombstone plants a dead owner's tombstone for id in the given phase.
-func injectSnapTombstone(t *testing.T, lf *LocalFile, id string, phase tombstone.Phase) {
-	t.Helper()
-	ctx := t.Context()
-	ts := lf.tombstones()
-	if err := lf.update(ctx, func(tx *snapTx) error {
-		rec, err := tx.Get(id)
-		if err != nil {
-			return err
-		}
-		cl, err := tombstone.MarshalCleanup(snapCleanup{Name: rec.Name, DataDir: rec.DataDir})
-		if err != nil {
-			return err
-		}
-		leaseID, err := ts.Lease(ctx, tx.Writer(), id, tombstone.Payload{Kind: tombstone.KindRecord, Mode: tombstone.ModeAggregate, Cleanup: cl})
-		if err != nil {
-			return err
-		}
-		if phase == tombstone.PhaseDeleting {
-			return ts.MarkDeleting(ctx, tx.Writer(), id, leaseID)
-		}
-		return nil
-	}); err != nil {
-		t.Fatalf("inject tombstone: %v", err)
-	}
-}
-
-func snapTombstonePresent(t *testing.T, lf *LocalFile, id string) bool {
-	t.Helper()
-	var present bool
-	if err := lf.view(t.Context(), func(tx *snapTx) error {
-		rec, err := lf.tombstones().Get(t.Context(), tx.Reader(), id)
-		present = rec != nil
-		return err
-	}); err != nil {
-		t.Fatalf("view tombstone: %v", err)
-	}
-	return present
-}
-
 func TestSharedLeaseEscalationLeasedRollsBack(t *testing.T) {
 	lf := newTestLF(t)
 	id := makeExportableSnapshot(t, lf, "esc-leased", map[string][]byte{"disk.raw": []byte("data")})
@@ -98,4 +58,44 @@ func TestSharedLeaseEscalationDeletingRollsForward(t *testing.T) {
 	if _, _, _, err := lf.DataDir(t.Context(), "esc-deleting"); !errors.Is(err, snapshot.ErrNotFound) {
 		t.Errorf("name still resolves after roll-forward: %v", err)
 	}
+}
+
+// injectSnapTombstone plants a dead owner's tombstone for id in the given phase.
+func injectSnapTombstone(t *testing.T, lf *LocalFile, id string, phase tombstone.Phase) {
+	t.Helper()
+	ctx := t.Context()
+	ts := lf.tombstones()
+	if err := lf.update(ctx, func(tx *snapTx) error {
+		rec, err := tx.Get(id)
+		if err != nil {
+			return err
+		}
+		cl, err := tombstone.MarshalCleanup(snapCleanup{Name: rec.Name, DataDir: rec.DataDir})
+		if err != nil {
+			return err
+		}
+		leaseID, err := ts.Lease(ctx, tx.Writer(), id, tombstone.Payload{Kind: tombstone.KindRecord, Mode: tombstone.ModeAggregate, Cleanup: cl})
+		if err != nil {
+			return err
+		}
+		if phase == tombstone.PhaseDeleting {
+			return ts.MarkDeleting(ctx, tx.Writer(), id, leaseID)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("inject tombstone: %v", err)
+	}
+}
+
+func snapTombstonePresent(t *testing.T, lf *LocalFile, id string) bool {
+	t.Helper()
+	var present bool
+	if err := lf.view(t.Context(), func(tx *snapTx) error {
+		rec, err := lf.tombstones().Get(t.Context(), tx.Reader(), id)
+		present = rec != nil
+		return err
+	}); err != nil {
+		t.Fatalf("view tombstone: %v", err)
+	}
+	return present
 }

--- a/utils/pidfd_linux.go
+++ b/utils/pidfd_linux.go
@@ -10,6 +10,16 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// OpenPidfd returns a pidfd for pid; the fd becomes readable once the process exits.
+func OpenPidfd(pid int) (int, error) { return unix.PidfdOpen(pid, 0) }
+
+// CloseFD closes a raw descriptor, ignoring a zero or negative one.
+func CloseFD(fd int) {
+	if fd > 0 {
+		_ = unix.Close(fd)
+	}
+}
+
 // terminateWithPidfd uses pidfd_open + pidfd_send_signal for TOCTOU-safe process termination. Returns false if pidfd is unavailable (kernel < 5.3).
 func terminateWithPidfd(ctx context.Context, pid int, binaryName, expectArg string, gracePeriod time.Duration) (handled bool, err error) {
 	fd, err := unix.PidfdOpen(pid, 0)
@@ -45,14 +55,4 @@ func terminateWithPidfd(ctx context.Context, pid int, binaryName, expectArg stri
 		}
 	}
 	return true, waitDead(ctx, pid, killWaitTimeout)
-}
-
-// OpenPidfd returns a pidfd for pid; the fd becomes readable once the process exits.
-func OpenPidfd(pid int) (int, error) { return unix.PidfdOpen(pid, 0) }
-
-// CloseFD closes a raw descriptor, ignoring a zero or negative one.
-func CloseFD(fd int) {
-	if fd > 0 {
-		_ = unix.Close(fd)
-	}
 }

--- a/utils/pidfd_other.go
+++ b/utils/pidfd_other.go
@@ -10,12 +10,12 @@ import (
 
 var errPidfdUnsupported = errors.New("pidfd is unsupported on this OS")
 
-func terminateWithPidfd(_ context.Context, _ int, _, _ string, _ time.Duration) (bool, error) {
-	return false, nil
-}
-
 // OpenPidfd has no counterpart outside Linux.
 func OpenPidfd(int) (int, error) { return 0, errPidfdUnsupported }
 
 // CloseFD is a no-op where no descriptor is ever opened.
 func CloseFD(int) {}
+
+func terminateWithPidfd(_ context.Context, _ int, _, _ string, _ time.Duration) (bool, error) {
+	return false, nil
+}

--- a/utils/process_linux.go
+++ b/utils/process_linux.go
@@ -24,6 +24,28 @@ func ScanProcsByBinary(binaryName string) (ProcScan, error) {
 	return scanProcsByBinary(binaryName, os.ReadFile, IsProcessAlive)
 }
 
+// Find returns the cached pids whose cmdline contains expectArg, sorted numerically; empty expectArg matches all.
+func (s ProcScan) Find(expectArg string) []int {
+	var pids []int
+	for _, e := range s {
+		_, rest, _ := strings.Cut(e.cmdline, "\x00")
+		if expectArg == "" || strings.Contains(rest, expectArg) {
+			pids = append(pids, e.pid)
+		}
+	}
+	slices.Sort(pids)
+	return pids
+}
+
+// FindVMMByCmdline is the one-shot equivalent of ScanProcsByBinary().Find(); batch callers should use ScanProcsByBinary directly to share one /proc walk.
+func FindVMMByCmdline(binaryName, expectArg string) ([]int, error) {
+	scan, err := ScanProcsByBinary(binaryName)
+	if err != nil {
+		return nil, err
+	}
+	return scan.Find(expectArg), nil
+}
+
 func scanProcsByBinary(binaryName string, readFile func(string) ([]byte, error), alive func(int) bool) (ProcScan, error) {
 	entries, err := os.ReadDir("/proc")
 	if err != nil {
@@ -51,28 +73,6 @@ func scanProcsByBinary(binaryName string, readFile func(string) ([]byte, error),
 		scan = append(scan, procEntry{pid: pid, cmdline: string(data)})
 	}
 	return scan, nil
-}
-
-// Find returns the cached pids whose cmdline contains expectArg, sorted numerically; empty expectArg matches all.
-func (s ProcScan) Find(expectArg string) []int {
-	var pids []int
-	for _, e := range s {
-		_, rest, _ := strings.Cut(e.cmdline, "\x00")
-		if expectArg == "" || strings.Contains(rest, expectArg) {
-			pids = append(pids, e.pid)
-		}
-	}
-	slices.Sort(pids)
-	return pids
-}
-
-// FindVMMByCmdline is the one-shot equivalent of ScanProcsByBinary().Find(); batch callers should use ScanProcsByBinary directly to share one /proc walk.
-func FindVMMByCmdline(binaryName, expectArg string) ([]int, error) {
-	scan, err := ScanProcsByBinary(binaryName)
-	if err != nil {
-		return nil, err
-	}
-	return scan.Find(expectArg), nil
 }
 
 // Match argv[0] basename strictly + expectArg substring so "bash -c 'cloud-hypervisor ...'" can't impersonate the VMM.


### PR DESCRIPTION
## What

Unset `meta_backend` now auto-resolves instead of meaning json:

- an existing store binds its engine — `meta/meta.db` → sqlite, any legacy json namespace file → json (with an INFO hint to run `cocoon meta convert`)
- a completely fresh root gets sqlite and bootstraps itself (transient-flock-serialized `InitIfMissing`, safe under concurrent first commands)
- explicit `meta_backend: json|sqlite` keeps its semantics, with one deliberate change: explicit sqlite on a completely fresh root now bootstraps instead of erroring (there is no data to shadow); explicit sqlite on an uninitialized legacy root still fails loudly
- `meta init` refuses a legacy json root even under explicit sqlite — a fresh store must never shadow existing data
- `meta convert` with unset backend now targets sqlite; doctor/check.sh mirrors the resolution (all seven json namespaces probed)

## Why

Bare-metal burst matrix (idle 16-core NVMe, CH backend, 512M guests): json's whole-file rewrite degrades linearly with resident count — create-storm round wall 326→1925 ms as residents grow 64→1024, and it drags clone bursts along (clone64 p50 194→1101 ms at 1k residents). sqlite stays flat (~250 ms rounds, clone64 p50 241 ms at 1k). json only edges sqlite below a few hundred residents; past that it taxes every operation class.

## Verification

- Unit: resolution matrix, fresh-root bootstrap, legacy-root non-shadowing, racing `InitIfMissing` (4 goroutines), crashed-bootstrap repair, crashed-conversion-target rerun, backup refusals, lock-file self-cleanup
- Hardware acceptance (bare metal, as-root): 17/17 — fresh root bootstraps sqlite with no residue; legacy json root stays json across list/gc, INFO hint logged, nothing collected; convert lands on sqlite with records intact; explicit-sqlite-on-legacy refused with guidance; `meta init` shadow guard holds; 16/16 clone burst on the default engine
- Acceptance also caught a real regression mid-round: dropping the viper `SetDefault` deregistered the key and `COCOON_META_BACKEND` was silently ignored (unit tests construct `config.Config` directly and cannot see the binding layer) — fixed by registering an empty default

## Review round

Adversarial review surfaced two crash-window bugs, fixed in the last commit: a bootstrap (or conversion target init) dying between the driver's first file touch and the schema commit used to strand an unidentified empty `meta.db`; both paths now route through the crashed-init repair. `meta backup` now refuses a missing source (the raw connection would create one) and an in-flight conversion manifest. One narrow race is accepted with rationale: on an empty root, a mixed-config window (one process still explicitly json, another already unset) can shadow a concurrent first-ever json write — engine transitions on active roots already require quiescing per the convert contract.

The `review:` commit is declaration-layout normalization only (exported-above-unexported, test helpers below tests, repo-wide) and carries zero behavior change.
