### PR TITLE
cmd: isolate a pinned sandbox hypervisor without narrowing meta conversion

### DIFF
--- a/cmd/core/init.go
+++ b/cmd/core/init.go
@@ -80,8 +80,15 @@ func InitHypervisor(ctx context.Context, conf *config.Config) (hypervisor.Hyperv
 }
 
 func InitAllHypervisors(ctx context.Context, conf *config.Config) ([]hypervisor.Hypervisor, error) {
-	result := make([]hypervisor.Hypervisor, 0, len(hypervisorFactories))
-	for _, f := range hypervisorFactories {
+	factories := hypervisorFactories
+	// The sandbox data plane pins itself to Firecracker so list/gc never sweep
+	// a co-located desktop's Cloud Hypervisor VMs. Backend selection alone must
+	// not change the scope of ordinary multi-backend cocoon installations.
+	if conf.PinHypervisor {
+		factories = onlyHypervisorFactory(conf.Hypervisor())
+	}
+	result := make([]hypervisor.Hypervisor, 0, len(factories))
+	for _, f := range factories {
 		h, err := f.ctor(ctx, conf)
 		if err != nil {
 			return nil, fmt.Errorf("init hypervisor %s: %w", f.typ, err)
@@ -89,6 +96,16 @@ func InitAllHypervisors(ctx context.Context, conf *config.Config) ([]hypervisor.
 		result = append(result, h)
 	}
 	return result, nil
+}
+
+// onlyHypervisorFactory returns the single factory for typ (empty if unknown).
+func onlyHypervisorFactory(typ config.HypervisorType) []hypervisorFactory {
+	for _, f := range hypervisorFactories {
+		if f.typ == typ {
+			return []hypervisorFactory{f}
+		}
+	}
+	return nil
 }
 
 func InitNetwork(conf *config.Config) (network.Network, error) {

--- a/cmd/core/init_test.go
+++ b/cmd/core/init_test.go
@@ -1,0 +1,91 @@
+package core
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/cocoonstack/cocoon/config"
+	"github.com/cocoonstack/cocoon/hypervisor"
+)
+
+func resetMetaStoreForTest(t *testing.T) {
+	t.Helper()
+	reset := func() {
+		CloseMetaStore(t.Context())
+		metaOnce = sync.Once{}
+		metaStore = nil
+		metaErr = nil
+	}
+	reset()
+	t.Cleanup(reset)
+}
+
+// TestInitAllHypervisorsFirecrackerPinned guards the desktop-isolation contract:
+// selecting Firecracker alone keeps normal multi-backend behavior; the explicit
+// pin is what restricts list/gc to Firecracker on a shared sandbox host.
+func TestInitAllHypervisorsFirecrackerPinned(t *testing.T) {
+	t.Run("pinned returns only firecracker", func(t *testing.T) {
+		resetMetaStoreForTest(t)
+		conf := &config.Config{RootDir: t.TempDir(), RunDir: t.TempDir(), LogDir: t.TempDir(), UseFirecracker: true, PinHypervisor: true}
+		hypers, err := InitAllHypervisors(t.Context(), conf)
+		if err != nil {
+			t.Fatalf("InitAllHypervisors: %v", err)
+		}
+		if len(hypers) != 1 || hypers[0].Type() != string(config.HypervisorFirecracker) {
+			got := make([]string, len(hypers))
+			for i, h := range hypers {
+				got[i] = h.Type()
+			}
+			t.Fatalf("pinned engine constructed %v, want only [%s]", got, config.HypervisorFirecracker)
+		}
+	})
+
+	t.Run("selected but unpinned returns every backend", func(t *testing.T) {
+		resetMetaStoreForTest(t)
+		conf := &config.Config{RootDir: t.TempDir(), RunDir: t.TempDir(), LogDir: t.TempDir(), UseFirecracker: true}
+		hypers, err := InitAllHypervisors(t.Context(), conf)
+		if err != nil {
+			t.Fatalf("InitAllHypervisors: %v", err)
+		}
+		if len(hypers) != len(hypervisorFactories) {
+			t.Fatalf("unpinned engine constructed %d backends, want %d", len(hypers), len(hypervisorFactories))
+		}
+	})
+}
+
+func TestMetaNamespacesFirecrackerPinned(t *testing.T) {
+	ch := hypervisor.VMNamespaceName(string(config.HypervisorCloudHypervisor))
+	fc := hypervisor.VMNamespaceName(string(config.HypervisorFirecracker))
+	wholeSQLite := map[string]bool{}
+	for _, ns := range MetaNamespaces() {
+		wholeSQLite[ns.Name] = true
+	}
+	for _, tt := range []struct {
+		name        string
+		useFC       bool
+		pinned      bool
+		wantRuntime map[string]bool
+	}{
+		{name: "firecracker pinned", useFC: true, pinned: true, wantRuntime: map[string]bool{fc: true}},
+		{name: "cloud hypervisor pinned", pinned: true, wantRuntime: map[string]bool{ch: true}},
+		{name: "selected but unpinned", useFC: true, wantRuntime: map[string]bool{ch: true, fc: true}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := &config.Config{RootDir: t.TempDir(), UseFirecracker: tt.useFC, PinHypervisor: tt.pinned}
+			wholeJSON := map[string]bool{}
+			for _, ns := range MetaJSONNamespaces(conf) {
+				wholeJSON[ns.Name] = true
+			}
+			if !wholeSQLite[ch] || !wholeSQLite[fc] || !wholeJSON[ch] || !wholeJSON[fc] {
+				t.Fatalf("whole-store scope changed: sqlite=%v json=%v", wholeSQLite, wholeJSON)
+			}
+			runtimeJSON := map[string]bool{}
+			for _, ns := range runtimeJSONNamespaces(conf) {
+				runtimeJSON[ns.Name] = true
+			}
+			if runtimeJSON[ch] != tt.wantRuntime[ch] || runtimeJSON[fc] != tt.wantRuntime[fc] {
+				t.Errorf("runtime json scope: ch=%v fc=%v, want ch=%v fc=%v", runtimeJSON[ch], runtimeJSON[fc], tt.wantRuntime[ch], tt.wantRuntime[fc])
+			}
+		})
+	}
+}

--- a/cmd/core/metastore.go
+++ b/cmd/core/metastore.go
@@ -51,8 +51,9 @@ var (
 	}}
 )
 
