### PR TITLE
vm: add reconcile-stale-create verb over a shared ownerless-create reclaim

### DIFF
--- a/cmd/core/utils.go
+++ b/cmd/core/utils.go
@@ -24,12 +24,17 @@ import (
 )
 
 func FindHypervisor(ctx context.Context, conf *config.Config, ref string) (hypervisor.Hypervisor, error) {
+	owner, _, err := FindVM(ctx, conf, ref)
+	return owner, err
+}
+
+// FindVM resolves ref to its owning hypervisor and the resolved VM.
+func FindVM(ctx context.Context, conf *config.Config, ref string) (hypervisor.Hypervisor, *types.VM, error) {
 	hypers, err := InitAllHypervisors(ctx, conf)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	owner, _, err := resolveVMOwner(ctx, hypers, ref)
-	return owner, err
+	return resolveVMOwner(ctx, hypers, ref)
 }
 
 func ListAllVMs(ctx context.Context, hypers []hypervisor.Hypervisor) ([]*types.VM, error) {

--- a/cmd/storebench/main.go
+++ b/cmd/storebench/main.go
@@ -26,6 +26,20 @@ const opGet = "get"
 
 var benchPayload = json.RawMessage(`{"name":"bench","state":"running","config":{"cpu":2,"memory":1073741824}}`)
 
+type benchConfig struct{ dir string }
+
+func (c benchConfig) BinaryName() string                  { return "bench" }
+func (c benchConfig) RootDirPath() string                 { return c.dir }
+func (c benchConfig) PIDFileName() string                 { return "pid" }
+func (c benchConfig) TerminateGracePeriod() time.Duration { return time.Second }
+func (c benchConfig) SocketWaitTimeout() time.Duration    { return time.Second }
+func (c benchConfig) EffectivePoolSize() int              { return 4 }
+func (c benchConfig) EnsureDirs() error                   { return nil }
+func (c benchConfig) RunDir() string                      { return c.dir }
+func (c benchConfig) LogDir() string                      { return c.dir }
+func (c benchConfig) VMRunDir(id string) string           { return filepath.Join(c.dir, id) }
+func (c benchConfig) VMLogDir(id string) string           { return filepath.Join(c.dir, id) }
+
 func main() {
 	if len(os.Args) < 3 {
 		fmt.Fprintln(os.Stderr, "usage: storebench update|get <engine> <n> <ops> [dir]")
@@ -277,17 +291,3 @@ func argDir(i int) string {
 func uniquePayload(i int) json.RawMessage {
 	return json.RawMessage(fmt.Sprintf(`{"name":"bench","state":"running","seq":%d}`, i))
 }
-
-type benchConfig struct{ dir string }
-
-func (c benchConfig) BinaryName() string                  { return "bench" }
-func (c benchConfig) RootDirPath() string                 { return c.dir }
-func (c benchConfig) PIDFileName() string                 { return "pid" }
-func (c benchConfig) TerminateGracePeriod() time.Duration { return time.Second }
-func (c benchConfig) SocketWaitTimeout() time.Duration    { return time.Second }
-func (c benchConfig) EffectivePoolSize() int              { return 4 }
-func (c benchConfig) EnsureDirs() error                   { return nil }
-func (c benchConfig) RunDir() string                      { return c.dir }
-func (c benchConfig) LogDir() string                      { return c.dir }
-func (c benchConfig) VMRunDir(id string) string           { return filepath.Join(c.dir, id) }
-func (c benchConfig) VMLogDir(id string) string           { return filepath.Join(c.dir, id) }

--- a/cmd/vm/commands.go
+++ b/cmd/vm/commands.go
@@ -122,6 +122,14 @@ func Command(h Handler) *cobra.Command {
 	rmCmd.Flags().Bool("force", false, "force delete running VMs (immediate SIGTERM/SIGKILL, no graceful window)")
 	cliutil.AddOutputFlag(rmCmd)
 
+	reconcileStaleCreateCmd := &cobra.Command{
+		Use:   "reconcile-stale-create VM",
+		Short: "Reclaim an ownerless creating placeholder (refuses while a create or clone is in flight)",
+		Args:  cobra.ExactArgs(1),
+		RunE:  h.ReconcileStaleCreate,
+	}
+	cliutil.AddOutputFlag(reconcileStaleCreateCmd)
+
 	restoreCmd := &cobra.Command{
 		Use:   "restore [flags] VM [SNAPSHOT]",
 		Short: "Restore a running or stopped VM to a previous snapshot (or a directory via --from-dir)",
@@ -184,6 +192,7 @@ func Command(h Handler) *cobra.Command {
 		reseedCmd,
 		logsCmd,
 		rmCmd,
+		reconcileStaleCreateCmd,
 		restoreCmd,
 		hibernateCmd,
 		debugCmd,

--- a/cmd/vm/reconcile.go
+++ b/cmd/vm/reconcile.go
@@ -1,0 +1,50 @@
+package vm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/projecteru2/core/log"
+	"github.com/spf13/cobra"
+
+	"github.com/cocoonstack/cocoon/cmd/cliutil"
+	cmdcore "github.com/cocoonstack/cocoon/cmd/core"
+	"github.com/cocoonstack/cocoon/hypervisor"
+)
+
+type staleCreateResult struct {
+	ID      string                        `json:"id,omitempty"`
+	Outcome hypervisor.StaleCreateOutcome `json:"outcome"`
+}
+
+func (h Handler) ReconcileStaleCreate(cmd *cobra.Command, args []string) error {
+	ctx, conf, err := h.Init(cmd)
+	if err != nil {
+		return err
+	}
+	hyper, vm, err := cmdcore.FindVM(ctx, conf, args[0])
+	if errors.Is(err, hypervisor.ErrNotFound) {
+		return outputStaleCreate(ctx, cmd, args[0], staleCreateResult{Outcome: hypervisor.StaleCreateNotFound})
+	}
+	if err != nil {
+		return err
+	}
+	sup, ok := hyper.(hypervisor.Supervisable)
+	if !ok {
+		return fmt.Errorf("backend %s cannot reconcile stale creates", hyper.Type())
+	}
+	outcome, err := sup.ReconcileStaleCreate(ctx, vm.ID)
+	if err != nil {
+		return fmt.Errorf("reconcile stale create: %w", err)
+	}
+	return outputStaleCreate(ctx, cmd, args[0], staleCreateResult{ID: vm.ID, Outcome: outcome})
+}
+
+func outputStaleCreate(ctx context.Context, cmd *cobra.Command, ref string, res staleCreateResult) error {
+	if done, jsonErr := cliutil.MaybeOutputJSON(cmd, res); done {
+		return jsonErr
+	}
+	log.WithFunc("cmd.vm.reconcileStaleCreate").Infof(ctx, "%s: %s", ref, res.Outcome)
+	return nil
+}

--- a/daemon/reconcile.go
+++ b/daemon/reconcile.go
@@ -138,23 +138,17 @@ func (d *Daemon) convergeDead(ctx context.Context, b Supervisor, key watchKey, r
 	return nil
 }
 
-// collectOwnerless reclaims a creating placeholder whose owner died; a free ops lock is the proof, since create and clone hold it from prereserve through the final record commit.
+// collectOwnerless routes a creating placeholder to the backend's shared stale-create reclaim; busy and raced outcomes are healthy skips.
 func (d *Daemon) collectOwnerless(ctx context.Context, b Supervisor, rec *hypervisor.VMRecord) error {
-	unlock, ok, err := d.tryLock(ctx, b, rec.ID)
-	if !ok {
-		return err
-	}
-	defer unlock()
-	fresh, err := b.PeekRecord(ctx, rec.ID)
-	if err != nil || fresh == nil || fresh.State != types.VMStateCreating {
-		return err
-	}
 	logger := log.WithFunc("daemon.collectOwnerless")
-	if err := b.CollectStaleCreate(ctx, rec.ID, fresh); err != nil {
+	outcome, err := b.ReconcileStaleCreate(ctx, rec.ID)
+	if err != nil {
 		logger.Errorf(ctx, err, "collect ownerless create %s", rec.ID)
 		return err
 	}
-	logger.Warnf(ctx, "collected ownerless creating VM %s", rec.ID)
+	if outcome == hypervisor.StaleCreateCollected {
+		logger.Warnf(ctx, "collected ownerless creating VM %s", rec.ID)
+	}
 	return nil
 }
 

--- a/daemon/reconcile_test.go
+++ b/daemon/reconcile_test.go
@@ -359,12 +359,25 @@ func (f *fakeSupervisor) RecoverTombstone(_ context.Context, vmID string) (bool,
 	return true, nil
 }
 
-func (f *fakeSupervisor) CollectStaleCreate(_ context.Context, vmID string, _ *hypervisor.VMRecord) error {
+func (f *fakeSupervisor) ReconcileStaleCreate(_ context.Context, vmID string) (hypervisor.StaleCreateOutcome, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.lockErr != nil {
+		return "", f.lockErr
+	}
+	if _, held := f.busy[vmID]; held {
+		return hypervisor.StaleCreateBusy, nil
+	}
+	rec := f.records[vmID]
+	if rec == nil {
+		return hypervisor.StaleCreateNotFound, nil
+	}
+	if rec.State != types.VMStateCreating {
+		return hypervisor.StaleCreateNotCreating, nil
+	}
 	f.collected = append(f.collected, vmID)
 	delete(f.records, vmID)
-	return nil
+	return hypervisor.StaleCreateCollected, nil
 }
 
 func newFake() *fakeSupervisor {

--- a/daemon/reconcile_test.go
+++ b/daemon/reconcile_test.go
@@ -298,11 +298,9 @@ func (f *fakeSupervisor) ObserveVMM(_ context.Context, rec *hypervisor.VMRecord)
 func (f *fakeSupervisor) TryLockVMOps(_ context.Context, vmID string) (func(), bool, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if f.lockErr != nil {
-		return nil, false, f.lockErr
-	}
-	if _, held := f.busy[vmID]; held {
-		return nil, false, nil
+	busy, err := f.lockState(vmID)
+	if err != nil || busy {
+		return nil, false, err
 	}
 	return func() {}, true, nil
 }
@@ -357,10 +355,11 @@ func (f *fakeSupervisor) RecoverTombstone(_ context.Context, vmID string) (bool,
 func (f *fakeSupervisor) ReconcileStaleCreate(_ context.Context, vmID string) (hypervisor.StaleCreateOutcome, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if f.lockErr != nil {
-		return "", f.lockErr
+	busy, err := f.lockState(vmID)
+	if err != nil {
+		return "", err
 	}
-	if _, held := f.busy[vmID]; held {
+	if busy {
 		return hypervisor.StaleCreateBusy, nil
 	}
 	rec := f.records[vmID]
@@ -373,6 +372,15 @@ func (f *fakeSupervisor) ReconcileStaleCreate(_ context.Context, vmID string) (h
 	f.collected = append(f.collected, vmID)
 	delete(f.records, vmID)
 	return hypervisor.StaleCreateCollected, nil
+}
+
+// lockState reads the scripted lock condition; the caller holds f.mu.
+func (f *fakeSupervisor) lockState(vmID string) (busy bool, err error) {
+	if f.lockErr != nil {
+		return false, f.lockErr
+	}
+	_, held := f.busy[vmID]
+	return held, nil
 }
 
 func (f *fakeSupervisor) put(rec *hypervisor.VMRecord) *fakeSupervisor {

--- a/daemon/reconcile_test.go
+++ b/daemon/reconcile_test.go
@@ -263,11 +263,6 @@ type fakeSupervisor struct {
 	resumed   []string
 }
 
-func (f *fakeSupervisor) put(rec *hypervisor.VMRecord) *fakeSupervisor {
-	f.records[rec.ID] = rec
-	return f
-}
-
 func (f *fakeSupervisor) Type() string { return "fake-hv" }
 
 func (f *fakeSupervisor) ScanSupervision(context.Context) (hypervisor.SupervisionScan, error) {
@@ -378,6 +373,11 @@ func (f *fakeSupervisor) ReconcileStaleCreate(_ context.Context, vmID string) (h
 	f.collected = append(f.collected, vmID)
 	delete(f.records, vmID)
 	return hypervisor.StaleCreateCollected, nil
+}
+
+func (f *fakeSupervisor) put(rec *hypervisor.VMRecord) *fakeSupervisor {
+	f.records[rec.ID] = rec
+	return f
 }
 
 func newFake() *fakeSupervisor {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -217,7 +217,7 @@ The dir is read-only across the call, so multiple clones of the same dir (golden
 | `not-creating` | The record has left the creating state; nothing was touched |
 | `not-found` | No record under that ref (already collected, or never existed) |
 
-All four outcomes exit 0; a non-zero exit is a real failure (store I/O, an orphan VMM that would not die). The [daemon](daemon.md)'s ownerless-create reconcile and [GC](gc.md)'s `stale-creating` sweep run the same reclaim; this verb is for embedders that must clear skeletons synchronously (e.g. a startup reconcile) without waiting for either.
+All four outcomes exit 0; a non-zero exit is a real failure (store I/O, an orphan VMM that would not die). At a startup reconcile, `busy` means an external create or clone legitimately owns the record: leave it un-indexed and revisit on the next pass — it either becomes a live VM or becomes collectable. The [daemon](daemon.md)'s ownerless-create reconcile and [GC](gc.md)'s `stale-creating` sweep run the same reclaim; this verb is for embedders that must clear skeletons synchronously (e.g. a startup reconcile) without waiting for either.
 
 ### Reseed Flags
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -25,6 +25,7 @@ cocoon
 │   ├── reseed [--machine-id] VM   Force a CRNG reseed inside the guest (fresh entropy over vsock)
 │   ├── logs [-f] [--tail N] VM    Print the per-VM hypervisor log file
 │   ├── rm [flags] VM [VM...]      Delete VM(s) (--force kills running VMs immediately)
+│   ├── reconcile-stale-create VM  Reclaim an ownerless creating placeholder (JSON outcome)
 │   ├── restore [flags] VM SNAP   Restore a VM (running or stopped) to a snapshot
 │   ├── hibernate [flags] VM       Atomically snapshot a running VM and stop it
 │   ├── status [VM...]             Watch VM status in real time
@@ -204,6 +205,19 @@ cocoon vm restore my-vm --from-dir /unrelated/lineage --force
 ```
 
 The dir is read-only across the call, so multiple clones of the same dir (golden image use case) are safe. Pass `--pull` if the base image's blobs may not be present locally — `EnsureImage` reads `image_blob_ids` from the envelope and pulls as needed.
+
+### Reconcile Stale Create
+
+`cocoon vm reconcile-stale-create VM` reclaims a `creating` placeholder whose owning create or clone died mid-flight, freeing the record and its name. A free VM ops lock is the proof of ownerlessness — create and clone hold it from prereserve through the final record commit — so the verb never races an in-flight operation and needs no age heuristics (contrast `vm rm --force`, which queues behind a live clone and then deletes the freshly created VM). With `--output json` it prints `{"id": "...", "outcome": "..."}`:
+
+| Outcome | Meaning |
+|------|-------------|
+| `collected` | Placeholder reclaimed; record and name are free |
+| `busy` | An in-flight operation owns the VM; nothing was touched — not worth retrying blindly |
+| `not-creating` | The record has left the creating state; nothing was touched |
+| `not-found` | No record under that ref (already collected, or never existed) |
+
+All four outcomes exit 0; a non-zero exit is a real failure (store I/O, an orphan VMM that would not die). The [daemon](daemon.md)'s ownerless-create reconcile and [GC](gc.md)'s `stale-creating` sweep run the same reclaim; this verb is for embedders that must clear skeletons synchronously (e.g. a startup reconcile) without waiting for either.
 
 ### Reseed Flags
 

--- a/gc/orchestrator.go
+++ b/gc/orchestrator.go
@@ -20,11 +20,6 @@ type Orchestrator struct {
 // New returns an Orchestrator with no registered modules.
 func New() *Orchestrator { return &Orchestrator{} }
 
-// Register is package-level because Go methods can't have type params.
-func Register[S any](o *Orchestrator, m Module[S]) {
-	o.modules = append(o.modules, m)
-}
-
 // Run executes one GC cycle: recover tombstones by phase, then snapshot →
 // resolve → collect; modules revalidate every destructive decision under
 // their own entity locks (§5 loose-snapshot rule).
@@ -69,6 +64,11 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 	logger.Infof(ctx, "completed: %s (failures: %d, duration: %s)",
 		formatSummary(summary), len(errs), time.Since(start).Truncate(time.Millisecond))
 	return errors.Join(errs...)
+}
+
+// Register is package-level because Go methods can't have type params.
+func Register[S any](o *Orchestrator, m Module[S]) {
+	o.modules = append(o.modules, m)
 }
 
 // formatSummary renders counts as `m1=N m2=M`, sorted.

--- a/hypervisor/backend.go
+++ b/hypervisor/backend.go
@@ -62,6 +62,8 @@ type BackendConfig interface {
 	VMLogDir(id string) string
 }
 
+var _ Supervisable = (*Backend)(nil)
+
 // Backend provides shared store operations for hypervisor backends.
 type Backend struct {
 	Typ      string

--- a/hypervisor/clone.go
+++ b/hypervisor/clone.go
@@ -43,6 +43,25 @@ func (b *Backend) CloneFromStream(
 	})
 }
 
+// FinalizeClone persists the record and emits the clone open-interval pair.
+func (b *Backend) FinalizeClone(ctx context.Context, vmID string, info *types.VM, bootCfg *types.BootConfig, blobIDs map[string]struct{}, sourceSnapshotID string) error {
+	if err := b.UpdateRecord(ctx, vmID, func(r *VMRecord) error {
+		r.VM = *info
+		// The subpackage building info cannot reach markTransition; without this the clone commits at generation zero.
+		markTransition(r, info.State, types.TransitionClone, timeNow())
+		r.BootConfig = bootCfg
+		r.FirstBooted = true
+		if blobIDs != nil {
+			r.ImageBlobIDs = blobIDs
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	b.emitOpenInterval(ctx, info, metering.ReasonClone, sourceSnapshotID, timeNow())
+	return nil
+}
+
 func (b *Backend) cloneBase(
 	ctx context.Context, vmID string, vmCfg *types.VMConfig,
 	net types.NetSetup, snapshotConfig *types.SnapshotConfig,
@@ -61,23 +80,4 @@ func (b *Backend) cloneBase(
 		return nil, err
 	}
 	return afterExtract(ctx, vmID, vmCfg, net, runDir, logDir, now, snapshotConfig.ID)
-}
-
-// FinalizeClone persists the record and emits the clone open-interval pair.
-func (b *Backend) FinalizeClone(ctx context.Context, vmID string, info *types.VM, bootCfg *types.BootConfig, blobIDs map[string]struct{}, sourceSnapshotID string) error {
-	if err := b.UpdateRecord(ctx, vmID, func(r *VMRecord) error {
-		r.VM = *info
-		// The subpackage building info cannot reach markTransition; without this the clone commits at generation zero.
-		markTransition(r, info.State, types.TransitionClone, timeNow())
-		r.BootConfig = bootCfg
-		r.FirstBooted = true
-		if blobIDs != nil {
-			r.ImageBlobIDs = blobIDs
-		}
-		return nil
-	}); err != nil {
-		return err
-	}
-	b.emitOpenInterval(ctx, info, metering.ReasonClone, sourceSnapshotID, timeNow())
-	return nil
 }

--- a/hypervisor/cloudhypervisor/cloudhypervisor.go
+++ b/hypervisor/cloudhypervisor/cloudhypervisor.go
@@ -5,6 +5,10 @@ import (
 	"fmt"
 
 	"github.com/cocoonstack/cocoon/config"
+	"github.com/cocoonstack/cocoon/extend/disk"
+	"github.com/cocoonstack/cocoon/extend/fs"
+	"github.com/cocoonstack/cocoon/extend/netresize"
+	"github.com/cocoonstack/cocoon/extend/vfio"
 	"github.com/cocoonstack/cocoon/hypervisor"
 	"github.com/cocoonstack/cocoon/meta"
 	"github.com/cocoonstack/cocoon/metering"
@@ -15,6 +19,13 @@ const typ = "cloud-hypervisor"
 var (
 	_ hypervisor.Hypervisor = (*CloudHypervisor)(nil)
 	_ hypervisor.Direct     = (*CloudHypervisor)(nil)
+	_ disk.Attacher         = (*CloudHypervisor)(nil)
+	_ disk.Lister           = (*CloudHypervisor)(nil)
+	_ fs.Attacher           = (*CloudHypervisor)(nil)
+	_ fs.Lister             = (*CloudHypervisor)(nil)
+	_ vfio.Attacher         = (*CloudHypervisor)(nil)
+	_ vfio.Lister           = (*CloudHypervisor)(nil)
+	_ netresize.Resizer     = (*CloudHypervisor)(nil)
 )
 
 // CloudHypervisor implements hypervisor.Hypervisor.

--- a/hypervisor/cloudhypervisor/extend.go
+++ b/hypervisor/cloudhypervisor/extend.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/cocoonstack/cocoon/extend/disk"
 	"github.com/cocoonstack/cocoon/extend/fs"
-	"github.com/cocoonstack/cocoon/extend/netresize"
 	"github.com/cocoonstack/cocoon/extend/vfio"
 	"github.com/cocoonstack/cocoon/hypervisor"
 	"github.com/cocoonstack/cocoon/types"
@@ -21,16 +20,6 @@ import (
 )
 
 const chStatePaused = "Paused"
-
-var (
-	_ disk.Attacher     = (*CloudHypervisor)(nil)
-	_ disk.Lister       = (*CloudHypervisor)(nil)
-	_ fs.Attacher       = (*CloudHypervisor)(nil)
-	_ fs.Lister         = (*CloudHypervisor)(nil)
-	_ vfio.Attacher     = (*CloudHypervisor)(nil)
-	_ vfio.Lister       = (*CloudHypervisor)(nil)
-	_ netresize.Resizer = (*CloudHypervisor)(nil)
-)
 
 func (ch *CloudHypervisor) DiskAttach(ctx context.Context, vmRef string, spec disk.Spec) (string, error) {
 	if err := spec.Normalize(); err != nil {

--- a/hypervisor/gc.go
+++ b/hypervisor/gc.go
@@ -188,7 +188,7 @@ func (b *Backend) gcCollect(ctx context.Context, ids []string, snap VMGCSnapshot
 			if rec.State != types.VMStateCreating || !rec.UpdatedAt.Before(cutoff) {
 				return
 			}
-			if err := b.CollectStaleCreate(ctx, id, rec); err != nil {
+			if err := b.collectStaleCreate(ctx, id, rec); err != nil {
 				errs = append(errs, fmt.Errorf("collect %s: %w", id, err))
 				return
 			}

--- a/hypervisor/restore.go
+++ b/hypervisor/restore.go
@@ -26,14 +26,6 @@ func (b *Backend) KillForRestore(ctx context.Context, vmID string, rec *VMRecord
 	return nil
 }
 
-// failRestore marks the VM error after a restore failure; a stopped origin (the pre-kill state) is spared so hibernate wake stays retryable — run-dir-mutating steps quarantine at their own site.
-func (b *Backend) failRestore(ctx context.Context, vmID string, origin types.VMState) {
-	if origin == types.VMStateStopped {
-		return
-	}
-	b.MarkError(ctx, vmID)
-}
-
 func (b *Backend) ResolveForRestore(ctx context.Context, vmRef string) (string, *VMRecord, error) {
 	vmID, rec, err := b.ResolveAndLoad(ctx, vmRef)
 	if err != nil {
@@ -131,6 +123,14 @@ func (b *Backend) DirectRestoreSequence(ctx context.Context, vmRef string, spec 
 		return nil
 	}
 	return b.restoreCore(ctx, vmID, rec, spec.VMCfg, spec.SourceSnapshotID, spec.Kill, apply, spec.AfterExtract)
+}
+
+// failRestore marks the VM error after a restore failure; a stopped origin (the pre-kill state) is spared so hibernate wake stays retryable — run-dir-mutating steps quarantine at their own site.
+func (b *Backend) failRestore(ctx context.Context, vmID string, origin types.VMState) {
+	if origin == types.VMStateStopped {
+		return
+	}
+	b.MarkError(ctx, vmID)
 }
 
 // restoreCore is the shared kill→emit→apply→finalize tail of both restore sequences.

--- a/hypervisor/state.go
+++ b/hypervisor/state.go
@@ -28,36 +28,6 @@ func (b *Backend) WithRunningVM(ctx context.Context, rec *VMRecord, fn func(pid 
 	return b.withRunningVM(ctx, rec, nil, fn)
 }
 
-// withRunningVM resolves liveness against the caller's /proc walk; a nil scan walks now, so batch callers turn N walks into one.
-func (b *Backend) withRunningVM(ctx context.Context, rec *VMRecord, scan *utils.ProcScan, fn func(pid int) error) error {
-	logger := log.WithFunc(b.Typ + ".withRunningVM")
-	pid, pidErr := utils.ReadPIDFile(b.PIDFilePath(rec.RunDir))
-	if pidErr != nil && !errors.Is(pidErr, fs.ErrNotExist) {
-		logger.Warnf(ctx, "read PID file: %v", pidErr)
-	}
-	sockPath := SocketPath(rec.RunDir)
-	if utils.VerifyProcessCmdline(pid, b.Conf.BinaryName(), sockPath) {
-		return fn(pid)
-	}
-	// Covers pidfile/socket cleaned up before VMM exited. Fail-closed if scan errors so callers don't treat inconclusive state as ErrNotRunning.
-	scanned, scanErr := b.scanFor(scan, sockPath)
-	if scanErr != nil {
-		return fmt.Errorf("vm %s: pidfile-based check failed and /proc scan errored: %w (resolve the host issue and retry)", rec.ID, scanErr)
-	}
-	if len(scanned) == 0 {
-		return ErrNotRunning
-	}
-	logger.Warnf(ctx, "VM %s recovered live pids %v via cmdline scan", rec.ID, scanned)
-	return fn(scanned[0])
-}
-
-func (b *Backend) scanFor(scan *utils.ProcScan, sockPath string) ([]int, error) {
-	if scan != nil {
-		return scan.Find(sockPath), nil
-	}
-	return utils.FindVMMByCmdline(b.Conf.BinaryName(), sockPath)
-}
-
 // IsAPISocketLive: (true,nil)=confirmed live; (false,nil)=ENOENT/ECONNREFUSED; (true,err)=fail-closed for unknown dial errors.
 func (b *Backend) IsAPISocketLive(ctx context.Context, rec *VMRecord) (bool, error) {
 	sock := SocketPath(rec.RunDir)
@@ -134,66 +104,10 @@ func (b *Backend) UpdateStates(ctx context.Context, ids []string, state types.VM
 	})
 }
 
-// Metering entries stage inside the closure and publish only after commit, so a retried closure cannot double-emit (meta contract clause 1).
-func (b *Backend) batchUpdateVMs(ctx context.Context, ids []string, mutate func(r *VMRecord, id string) []metering.Entry) error {
-	var emits []metering.Entry
-	if err := b.update(ctx, func(t *vmTx) error {
-		staged := []metering.Entry{}
-		for _, id := range ids {
-			r, err := t.Get(id)
-			if err != nil {
-				return err
-			}
-			if r == nil {
-				continue
-			}
-			staged = append(staged, mutate(r, id)...)
-			if err := t.Put(id, r); err != nil {
-				return err
-			}
-		}
-		emits = staged
-		return nil
-	}); err != nil {
-		return err
-	}
-	b.emitAll(ctx, emits)
-	return nil
-}
-
 // MarkError flips a single VM's state to VMStateError, logging on persist failure.
 func (b *Backend) MarkError(ctx context.Context, id string) {
 	if err := b.UpdateStates(ctx, []string{id}, types.VMStateError); err != nil {
 		log.WithFunc(b.Typ+".MarkError").Errorf(ctx, err, "mark VM %s error", id)
-	}
-}
-
-// markFailedOperation records retryable network convergence after an operation may have brought plumbing up without committing a usable VMM; the daemon re-observes before acting on it.
-func (b *Backend) markFailedOperation(ctx context.Context, id string, markError bool) {
-	ctx, cancel := detachedWrite(ctx)
-	defer cancel()
-	now := timeNow()
-	if err := b.update(ctx, func(t *vmTx) error {
-		r, err := t.Get(id)
-		if err != nil || r == nil {
-			return err
-		}
-		changed := false
-		if markError && r.State != types.VMStateError {
-			markTransition(r, types.VMStateError, types.TransitionError, now)
-			changed = true
-		}
-		pending := needsQuiesce(r)
-		if r.QuiescePending != pending {
-			r.QuiescePending = pending
-			changed = true
-		}
-		if !changed {
-			return nil
-		}
-		return t.Put(id, r)
-	}); err != nil {
-		log.WithFunc(b.Typ+".markFailedOperation").Errorf(ctx, err, "persist failed operation for VM %s", id)
 	}
 }
 
@@ -280,6 +194,92 @@ func (b *Backend) ReconcileToRunning(ctx context.Context, id string) (uint64, er
 		b.Metering.Emit(ctx, b.makeEntry(metering.KindVMComputeStart, id, reason, shape, now))
 	}
 	return gen, nil
+}
+
+// withRunningVM resolves liveness against the caller's /proc walk; a nil scan walks now, so batch callers turn N walks into one.
+func (b *Backend) withRunningVM(ctx context.Context, rec *VMRecord, scan *utils.ProcScan, fn func(pid int) error) error {
+	logger := log.WithFunc(b.Typ + ".withRunningVM")
+	pid, pidErr := utils.ReadPIDFile(b.PIDFilePath(rec.RunDir))
+	if pidErr != nil && !errors.Is(pidErr, fs.ErrNotExist) {
+		logger.Warnf(ctx, "read PID file: %v", pidErr)
+	}
+	sockPath := SocketPath(rec.RunDir)
+	if utils.VerifyProcessCmdline(pid, b.Conf.BinaryName(), sockPath) {
+		return fn(pid)
+	}
+	// Covers pidfile/socket cleaned up before VMM exited. Fail-closed if scan errors so callers don't treat inconclusive state as ErrNotRunning.
+	scanned, scanErr := b.scanFor(scan, sockPath)
+	if scanErr != nil {
+		return fmt.Errorf("vm %s: pidfile-based check failed and /proc scan errored: %w (resolve the host issue and retry)", rec.ID, scanErr)
+	}
+	if len(scanned) == 0 {
+		return ErrNotRunning
+	}
+	logger.Warnf(ctx, "VM %s recovered live pids %v via cmdline scan", rec.ID, scanned)
+	return fn(scanned[0])
+}
+
+func (b *Backend) scanFor(scan *utils.ProcScan, sockPath string) ([]int, error) {
+	if scan != nil {
+		return scan.Find(sockPath), nil
+	}
+	return utils.FindVMMByCmdline(b.Conf.BinaryName(), sockPath)
+}
+
+// Metering entries stage inside the closure and publish only after commit, so a retried closure cannot double-emit (meta contract clause 1).
+func (b *Backend) batchUpdateVMs(ctx context.Context, ids []string, mutate func(r *VMRecord, id string) []metering.Entry) error {
+	var emits []metering.Entry
+	if err := b.update(ctx, func(t *vmTx) error {
+		staged := []metering.Entry{}
+		for _, id := range ids {
+			r, err := t.Get(id)
+			if err != nil {
+				return err
+			}
+			if r == nil {
+				continue
+			}
+			staged = append(staged, mutate(r, id)...)
+			if err := t.Put(id, r); err != nil {
+				return err
+			}
+		}
+		emits = staged
+		return nil
+	}); err != nil {
+		return err
+	}
+	b.emitAll(ctx, emits)
+	return nil
+}
+
+// markFailedOperation records retryable network convergence after an operation may have brought plumbing up without committing a usable VMM; the daemon re-observes before acting on it.
+func (b *Backend) markFailedOperation(ctx context.Context, id string, markError bool) {
+	ctx, cancel := detachedWrite(ctx)
+	defer cancel()
+	now := timeNow()
+	if err := b.update(ctx, func(t *vmTx) error {
+		r, err := t.Get(id)
+		if err != nil || r == nil {
+			return err
+		}
+		changed := false
+		if markError && r.State != types.VMStateError {
+			markTransition(r, types.VMStateError, types.TransitionError, now)
+			changed = true
+		}
+		pending := needsQuiesce(r)
+		if r.QuiescePending != pending {
+			r.QuiescePending = pending
+			changed = true
+		}
+		if !changed {
+			return nil
+		}
+		return t.Put(id, r)
+	}); err != nil {
+		log.WithFunc(b.Typ+".markFailedOperation").Errorf(ctx, err, "persist failed operation for VM %s", id)
+	}
 }
 
 // detachedWrite returns a context for bookkeeping writes that must survive caller cancellation, bounded by persistTimeout.

--- a/hypervisor/state_test.go
+++ b/hypervisor/state_test.go
@@ -620,15 +620,6 @@ func TestForcedRetryStateOps(t *testing.T) {
 	}
 }
 
-func newDiskStubConfig(t *testing.T) stubBackendConfig {
-	dir := t.TempDir()
-	return stubBackendConfig{
-		rootDir:   dir,
-		indexFile: filepath.Join(dir, "index.json"),
-		indexLock: filepath.Join(dir, "index.lock"),
-	}
-}
-
 // stubBackendConfig satisfies BackendConfig for tests that only exercise the
 // metering wiring; unused methods panic so accidental dependence shows up loud.
 type stubBackendConfig struct {
@@ -667,6 +658,15 @@ func (c meteringStubConfig) VMLogDir(string) string { return c.vmRunRoot }
 func (c meteringStubConfig) RunDir() string { return c.vmRunRoot }
 
 func (c meteringStubConfig) LogDir() string { return c.vmRunRoot }
+
+func newDiskStubConfig(t *testing.T) stubBackendConfig {
+	dir := t.TempDir()
+	return stubBackendConfig{
+		rootDir:   dir,
+		indexFile: filepath.Join(dir, "index.json"),
+		indexLock: filepath.Join(dir, "index.lock"),
+	}
+}
 
 func newMeteringTestBackend(t *testing.T) (*Backend, *meteringcapture.Recorder) {
 	t.Helper()

--- a/hypervisor/stop.go
+++ b/hypervisor/stop.go
@@ -105,6 +105,15 @@ func (b *Backend) DeleteAll(ctx context.Context, refs []string, force bool, stop
 	})
 }
 
+func (b *Backend) HandleStopResult(ctx context.Context, id, runDir string, runtimeFiles []string, shutdownErr error) error {
+	if shutdownErr != nil && !errors.Is(shutdownErr, ErrNotRunning) {
+		b.MarkError(ctx, id)
+		return shutdownErr
+	}
+	CleanupRuntimeFiles(ctx, runDir, runtimeFiles)
+	return nil
+}
+
 // deleteOneLocked is DeleteAll's per-VM body, run under the ops lock.
 func (b *Backend) deleteOneLocked(ctx context.Context, id string, force bool, stopLocked func(context.Context, string) error, rec *VMRecord, procScan utils.ProcScan) error {
 	sockPath := SocketPath(rec.RunDir)
@@ -154,14 +163,5 @@ func (b *Backend) deleteOneLocked(ctx context.Context, id string, force bool, st
 		computeReason = metering.ReasonStopUser
 	}
 	b.emitDeleteClose(ctx, id, shape, computeReason, hadRunningInterval)
-	return nil
-}
-
-func (b *Backend) HandleStopResult(ctx context.Context, id, runDir string, runtimeFiles []string, shutdownErr error) error {
-	if shutdownErr != nil && !errors.Is(shutdownErr, ErrNotRunning) {
-		b.MarkError(ctx, id)
-		return shutdownErr
-	}
-	CleanupRuntimeFiles(ctx, runDir, runtimeFiles)
 	return nil
 }

--- a/hypervisor/supervisor.go
+++ b/hypervisor/supervisor.go
@@ -26,8 +26,6 @@ const (
 	StaleCreateNotFound StaleCreateOutcome = "not-found"
 )
 
-var _ Supervisable = (*Backend)(nil)
-
 // StaleCreateOutcome reports what ReconcileStaleCreate did with the record.
 type StaleCreateOutcome string
 
@@ -91,16 +89,6 @@ func (b *Backend) ObserveVMMIn(ctx context.Context, rec *VMRecord, scan utils.Pr
 	return b.observe(ctx, rec, &scan)
 }
 
-func (b *Backend) observe(ctx context.Context, rec *VMRecord, scan *utils.ProcScan) (utils.ProcRef, error) {
-	var ref utils.ProcRef
-	err := b.withRunningVM(ctx, rec, scan, func(pid int) error {
-		var refErr error
-		ref, refErr = utils.ProcRefOf(pid)
-		return refErr
-	})
-	return ref, err
-}
-
 // TryLockVMOps takes the VM ops lock without blocking; ok=false with a nil error means another operation owns it.
 func (b *Backend) TryLockVMOps(ctx context.Context, vmID string) (unlock func(), ok bool, err error) {
 	l, err := opsLock(b.Conf, vmID)
@@ -121,33 +109,6 @@ func (b *Backend) ConvergeDead(ctx context.Context, id string, gen uint64, obser
 		return err
 	}
 	return b.QuiesceIfPending(ctx, id)
-}
-
-// convergeDeadRecord commits the stop transition and publishes its staged metering entry; the quiesce it schedules is the caller's to run.
-func (b *Backend) convergeDeadRecord(ctx context.Context, id string, gen uint64, observedAt time.Time) error {
-	var emit []metering.Entry
-	if err := b.update(ctx, func(t *vmTx) error {
-		emit = nil
-		r, err := t.Get(id)
-		if err != nil || r == nil {
-			return err
-		}
-		if r.TransitionGeneration != gen || !NeedsDeadConvergence(r) {
-			return nil
-		}
-		if hasOpenComputeInterval(r) {
-			emit = []metering.Entry{b.makeEntry(metering.KindVMComputeStop, id, metering.ReasonStopCrash, shapeFromConfig(r.Config), observedAt)}
-		}
-		// StoppedAt is observation time, owed even to records predating the interval bookkeeping.
-		r.StoppedAt = &observedAt
-		markTransition(r, types.VMStateStopped, types.TransitionUnexpectedExit, observedAt)
-		r.QuiescePending = needsQuiesce(r)
-		return t.Put(id, r)
-	}); err != nil {
-		return err
-	}
-	b.emitAll(ctx, emit)
-	return nil
 }
 
 // QuiesceIfPending runs a scheduled quiesce and clears the flag fenced on the generation it read; the caller holds the ops lock with no VMM live.
@@ -204,6 +165,43 @@ func (b *Backend) ReconcileStaleCreate(ctx context.Context, id string) (StaleCre
 // RecoverTombstone drives an unfinished delete to completion under the held ops lock; supervision starts deletes of its own, so it must be able to finish them.
 func (b *Backend) RecoverTombstone(ctx context.Context, id string) (bool, error) {
 	return b.recoverVMTombstone(ctx, id)
+}
+
+func (b *Backend) observe(ctx context.Context, rec *VMRecord, scan *utils.ProcScan) (utils.ProcRef, error) {
+	var ref utils.ProcRef
+	err := b.withRunningVM(ctx, rec, scan, func(pid int) error {
+		var refErr error
+		ref, refErr = utils.ProcRefOf(pid)
+		return refErr
+	})
+	return ref, err
+}
+
+// convergeDeadRecord commits the stop transition and publishes its staged metering entry; the quiesce it schedules is the caller's to run.
+func (b *Backend) convergeDeadRecord(ctx context.Context, id string, gen uint64, observedAt time.Time) error {
+	var emit []metering.Entry
+	if err := b.update(ctx, func(t *vmTx) error {
+		emit = nil
+		r, err := t.Get(id)
+		if err != nil || r == nil {
+			return err
+		}
+		if r.TransitionGeneration != gen || !NeedsDeadConvergence(r) {
+			return nil
+		}
+		if hasOpenComputeInterval(r) {
+			emit = []metering.Entry{b.makeEntry(metering.KindVMComputeStop, id, metering.ReasonStopCrash, shapeFromConfig(r.Config), observedAt)}
+		}
+		// StoppedAt is observation time, owed even to records predating the interval bookkeeping.
+		r.StoppedAt = &observedAt
+		markTransition(r, types.VMStateStopped, types.TransitionUnexpectedExit, observedAt)
+		r.QuiescePending = needsQuiesce(r)
+		return t.Put(id, r)
+	}); err != nil {
+		return err
+	}
+	b.emitAll(ctx, emit)
+	return nil
 }
 
 // collectStaleCreate runs the reclaim under the caller's held ops lock: no orphan VMM may survive, then the tombstoned delete protocol.

--- a/hypervisor/supervisor.go
+++ b/hypervisor/supervisor.go
@@ -15,7 +15,21 @@ import (
 	"github.com/cocoonstack/cocoon/utils"
 )
 
+const (
+	// StaleCreateCollected reports the ownerless placeholder was reclaimed.
+	StaleCreateCollected StaleCreateOutcome = "collected"
+	// StaleCreateBusy reports an in-flight operation owns the VM; nothing was touched.
+	StaleCreateBusy StaleCreateOutcome = "busy"
+	// StaleCreateNotCreating reports the record left the creating state; not a stale create.
+	StaleCreateNotCreating StaleCreateOutcome = "not-creating"
+	// StaleCreateNotFound reports no record exists under the id.
+	StaleCreateNotFound StaleCreateOutcome = "not-found"
+)
+
 var _ Supervisable = (*Backend)(nil)
+
+// StaleCreateOutcome reports what ReconcileStaleCreate did with the record.
+type StaleCreateOutcome string
 
 // Supervisable is the backend surface a resident supervisor drives.
 type Supervisable interface {
@@ -27,7 +41,7 @@ type Supervisable interface {
 	PeekRecord(ctx context.Context, vmID string) (*VMRecord, error)
 	ConvergeDead(ctx context.Context, vmID string, gen uint64, observedAt time.Time) error
 	ReconcileToRunning(ctx context.Context, vmID string) (uint64, error)
-	CollectStaleCreate(ctx context.Context, vmID string, rec *VMRecord) error
+	ReconcileStaleCreate(ctx context.Context, vmID string) (StaleCreateOutcome, error)
 	RecoverTombstone(ctx context.Context, vmID string) (bool, error)
 }
 
@@ -161,17 +175,43 @@ func (b *Backend) QuiesceIfPending(ctx context.Context, id string) error {
 	return b.clearQuiescePending(ctx, id, gen)
 }
 
-// CollectStaleCreate reclaims an ownerless creating placeholder; the held ops lock is the proof of ownerlessness, since create and clone hold it from prereserve through the final commit.
-func (b *Backend) CollectStaleCreate(ctx context.Context, id string, rec *VMRecord) error {
-	if err := b.ensureOrphanVMMDead(ctx, rec.RunDir); err != nil {
-		return fmt.Errorf("orphan vmm for %s: %w (dirs kept)", id, err)
+// ReconcileStaleCreate reclaims id when it is an ownerless creating placeholder; a free ops lock is the proof of ownerlessness, since create and clone hold it from prereserve through the final record commit.
+func (b *Backend) ReconcileStaleCreate(ctx context.Context, id string) (StaleCreateOutcome, error) {
+	unlock, ok, err := b.TryLockVMOps(ctx, id)
+	if err != nil {
+		return "", err
 	}
-	return b.deleteVMProtocol(ctx, id, rec)
+	if !ok {
+		return StaleCreateBusy, nil
+	}
+	defer unlock()
+	rec, err := b.PeekRecord(ctx, id)
+	if err != nil {
+		return "", err
+	}
+	if rec == nil {
+		return StaleCreateNotFound, nil
+	}
+	if rec.State != types.VMStateCreating {
+		return StaleCreateNotCreating, nil
+	}
+	if err := b.collectStaleCreate(ctx, id, rec); err != nil {
+		return "", err
+	}
+	return StaleCreateCollected, nil
 }
 
 // RecoverTombstone drives an unfinished delete to completion under the held ops lock; supervision starts deletes of its own, so it must be able to finish them.
 func (b *Backend) RecoverTombstone(ctx context.Context, id string) (bool, error) {
 	return b.recoverVMTombstone(ctx, id)
+}
+
+// collectStaleCreate runs the reclaim under the caller's held ops lock: no orphan VMM may survive, then the tombstoned delete protocol.
+func (b *Backend) collectStaleCreate(ctx context.Context, id string, rec *VMRecord) error {
+	if err := b.ensureOrphanVMMDead(ctx, rec.RunDir); err != nil {
+		return fmt.Errorf("orphan vmm for %s: %w (dirs kept)", id, err)
+	}
+	return b.deleteVMProtocol(ctx, id, rec)
 }
 
 // clearQuiescePending is relaxed: losing the clear only costs one idempotent re-quiesce on a later pass.

--- a/hypervisor/supervisor.go
+++ b/hypervisor/supervisor.go
@@ -16,14 +16,10 @@ import (
 )
 
 const (
-	// StaleCreateCollected reports the ownerless placeholder was reclaimed.
-	StaleCreateCollected StaleCreateOutcome = "collected"
-	// StaleCreateBusy reports an in-flight operation owns the VM; nothing was touched.
-	StaleCreateBusy StaleCreateOutcome = "busy"
-	// StaleCreateNotCreating reports the record left the creating state; not a stale create.
-	StaleCreateNotCreating StaleCreateOutcome = "not-creating"
-	// StaleCreateNotFound reports no record exists under the id.
-	StaleCreateNotFound StaleCreateOutcome = "not-found"
+	StaleCreateCollected   StaleCreateOutcome = "collected"    // ownerless placeholder reclaimed; record and name freed
+	StaleCreateBusy        StaleCreateOutcome = "busy"         // in-flight operation owns the VM; nothing touched
+	StaleCreateNotCreating StaleCreateOutcome = "not-creating" // record left the creating state under the lock
+	StaleCreateNotFound    StaleCreateOutcome = "not-found"    // no record under the id
 )
 
 // StaleCreateOutcome reports what ReconcileStaleCreate did with the record.

--- a/hypervisor/supervisor_test.go
+++ b/hypervisor/supervisor_test.go
@@ -236,7 +236,7 @@ func TestNeedsDeadConvergence(t *testing.T) {
 	}
 }
 
-func TestCollectStaleCreateFreesTheName(t *testing.T) {
+func TestReconcileStaleCreateCollectsAndFreesTheName(t *testing.T) {
 	b, _ := newMeteringTestBackend(t)
 	ctx := t.Context()
 	cfg := &types.VMConfig{Name: "alpha", Config: types.Config{CPU: 1}}
@@ -244,14 +244,61 @@ func TestCollectStaleCreateFreesTheName(t *testing.T) {
 		t.Fatalf("ReserveVM: %v", err)
 	}
 
-	if err := b.CollectStaleCreate(ctx, "vm1", recordOf(t, b, "vm1")); err != nil {
-		t.Fatalf("CollectStaleCreate: %v", err)
+	outcome, err := b.ReconcileStaleCreate(ctx, "vm1")
+	if err != nil || outcome != StaleCreateCollected {
+		t.Fatalf("got (%q, %v), want collected", outcome, err)
 	}
 	if rec, err := b.PeekRecord(ctx, "vm1"); err != nil || rec != nil {
 		t.Errorf("got record %v (err %v), want it collected", rec, err)
 	}
 	if _, err := b.ResolveRef(ctx, "alpha"); err == nil {
 		t.Error("the name is still reserved; a retry would be blocked until GC")
+	}
+}
+
+// A held ops lock is the create owner still working; the record must survive untouched.
+func TestReconcileStaleCreateRefusesInFlightCreate(t *testing.T) {
+	b, _ := newMeteringTestBackend(t)
+	ctx := t.Context()
+	cfg := &types.VMConfig{Name: "alpha", Config: types.Config{CPU: 1}}
+	if err := b.ReserveVM(ctx, "vm1", cfg, nil, t.TempDir(), t.TempDir()); err != nil {
+		t.Fatalf("ReserveVM: %v", err)
+	}
+	held, err := b.LockVMOps(ctx, "vm1")
+	if err != nil {
+		t.Fatalf("LockVMOps: %v", err)
+	}
+	defer held()
+
+	outcome, err := b.ReconcileStaleCreate(ctx, "vm1")
+	if err != nil || outcome != StaleCreateBusy {
+		t.Fatalf("got (%q, %v), want busy", outcome, err)
+	}
+	if rec, err := b.PeekRecord(ctx, "vm1"); err != nil || rec == nil {
+		t.Errorf("got record %v (err %v), want the in-flight create untouched", rec, err)
+	}
+}
+
+func TestReconcileStaleCreateRefusesNonCreating(t *testing.T) {
+	b, _ := newMeteringTestBackend(t)
+	ctx := t.Context()
+	seedRunningVM(t, b, "vm1", 1, 1<<30, 10<<30)
+
+	outcome, err := b.ReconcileStaleCreate(ctx, "vm1")
+	if err != nil || outcome != StaleCreateNotCreating {
+		t.Fatalf("got (%q, %v), want not-creating", outcome, err)
+	}
+	if got := recordOf(t, b, "vm1").State; got != types.VMStateRunning {
+		t.Errorf("got state %q, want the record untouched at running", got)
+	}
+}
+
+func TestReconcileStaleCreateReportsMissingRecord(t *testing.T) {
+	b, _ := newMeteringTestBackend(t)
+
+	outcome, err := b.ReconcileStaleCreate(t.Context(), "ghost")
+	if err != nil || outcome != StaleCreateNotFound {
+		t.Fatalf("got (%q, %v), want not-found", outcome, err)
 	}
 }
 

--- a/hypervisor/teardown.go
+++ b/hypervisor/teardown.go
@@ -23,6 +23,21 @@ type vmCleanup struct {
 	LogDir string `json:"log_dir,omitempty"`
 }
 
+// EntryGuardLoad runs the tombstone entry guard under the caller's ops lock —
+// roll a leased tombstone back, drive a deleting one to completion and refuse —
+// returning the record from the guard's own transaction, sparing lock-held
+// entry paths a second whole-namespace read.
+func (b *Backend) EntryGuardLoad(ctx context.Context, id string) (VMRecord, error) {
+	rec, err := b.entryGuard(ctx, id)
+	if err != nil {
+		return VMRecord{}, err
+	}
+	if rec == nil {
+		return VMRecord{}, fmt.Errorf("%q not found", id)
+	}
+	return *rec, nil
+}
+
 func (b *Backend) tombstones() *tombstone.Table {
 	return tombstone.NewTable(b.Meta, b.NS)
 }
@@ -120,21 +135,6 @@ func (b *Backend) recoverVMTombstone(ctx context.Context, id string) (done bool,
 	}
 	log.WithFunc(b.Typ+".recoverVMTombstone").Warnf(ctx, "rolled forward interrupted delete of VM %s", id)
 	return true, nil
-}
-
-// EntryGuardLoad runs the tombstone entry guard under the caller's ops lock —
-// roll a leased tombstone back, drive a deleting one to completion and refuse —
-// returning the record from the guard's own transaction, sparing lock-held
-// entry paths a second whole-namespace read.
-func (b *Backend) EntryGuardLoad(ctx context.Context, id string) (VMRecord, error) {
-	rec, err := b.entryGuard(ctx, id)
-	if err != nil {
-		return VMRecord{}, err
-	}
-	if rec == nil {
-		return VMRecord{}, fmt.Errorf("%q not found", id)
-	}
-	return *rec, nil
 }
 
 func (b *Backend) entryGuard(ctx context.Context, id string) (*VMRecord, error) {

--- a/hypervisor/teardown_test.go
+++ b/hypervisor/teardown_test.go
@@ -287,28 +287,6 @@ func TestPrepareStartRefusesMidDeleting(t *testing.T) {
 	}
 }
 
-func seedProtoVM(t *testing.T, b *Backend, id string) *VMRecord {
-	t.Helper()
-	runDir, logDir := t.TempDir(), t.TempDir()
-	if err := os.WriteFile(filepath.Join(runDir, "cow.raw"), []byte("x"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := b.ReserveVM(t.Context(), id, &types.VMConfig{Name: "proto-" + id}, nil, runDir, logDir); err != nil {
-		t.Fatalf("reserve: %v", err)
-	}
-	if err := b.UpdateRecord(t.Context(), id, func(r *VMRecord) error {
-		r.State = types.VMStateStopped
-		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
-	rec, err := b.LoadRecord(t.Context(), id)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return &rec
-}
-
 // stubNetwork stands in for the injected host-networking seam; unset hooks are no-ops.
 type stubNetwork struct {
 	recover func(context.Context, *types.VM) error
@@ -335,6 +313,28 @@ func (s stubNetwork) Cleanup(ctx context.Context, vmID string) error {
 		return nil
 	}
 	return s.cleanup(ctx, vmID)
+}
+
+func seedProtoVM(t *testing.T, b *Backend, id string) *VMRecord {
+	t.Helper()
+	runDir, logDir := t.TempDir(), t.TempDir()
+	if err := os.WriteFile(filepath.Join(runDir, "cow.raw"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.ReserveVM(t.Context(), id, &types.VMConfig{Name: "proto-" + id}, nil, runDir, logDir); err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if err := b.UpdateRecord(t.Context(), id, func(r *VMRecord) error {
+		r.State = types.VMStateStopped
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	rec, err := b.LoadRecord(t.Context(), id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &rec
 }
 
 // entryGuardOnly exercises the entry guard the way an entrypoint does, discarding the record.

--- a/images/oci/image.go
+++ b/images/oci/image.go
@@ -10,6 +10,10 @@ import (
 
 type imageIndex = images.Index[imageEntry]
 
+type layerEntry struct {
+	Digest images.Digest `json:"digest"`
+}
+
 // Paths derive from digests at runtime; not stored.
 type imageEntry struct {
 	Ref            string        `json:"ref"`
@@ -31,10 +35,6 @@ func (e imageEntry) DigestHexes() []string {
 		hexes[i] = l.Digest.Hex()
 	}
 	return hexes
-}
-
-type layerEntry struct {
-	Digest images.Digest `json:"digest"`
 }
 
 // normalizeRef expands a short OCI ref (e.g. "ubuntu:24.04" → "docker.io/library/ubuntu:24.04").

--- a/meta/contracttest/suite.go
+++ b/meta/contracttest/suite.go
@@ -25,6 +25,28 @@ var errForcedRollback = errors.New("forced rollback")
 // Factory returns a fresh Store serving the given namespaces; the suite owns its lifetime.
 type Factory func(t *testing.T, namespaces []string) meta.Store
 
+type record struct {
+	Name string `json:"name"`
+	N    int    `json:"n"`
+}
+
+type retryStore struct {
+	meta.Store
+}
+
+func (r *retryStore) Update(ctx context.Context, sc meta.Scope, mode meta.CommitMode, fn func(meta.Writer) error) error {
+	err := r.Store.Update(ctx, sc, mode, func(w meta.Writer) error {
+		if err := fn(w); err != nil {
+			return err
+		}
+		return errForcedRollback
+	})
+	if err != nil && !errors.Is(err, errForcedRollback) {
+		return err
+	}
+	return r.Store.Update(ctx, sc, mode, fn)
+}
+
 // Run executes the full contract suite against factory.
 func Run(t *testing.T, factory Factory) {
 	t.Run("CRUD", func(t *testing.T) { testCRUD(t, factory) })
@@ -41,11 +63,6 @@ func Run(t *testing.T, factory Factory) {
 
 // ForcedRetry wraps s so every Update closure runs twice — once rolled back, once for real — enforcing pure retryable closures.
 func ForcedRetry(s meta.Store) meta.Store { return &retryStore{Store: s} }
-
-type record struct {
-	Name string `json:"name"`
-	N    int    `json:"n"`
-}
 
 func testCRUD(t *testing.T, factory Factory) {
 	ctx := t.Context()
@@ -423,23 +440,6 @@ func testLogCursor(t *testing.T, factory Factory) {
 	if seqs[0] != s2 || seqs[1] != s3 {
 		t.Fatalf("scan seqs: want [%d %d], got %v", s2, s3, seqs)
 	}
-}
-
-type retryStore struct {
-	meta.Store
-}
-
-func (r *retryStore) Update(ctx context.Context, sc meta.Scope, mode meta.CommitMode, fn func(meta.Writer) error) error {
-	err := r.Store.Update(ctx, sc, mode, func(w meta.Writer) error {
-		if err := fn(w); err != nil {
-			return err
-		}
-		return errForcedRollback
-	})
-	if err != nil && !errors.Is(err, errForcedRollback) {
-		return err
-	}
-	return r.Store.Update(ctx, sc, mode, fn)
 }
 
 func get1(t *testing.T, s meta.Store, c *meta.Collection[record]) (*record, error) {

--- a/meta/json/store.go
+++ b/meta/json/store.go
@@ -36,6 +36,18 @@ type Namespace struct {
 	Codec    Codec
 }
 
+type nsState struct {
+	def    Namespace
+	locker *flock.Lock
+}
+
+type loaded struct {
+	model *Model
+	// recovered means main was undecodable and .prev was served; commit must
+	// not rotate, or it would destroy the only good generation.
+	recovered bool
+}
+
 var _ meta.Store = (*Store)(nil)
 
 // Store is the json engine: one flocked file per namespace, legacy write
@@ -182,17 +194,66 @@ func (s *Store) loadAll(ctx context.Context, states []*nsState) (map[string]*loa
 	return models, nil
 }
 
-type nsState struct {
-	def    Namespace
-	locker *flock.Lock
+var _ meta.Reader = (*txReader)(nil)
+
+type txReader struct {
+	models map[string]*loaded
 }
 
-type loaded struct {
-	model *Model
-	// recovered means main was undecodable and .prev was served; commit must
-	// not rotate, or it would destroy the only good generation.
-	recovered bool
+func (r *txReader) GetRaw(_ context.Context, ns, table, id string) (json.RawMessage, bool, error) {
+	l, ok := r.models[ns]
+	if !ok {
+		return nil, false, fmt.Errorf("read %s: %w", ns, meta.ErrScope)
+	}
+	raw, ok := l.model.Get(table, id)
+	// Detached values (contract clause 4): aliasing model bytes would let a
+	// caller mutate committed state without PutRaw's scope/durability checks.
+	return slices.Clone(raw), ok, nil
 }
+
+func (r *txReader) ScanRaw(_ context.Context, ns, table string, fn func(id string, raw json.RawMessage) error) error {
+	l, ok := r.models[ns]
+	if !ok {
+		return fmt.Errorf("read %s: %w", ns, meta.ErrScope)
+	}
+	return l.model.Scan(table, func(id string, raw json.RawMessage) error {
+		return fn(id, slices.Clone(raw))
+	})
+}
+
+var _ meta.Writer = (*txWriter)(nil)
+
+type txWriter struct {
+	txReader
+	write string
+	model *Model
+	mode  meta.CommitMode
+}
+
+func (w *txWriter) PutRaw(_ context.Context, ns, table, id string, raw json.RawMessage, relaxedOK bool) error {
+	if err := meta.CheckWriteScope(ns, w.write, w.mode, relaxedOK); err != nil {
+		return err
+	}
+	w.model.Put(table, id, slices.Clone(raw))
+	return nil
+}
+
+func (w *txWriter) DeleteRaw(_ context.Context, ns, table, id string, relaxedOK bool) error {
+	if err := meta.CheckWriteScope(ns, w.write, w.mode, relaxedOK); err != nil {
+		return err
+	}
+	w.model.Delete(table, id)
+	return nil
+}
+
+// coded pairs an engine error with its taxonomy sentinel without changing the message text.
+type coded struct {
+	err  error
+	mark error
+}
+
+func (c *coded) Error() string   { return c.err.Error() }
+func (c *coded) Unwrap() []error { return []error{c.err, c.mark} }
 
 // loadNamespace ports the legacy load: a missing file is empty, an
 // undecodable main falls back to the .prev generation, read errors fail closed.
@@ -295,67 +356,6 @@ func crash(step string) error {
 	}
 	return testCrashStep(step)
 }
-
-var _ meta.Reader = (*txReader)(nil)
-
-type txReader struct {
-	models map[string]*loaded
-}
-
-func (r *txReader) GetRaw(_ context.Context, ns, table, id string) (json.RawMessage, bool, error) {
-	l, ok := r.models[ns]
-	if !ok {
-		return nil, false, fmt.Errorf("read %s: %w", ns, meta.ErrScope)
-	}
-	raw, ok := l.model.Get(table, id)
-	// Detached values (contract clause 4): aliasing model bytes would let a
-	// caller mutate committed state without PutRaw's scope/durability checks.
-	return slices.Clone(raw), ok, nil
-}
-
-func (r *txReader) ScanRaw(_ context.Context, ns, table string, fn func(id string, raw json.RawMessage) error) error {
-	l, ok := r.models[ns]
-	if !ok {
-		return fmt.Errorf("read %s: %w", ns, meta.ErrScope)
-	}
-	return l.model.Scan(table, func(id string, raw json.RawMessage) error {
-		return fn(id, slices.Clone(raw))
-	})
-}
-
-var _ meta.Writer = (*txWriter)(nil)
-
-type txWriter struct {
-	txReader
-	write string
-	model *Model
-	mode  meta.CommitMode
-}
-
-func (w *txWriter) PutRaw(_ context.Context, ns, table, id string, raw json.RawMessage, relaxedOK bool) error {
-	if err := meta.CheckWriteScope(ns, w.write, w.mode, relaxedOK); err != nil {
-		return err
-	}
-	w.model.Put(table, id, slices.Clone(raw))
-	return nil
-}
-
-func (w *txWriter) DeleteRaw(_ context.Context, ns, table, id string, relaxedOK bool) error {
-	if err := meta.CheckWriteScope(ns, w.write, w.mode, relaxedOK); err != nil {
-		return err
-	}
-	w.model.Delete(table, id)
-	return nil
-}
-
-// coded pairs an engine error with its taxonomy sentinel without changing the message text.
-type coded struct {
-	err  error
-	mark error
-}
-
-func (c *coded) Error() string   { return c.err.Error() }
-func (c *coded) Unwrap() []error { return []error{c.err, c.mark} }
 
 func code(err, mark error) error {
 	if errors.Is(err, syscall.ENOSPC) {

--- a/meta/json/tables.go
+++ b/meta/json/tables.go
@@ -23,6 +23,22 @@ type TableSpec struct {
 	StringList bool
 }
 
+var _ Codec = TableCodec{}
+
+// TableCodec is the declaration-only codec for pure table-shaped namespaces:
+// a subsystem states its legacy field layout and owns no codec code.
+type TableCodec struct {
+	Specs []TableSpec
+}
+
+func (c TableCodec) Decode(data []byte) (*Model, error) {
+	return DecodeTables(data, c.Specs)
+}
+
+func (c TableCodec) Encode(m *Model) ([]byte, error) {
+	return EncodeTables(m, c.Specs)
+}
+
 // DecodeTables loads specs' map fields into a fresh Model (sorted insertion,
 // matching what encoding/json always wrote). Single streaming pass — a whole-file
 // unmarshal into raw messages tokenizes the payload twice.
@@ -113,22 +129,6 @@ func EncodeTables(m *Model, specs []TableSpec) ([]byte, error) {
 		}
 	}
 	return append(buf, '}', '\n'), nil
-}
-
-var _ Codec = TableCodec{}
-
-// TableCodec is the declaration-only codec for pure table-shaped namespaces:
-// a subsystem states its legacy field layout and owns no codec code.
-type TableCodec struct {
-	Specs []TableSpec
-}
-
-func (c TableCodec) Decode(data []byte) (*Model, error) {
-	return DecodeTables(data, c.Specs)
-}
-
-func (c TableCodec) Encode(m *Model) ([]byte, error) {
-	return EncodeTables(m, c.Specs)
 }
 
 func appendKey(buf []byte, key string) []byte {

--- a/meta/sqlite/store.go
+++ b/meta/sqlite/store.go
@@ -299,6 +299,106 @@ func (s *Store) verifyIdentity() error {
 	return nil
 }
 
+var (
+	_ meta.Reader = (*txHandle)(nil)
+	_ meta.Writer = (*txHandle)(nil)
+)
+
+// txHandle implements Reader/Writer over one transaction; values are
+// detached by construction (every read allocates from row scans).
+type txHandle struct {
+	ctx   context.Context
+	tx    *sql.Tx
+	sm    map[string]tableStmts
+	scope map[string]struct{}
+	write string
+	mode  meta.CommitMode
+}
+
+func (h *txHandle) GetRaw(ctx context.Context, ns, table, id string) (json.RawMessage, bool, error) {
+	if err := h.checkRead(ns); err != nil {
+		return nil, false, err
+	}
+	ts, err := h.stmts(ns, table)
+	if err != nil {
+		return nil, false, err
+	}
+	var data []byte
+	err = h.tx.StmtContext(ctx, ts.get).QueryRowContext(ctx, id).Scan(&data)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, mapErr(err)
+	}
+	return data, true, nil
+}
+
+func (h *txHandle) ScanRaw(ctx context.Context, ns, table string, fn func(id string, raw json.RawMessage) error) error {
+	if err := h.checkRead(ns); err != nil {
+		return err
+	}
+	ts, err := h.stmts(ns, table)
+	if err != nil {
+		return err
+	}
+	rows, err := h.tx.StmtContext(ctx, ts.scan).QueryContext(ctx)
+	if err != nil {
+		return mapErr(err)
+	}
+	defer rows.Close() //nolint:errcheck
+	for rows.Next() {
+		var id string
+		var data []byte
+		if err := rows.Scan(&id, &data); err != nil {
+			return mapErr(err)
+		}
+		if err := fn(id, data); err != nil {
+			return err
+		}
+	}
+	return mapErr(rows.Err())
+}
+
+func (h *txHandle) PutRaw(ctx context.Context, ns, table, id string, raw json.RawMessage, relaxedOK bool) error {
+	if err := meta.CheckWriteScope(ns, h.write, h.mode, relaxedOK); err != nil {
+		return err
+	}
+	ts, err := h.stmts(ns, table)
+	if err != nil {
+		return err
+	}
+	_, err = h.tx.StmtContext(ctx, ts.put).ExecContext(ctx, id, []byte(raw))
+	return mapErr(err)
+}
+
+func (h *txHandle) DeleteRaw(ctx context.Context, ns, table, id string, relaxedOK bool) error {
+	if err := meta.CheckWriteScope(ns, h.write, h.mode, relaxedOK); err != nil {
+		return err
+	}
+	ts, err := h.stmts(ns, table)
+	if err != nil {
+		return err
+	}
+	_, err = h.tx.StmtContext(ctx, ts.del).ExecContext(ctx, id)
+	return mapErr(err)
+}
+
+func (h *txHandle) stmts(ns, table string) (tableStmts, error) {
+	ts, ok := h.sm[ns+"\x00"+table]
+	if !ok {
+		return tableStmts{}, fmt.Errorf("table %s/%s not declared: %w", ns, table, meta.ErrScope)
+	}
+	return ts, nil
+}
+
+func (h *txHandle) checkRead(ns string) error {
+	if _, ok := h.scope[ns]; !ok {
+		return fmt.Errorf("read %s: %w", ns, meta.ErrScope)
+	}
+	return nil
+}
+
 func tableName(ns, table string) string {
 	return quoteIdent(ns + "__" + table)
 }
@@ -417,104 +517,4 @@ func mapErr(err error) error {
 	default:
 		return err
 	}
-}
-
-var (
-	_ meta.Reader = (*txHandle)(nil)
-	_ meta.Writer = (*txHandle)(nil)
-)
-
-// txHandle implements Reader/Writer over one transaction; values are
-// detached by construction (every read allocates from row scans).
-type txHandle struct {
-	ctx   context.Context
-	tx    *sql.Tx
-	sm    map[string]tableStmts
-	scope map[string]struct{}
-	write string
-	mode  meta.CommitMode
-}
-
-func (h *txHandle) GetRaw(ctx context.Context, ns, table, id string) (json.RawMessage, bool, error) {
-	if err := h.checkRead(ns); err != nil {
-		return nil, false, err
-	}
-	ts, err := h.stmts(ns, table)
-	if err != nil {
-		return nil, false, err
-	}
-	var data []byte
-	err = h.tx.StmtContext(ctx, ts.get).QueryRowContext(ctx, id).Scan(&data)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, false, nil
-	}
-	if err != nil {
-		return nil, false, mapErr(err)
-	}
-	return data, true, nil
-}
-
-func (h *txHandle) ScanRaw(ctx context.Context, ns, table string, fn func(id string, raw json.RawMessage) error) error {
-	if err := h.checkRead(ns); err != nil {
-		return err
-	}
-	ts, err := h.stmts(ns, table)
-	if err != nil {
-		return err
-	}
-	rows, err := h.tx.StmtContext(ctx, ts.scan).QueryContext(ctx)
-	if err != nil {
-		return mapErr(err)
-	}
-	defer rows.Close() //nolint:errcheck
-	for rows.Next() {
-		var id string
-		var data []byte
-		if err := rows.Scan(&id, &data); err != nil {
-			return mapErr(err)
-		}
-		if err := fn(id, data); err != nil {
-			return err
-		}
-	}
-	return mapErr(rows.Err())
-}
-
-func (h *txHandle) PutRaw(ctx context.Context, ns, table, id string, raw json.RawMessage, relaxedOK bool) error {
-	if err := meta.CheckWriteScope(ns, h.write, h.mode, relaxedOK); err != nil {
-		return err
-	}
-	ts, err := h.stmts(ns, table)
-	if err != nil {
-		return err
-	}
-	_, err = h.tx.StmtContext(ctx, ts.put).ExecContext(ctx, id, []byte(raw))
-	return mapErr(err)
-}
-
-func (h *txHandle) DeleteRaw(ctx context.Context, ns, table, id string, relaxedOK bool) error {
-	if err := meta.CheckWriteScope(ns, h.write, h.mode, relaxedOK); err != nil {
-		return err
-	}
-	ts, err := h.stmts(ns, table)
-	if err != nil {
-		return err
-	}
-	_, err = h.tx.StmtContext(ctx, ts.del).ExecContext(ctx, id)
-	return mapErr(err)
-}
-
-func (h *txHandle) stmts(ns, table string) (tableStmts, error) {
-	ts, ok := h.sm[ns+"\x00"+table]
-	if !ok {
-		return tableStmts{}, fmt.Errorf("table %s/%s not declared: %w", ns, table, meta.ErrScope)
-	}
-	return ts, nil
-}
-
-func (h *txHandle) checkRead(ns string) error {
-	if _, ok := h.scope[ns]; !ok {
-		return fmt.Errorf("read %s: %w", ns, meta.ErrScope)
-	}
-	return nil
 }

--- a/metadata/fat12.go
+++ b/metadata/fat12.go
@@ -31,18 +31,6 @@ const (
 	writeBufSize = 64 << 10
 )
 
-// CreateFAT12 streams a 1 MiB FAT12 image with VFAT long-filename support to w.
-func CreateFAT12(w io.Writer, label string, files map[string][]byte) error {
-	b := newFAT12Builder(label)
-
-	for _, name := range slices.Sorted(maps.Keys(files)) {
-		if err := b.addFile(name, files[name]); err != nil {
-			return err
-		}
-	}
-	return b.writeTo(w)
-}
-
 // fat12Builder constructs a FAT12 image in memory (FAT + root dir only) and streams the full image on writeTo.
 type fat12Builder struct {
 	label       string
@@ -204,6 +192,18 @@ func (b *fat12Builder) makeBootSector() []byte {
 	copy(boot[54:62], "FAT12   ")     //nolint:mnd
 	boot[510], boot[511] = 0x55, 0xAA //nolint:mnd
 	return boot
+}
+
+// CreateFAT12 streams a 1 MiB FAT12 image with VFAT long-filename support to w.
+func CreateFAT12(w io.Writer, label string, files map[string][]byte) error {
+	b := newFAT12Builder(label)
+
+	for _, name := range slices.Sorted(maps.Keys(files)) {
+		if err := b.addFile(name, files[name]); err != nil {
+			return err
+		}
+	}
+	return b.writeTo(w)
 }
 
 // setFATEntry writes a 12-bit value into the FAT at the given cluster index.

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -8,6 +8,10 @@ type Tracker interface {
 	OnEvent(any)
 }
 
+type funcTracker func(any)
+
+func (f funcTracker) OnEvent(e any) { f(e) }
+
 // NewTracker wraps a typed callback as a non-generic Tracker so Images can hold it in its interface.
 func NewTracker[E any](fn func(E)) Tracker {
 	return funcTracker(func(v any) {
@@ -16,7 +20,3 @@ func NewTracker[E any](fn func(E)) Tracker {
 		}
 	})
 }
-
-type funcTracker func(any)
-
-func (f funcTracker) OnEvent(e any) { f(e) }

--- a/snapshot/localfile/gc.go
+++ b/snapshot/localfile/gc.go
@@ -58,6 +58,39 @@ type snapshotGCSnapshot struct {
 
 func (s snapshotGCSnapshot) UsedBlobIDs() map[string]struct{} { return s.blobIDs }
 
+// PinnedBlobIDs reports every image blob pinned by a snapshot record — image GC's under-digest-lock recheck source.
+func (lf *LocalFile) PinnedBlobIDs(ctx context.Context) (map[string]struct{}, error) {
+	pins := map[string]struct{}{}
+	if err := lf.view(ctx, func(t *snapTx) error {
+		return t.Scan(func(_ string, rec *snapshot.SnapshotRecord) error {
+			maps.Copy(pins, rec.ImageBlobIDs)
+			return nil
+		})
+	}); err != nil {
+		return nil, err
+	}
+	return pins, nil
+}
+
+// gcRecover resumes existing snapshot tombstones by phase before discovery.
+func (lf *LocalFile) gcRecover(ctx context.Context) []error {
+	var ids []string
+	if err := lf.view(ctx, func(t *snapTx) error {
+		var err error
+		ids, err = lf.tombstones().PendingIDs(ctx, t.Reader())
+		return err
+	}); err != nil {
+		return []error{err}
+	}
+	var errs []error
+	for _, id := range ids {
+		if err := lf.recoverSnapTombstone(ctx, id); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errs
+}
+
 func gcModule(lf *LocalFile, policy EvictionPolicy) gc.Module[snapshotGCSnapshot] {
 	conf, recorder := lf.conf, lf.metering
 	return gc.Module[snapshotGCSnapshot]{
@@ -194,20 +227,6 @@ func gcModule(lf *LocalFile, policy EvictionPolicy) gc.Module[snapshotGCSnapshot
 	}
 }
 
-// PinnedBlobIDs reports every image blob pinned by a snapshot record — image GC's under-digest-lock recheck source.
-func (lf *LocalFile) PinnedBlobIDs(ctx context.Context) (map[string]struct{}, error) {
-	pins := map[string]struct{}{}
-	if err := lf.view(ctx, func(t *snapTx) error {
-		return t.Scan(func(_ string, rec *snapshot.SnapshotRecord) error {
-			maps.Copy(pins, rec.ImageBlobIDs)
-			return nil
-		})
-	}); err != nil {
-		return nil, err
-	}
-	return pins, nil
-}
-
 // pickLRU maps each evict ID to its reason ("+" joins multi-match; no criteria → "lru-all").
 func pickLRU(records map[string]snapshotMeta, p EvictionPolicy) map[string]string {
 	sorted := slices.SortedFunc(maps.Keys(records), func(a, b string) int {
@@ -321,23 +340,4 @@ func backfillSizeBytes(ctx context.Context, lf *LocalFile, records map[string]sn
 	}); err != nil {
 		logger.Warnf(ctx, "persist backfilled SizeBytes: %v", err)
 	}
-}
-
-// gcRecover resumes existing snapshot tombstones by phase before discovery.
-func (lf *LocalFile) gcRecover(ctx context.Context) []error {
-	var ids []string
-	if err := lf.view(ctx, func(t *snapTx) error {
-		var err error
-		ids, err = lf.tombstones().PendingIDs(ctx, t.Reader())
-		return err
-	}); err != nil {
-		return []error{err}
-	}
-	var errs []error
-	for _, id := range ids {
-		if err := lf.recoverSnapTombstone(ctx, id); err != nil {
-			errs = append(errs, err)
-		}
-	}
-	return errs
 }


### PR DESCRIPTION
Closes the cocoon side of #172 (PR-0 for cocoonstack/vk-cocoon#54 Fix A).

## Problem

An embedder that must clear `creating` skeletons synchronously (vk's startup reconcile) has no safe verb today:

- `vm rm --force` takes the ops lock **blocking** (`DeleteAll` → `LockVMOps`), so against a record whose clone is genuinely in flight it queues behind the live clone and then deletes the freshly created VM.
- Raw `state == creating` cannot tell a skeleton from a live clone window; the free ops lock is the only sound predicate (create and clone hold it from prereserve through the final record commit), and until now only the daemon's `collectOwnerless` used it.

## Change

- `Backend.ReconcileStaleCreate(ctx, id)` — the shared primitive: `TryLockVMOps` (non-blocking) → `PeekRecord` re-validation under the lock → `collectStaleCreate` (orphan-VMM check + tombstoned, resumable delete protocol). Four outcomes: `collected` / `busy` / `not-creating` / `not-found`. No age heuristics, no force fallback.
- The daemon's `collectOwnerless` is now a thin wrapper over the same primitive (`Supervisable` swaps `CollectStaleCreate` for `ReconcileStaleCreate`), so the daemon and the verb cannot diverge. GC's sweep keeps its own lock+age-gated wrapper (it already holds the ops lock when it reaches the reclaim) but shares the same `collectStaleCreate` body.
- New CLI verb `cocoon vm reconcile-stale-create VM` with `--output json` emitting `{"id", "outcome"}`; all four outcomes exit 0 so embedders branch on the JSON, errors stay non-zero. Documented in docs/cli.md.
- `cmdcore.FindVM` resolves ref → (owner hypervisor, VM) in one pass; `FindHypervisor` now delegates to it.

A half-finished collect is resumable: the delete protocol tombstones first, so a crashed collect is picked up by the next verb invocation, the daemon's resumeDelete, or GC.

## Also in this PR

A whole-repo declaration-layout pass (separate `review:` commit, +501/−501 pure moves): exported methods before unexported per type per file, standalone helpers below method sets, vocabulary types ahead of the types they serve, compile-time interface checks above the implementing type, test helpers after all test funcs. 17 files fixed; the sweep covered all 340 Go files.

## Evidence

- `go test ./...` green (new coverage: four outcome tests in hypervisor, daemon fake reworked to the new interface).
- `make lint` 0 issues on GOOS=linux and GOOS=darwin; `asl ./...` clean on both.
- Layout commit verified move-only by sorted added/removed line-set comparison, modulo the adjustments forced by relocating the interface-check block (extend/* import shifts, one dissolved `var ( ... )` wrapper, gofmt re-alignment of the merged block).