-// MetaNamespaces lists every namespace with its tables — the engine-neutral
-// declaration both engines consume.
+// MetaNamespaces lists the stable whole-root namespace set used by sqlite
+// and conversion. Conversion may retire a whole sqlite database, so this set
+// must never depend on a process-local hypervisor pin.
 func MetaNamespaces() []metasqlite.Namespace {
 	return []metasqlite.Namespace{
 		{Name: hypervisor.VMNamespaceName(string(config.HypervisorCloudHypervisor)), Tables: []string{hypervisor.TableRecords, hypervisor.TableNames, hypervisor.TableOrphanDirs, tombstone.TableName}},
@@ -85,6 +86,26 @@ func MetaJSONNamespaces(conf *config.Config) []metajson.Namespace {
 			Codec:    metajson.GenericCodec{},
 		},
 	}
+}
+
+// runtimeJSONNamespaces scopes only ordinary legacy-json opens. Whole-store
+// conversion always uses MetaJSONNamespaces so its manifest has a fixed scope.
+func runtimeJSONNamespaces(conf *config.Config) []metajson.Namespace {
+	namespaces := MetaJSONNamespaces(conf)
+	if !conf.PinHypervisor {
+		return namespaces
+	}
+	selected := hypervisor.VMNamespaceName(string(conf.Hypervisor()))
+	ch := hypervisor.VMNamespaceName(string(config.HypervisorCloudHypervisor))
+	fc := hypervisor.VMNamespaceName(string(config.HypervisorFirecracker))
+	result := make([]metajson.Namespace, 0, len(namespaces)-1)
+	for _, ns := range namespaces {
+		if (ns.Name == ch || ns.Name == fc) && ns.Name != selected {
+			continue
+		}
+		result = append(result, ns)
+	}
+	return result
 }
 
 // MetaDBPath is the sqlite engine's database under the meta root.
@@ -149,7 +170,7 @@ func MetaStore(conf *config.Config) (meta.Store, error) {
 		if conf.MetaBackend == "" {
 			log.WithFunc("core.MetaStore").Info(ctx, "legacy json meta store in use; `cocoon meta convert` upgrades it to sqlite")
 		}
-		if s, err := metajson.Open(MetaJSONNamespaces(conf)...); err != nil {
+		if s, err := metajson.Open(runtimeJSONNamespaces(conf)...); err != nil {
 			metaErr = err
 		} else {
 			metaStore = s

--- a/cmd/meta/handler.go
+++ b/cmd/meta/handler.go
@@ -29,6 +29,9 @@ func (h Handler) InitStore(cmd *cobra.Command, _ []string) error {
 	if cmdcore.LegacyJSONPresent(conf) {
 		return fmt.Errorf("legacy json metadata present; a fresh sqlite store would shadow it — run `cocoon meta convert`")
 	}
+	if conf.PinHypervisor {
+		return fmt.Errorf("meta init operates on the whole root; rerun with pin_hypervisor disabled")
+	}
 	dbPath := cmdcore.MetaDBPath(conf)
 	if err := metasqlite.Init(ctx, dbPath, cmdcore.MetaNamespaces()...); err != nil {
 		return err
@@ -41,6 +44,9 @@ func (h Handler) Convert(cmd *cobra.Command, _ []string) error {
 	ctx, conf, err := h.Init(cmd)
 	if err != nil {
 		return err
+	}
+	if conf.PinHypervisor {
+		return fmt.Errorf("meta convert operates on the whole root; stop every cocoon consumer sharing it and rerun with pin_hypervisor disabled")
 	}
 	// The configured backend is the sole target authority (§6): convert
 	// always moves the OTHER engine's data into the effective backend.

--- a/cmd/meta/handler_test.go
+++ b/cmd/meta/handler_test.go
@@ -1,0 +1,24 @@
+package meta
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
+	"github.com/cocoonstack/cocoon/config"
+)
+
+func TestConvertRejectsPinnedScope(t *testing.T) {
+	conf := &config.Config{PinHypervisor: true, MetaBackend: "sqlite"}
+	h := Handler{BaseHandler: cmdcore.BaseHandler{ConfProvider: func() *config.Config { return conf }}}
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+	if err := h.Convert(cmd, nil); err == nil || !strings.Contains(err.Error(), "whole root") {
+		t.Fatalf("Convert error = %v, want whole-root pin rejection", err)
+	}
+	if err := h.InitStore(cmd, nil); err == nil || !strings.Contains(err.Error(), "whole root") {
+		t.Fatalf("InitStore error = %v, want whole-root pin rejection", err)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,6 +66,10 @@ func newRootCmd() *cobra.Command {
 
 	viper.SetEnvPrefix("COCOON")
 	viper.AutomaticEnv()
+	// These fields have no persistent flag/default, so AutomaticEnv+Unmarshal
+	// will not see their COCOON_* values without explicit binds.
+	_ = viper.BindEnv("use_firecracker")
+	_ = viper.BindEnv("pin_hypervisor")
 	viper.SetDefault("root_dir", "/var/lib/cocoon")
 	viper.SetDefault("run_dir", "/var/lib/cocoon/run")
 	viper.SetDefault("log_dir", "/var/log/cocoon")

--- a/config/config.go
+++ b/config/config.go
@@ -40,6 +40,9 @@ type Config struct {
 	FCBinary string `json:"fc_binary" mapstructure:"fc_binary"`
 	// UseFirecracker selects the Firecracker backend (--fc flag). Default: false (Cloud Hypervisor).
 	UseFirecracker bool `json:"use_firecracker,omitempty" mapstructure:"use_firecracker"`
+	// PinHypervisor restricts multi-backend operations (list/gc) and the legacy
+	// json VM namespace to Hypervisor(). It does not narrow whole-store conversion.
+	PinHypervisor bool `json:"pin_hypervisor,omitempty" mapstructure:"pin_hypervisor"`
 	// StopTimeoutSeconds: guest ACPI grace before SIGTERM/SIGKILL escalation. Default: 30.
 	StopTimeoutSeconds int `json:"stop_timeout_seconds" mapstructure:"stop_timeout_seconds"`
 	// PoolSize: goroutine pool size for concurrent operations; 0 = runtime.NumCPU().

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -60,6 +60,10 @@ cocoon
 
 The meta engine is selected by `meta_backend` in the config; unset auto-resolves — an existing store binds its engine (legacy json roots keep json), fresh roots get `sqlite` and bootstrap themselves. `meta convert` always converts TO the effective backend (default sqlite).
 
+`pin_hypervisor` (`COCOON_PIN_HYPERVISOR=1`) scopes runtime list/GC and
+legacy-json VM access only; both whole-root mutation commands refuse while the
+pin is set so it cannot be mistaken for a partial-engine operation.
+
 ## Global Flags
 
 | Flag              | Env Variable                   | Default            | Description                            |


### PR DESCRIPTION
## What

Adds an explicit `pin_hypervisor` scope so a co-located **sandbox** hypervisor can be isolated from a **desktop** hypervisor sharing the same host: sandbox `list`/GC and legacy JSON opens can no longer reach across to a desktop VM, without changing ordinary `use_firecracker` semantics.

## Why

When a sandbox hypervisor and a desktop hypervisor run on one machine, an unscoped `list`/GC pass can touch the wrong hypervisor's VMs. Pinning the scope keeps each plane's `vm list` and garbage collection confined to its own hypervisor.

## Notes

- SQLite and conversion declarations stay whole-root and stable — the pin does **not** narrow meta conversion.
- Pinned meta init/convert **fail before writing**, so a runtime scope can never be mistaken for a partial database migration.
- New unit tests cover the pinned init/convert paths and the meta handler.

`go build ./...` and `go test ./cmd/core/... ./cmd/meta/...` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)