### PR TITLE
perf(clone): hand post-resume reseed to a detached child

### DIFF
--- a/cmd/core/handler.go
+++ b/cmd/core/handler.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -15,20 +14,5 @@ type BaseHandler struct {
 }
 
 func (h BaseHandler) Init(cmd *cobra.Command) (context.Context, *config.Config, error) {
-	conf, err := h.Conf()
-	if err != nil {
-		return nil, nil, err
-	}
-	return cliutil.CommandContext(cmd), conf, nil
-}
-
-func (h BaseHandler) Conf() (*config.Config, error) {
-	if h.ConfProvider == nil {
-		return nil, fmt.Errorf("config provider is nil")
-	}
-	conf := h.ConfProvider()
-	if conf == nil {
-		return nil, fmt.Errorf("config not initialized")
-	}
-	return conf, nil
+	return cliutil.CommandContext(cmd), h.ConfProvider(), nil
 }

--- a/cmd/vm/debug.go
+++ b/cmd/vm/debug.go
@@ -74,8 +74,7 @@ func (h Handler) Debug(cmd *cobra.Command, args []string) error {
 
 func printFCDebug(configs []*types.StorageConfig, boot *types.BootConfig, vmCfg *types.VMConfig, fcBin string) {
 	cowPath := fmt.Sprintf("cow-%s.raw", vmCfg.Name)
-	memMiB := int(vmCfg.Memory >> 20)     //nolint:mnd
-	cowSizeGB := int(vmCfg.Storage >> 30) //nolint:mnd
+	memMiB := int(vmCfg.Memory >> 20) //nolint:mnd
 
 	nLayers := 0
 	for _, s := range configs {
@@ -92,10 +91,7 @@ func printFCDebug(configs []*types.StorageConfig, boot *types.BootConfig, vmCfg 
 	cmdline := hypervisor.BuildBaseCmdline("console=ttyS0 reboot=k loglevel=3 pci=off i8042.noaux 8250.nr_uarts=1",
 		strings.Join(layerDevs, ","), cowDev, nil, vmCfg.Name, nil)
 
-	fmt.Println("# Prepare COW disk")
-	fmt.Printf("truncate -s %dG %s\n", cowSizeGB, cowPath)
-	fmt.Printf("mkfs.ext4 -F -m 0 -q -E lazy_itable_init=1,lazy_journal_init=1,discard %s\n", cowPath)
-	fmt.Println()
+	printPrepareCOWDisk(vmCfg.Storage>>30, cowPath) //nolint:mnd
 
 	fmt.Printf("# Launch Firecracker: %s (image: %s)\n", vmCfg.Name, vmCfg.Image)
 	fmt.Printf("%s --api-sock /tmp/fc-%s.sock --id %s\n", fcBin, vmCfg.Name, vmCfg.Name)
@@ -179,10 +175,7 @@ func printCHDebug(s chDebugSpec) {
 		cmdline := hypervisor.BuildBaseCmdline("console=hvc0 loglevel=3",
 			cocoonLayers, hypervisor.CowSerial, nil, s.VMCfg.Name, nil)
 
-		fmt.Println("# Prepare COW disk")
-		fmt.Printf("truncate -s %dG %s\n", s.VMCfg.Storage>>30, s.CowPath) //nolint:mnd
-		fmt.Printf("mkfs.ext4 -F -m 0 -q -E lazy_itable_init=1,lazy_journal_init=1,discard %s\n", s.CowPath)
-		fmt.Println()
+		printPrepareCOWDisk(s.VMCfg.Storage>>30, s.CowPath) //nolint:mnd
 		fmt.Printf("# Launch VM: %s (image: %s, boot: direct kernel)\n", s.VMCfg.Name, s.VMCfg.Image)
 		fmt.Printf("%s \\\n", s.CHBin)
 		fmt.Printf("  --kernel %s \\\n", s.Boot.KernelPath)
@@ -212,6 +205,13 @@ func printCHDebug(s chDebugSpec) {
 		fmt.Printf("    \"%s\" \\\n", diskArgs[0])
 	}
 	printCommonCHArgs(s)
+}
+
+func printPrepareCOWDisk(sizeGB int64, path string) {
+	fmt.Println("# Prepare COW disk")
+	fmt.Printf("truncate -s %dG %s\n", sizeGB, path)
+	fmt.Printf("mkfs.ext4 -F -m 0 -q -E lazy_itable_init=1,lazy_journal_init=1,discard %s\n", path)
+	fmt.Println()
 }
 
 func printCommonCHArgs(s chDebugSpec) {

--- a/cmd/vm/reseed.go
+++ b/cmd/vm/reseed.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
 	"time"
 
 	"github.com/projecteru2/core/log"
 	"github.com/spf13/cobra"
 
 	"github.com/cocoonstack/cocoon-agent/client"
+	"github.com/cocoonstack/cocoon/config"
 	"github.com/cocoonstack/cocoon/hypervisor"
 	"github.com/cocoonstack/cocoon/types"
 )
@@ -37,11 +41,14 @@ func (h Handler) Reseed(cmd *cobra.Command, args []string) error {
 }
 
 // reseedAfterResume fires the best-effort reseed, re-inspecting only when the in-process record lacks VsockSocket — a zero value would silently no-op.
-func (h Handler) reseedAfterResume(ctx context.Context, hyper hypervisor.Hypervisor, vm *types.VM, regenMachineID bool) {
+// It hands the reseed to a detached child by default: the vsock dial waits out the guest's post-resume wakeup (tens of ms, growing with snapshot age), which would otherwise sit on every clone/restore critical path.
+func (h Handler) reseedAfterResume(ctx context.Context, conf *config.Config, hyper hypervisor.Hypervisor, vm *types.VM, regenMachineID bool) {
 	if vm.VsockSocket == "" {
 		vm = refreshVM(ctx, hyper, vm)
 	}
-	signalReseed(ctx, vm, regenMachineID)
+	if vm.VsockSocket == "" || vm.Config.Windows || !detachReseed(ctx, conf, vm, regenMachineID) {
+		signalReseed(ctx, vm, regenMachineID)
+	}
 }
 
 // reseedVM pushes fresh entropy and a CRNG reseed order over vsock; only a failed dial retries (the agent re-listens shortly after resume) — a live agent's reply is final.
@@ -82,6 +89,26 @@ func reseedVM(ctx context.Context, vm *types.VM, regenMachineID bool) error {
 		return nil
 	}
 	return fmt.Errorf("reseed: dial agent: %w", dialErr)
+}
+
+// detachReseed re-execs `cocoon vm reseed` as a session-detached child and reports whether the hand-off started; resolved dirs travel as flags so file- or flag-configured parents behave like env-configured ones.
+func detachReseed(ctx context.Context, conf *config.Config, vm *types.VM, regenMachineID bool) bool {
+	exe, err := os.Executable()
+	if err != nil {
+		return false
+	}
+	args := []string{"--root-dir", conf.RootDir, "--run-dir", conf.RunDir, "--log-dir", conf.LogDir, "vm", "reseed"}
+	if regenMachineID {
+		args = append(args, "--machine-id")
+	}
+	c := exec.Command(exe, append(args, vm.ID)...) //nolint:gosec // self re-exec: path from os.Executable, args are internal flags/IDs
+	c.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := c.Start(); err != nil {
+		log.WithFunc("cmd.vm.reseed").Warnf(ctx, "detached reseed spawn failed, reseeding inline: %v", err)
+		return false
+	}
+	go c.Wait() //nolint:errcheck
+	return true
 }
 
 // signalReseed is the non-fatal clone/restore wrapper: reports whether a reseed was attempted (false = Windows or no vsock) and never fails the calling command.

--- a/cmd/vm/run.go
+++ b/cmd/vm/run.go
@@ -265,9 +265,6 @@ func (h Handler) cloneFromDir(ctx context.Context, cmd *cobra.Command, conf *con
 	if err != nil {
 		return fmt.Errorf("load envelope: %w", err)
 	}
-	if conf == nil {
-		return fmt.Errorf("nil config")
-	}
 	// Local copy keeps backend flip from leaking to the caller's shared *config.Config.
 	localConf := *conf
 	if cfg.Hypervisor != "" {
@@ -596,9 +593,6 @@ func initNetwork(ctx context.Context, conf *config.Config, vmID string, nics int
 }
 
 func rollbackNetwork(ctx context.Context, netProvider network.Network, vmID string) {
-	if netProvider == nil {
-		return
-	}
 	// Survive Ctrl-C, bounded so a hung plugin can't wedge the CLI; an aborted rollback keeps its records for GC retry.
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), rollbackTimeout)
 	defer cancel()

--- a/cmd/vm/run.go
+++ b/cmd/vm/run.go
@@ -129,7 +129,7 @@ func (h Handler) Clone(cmd *cobra.Command, args []string) error {
 		rollbackReserve()
 		return fmt.Errorf("clone VM: %w", cloneErr)
 	}
-	h.reseedAfterResume(ctx, hyper, vm, true)
+	h.reseedAfterResume(ctx, conf, hyper, vm, true)
 
 	if done, jsonErr := cliutil.MaybeOutputJSON(cmd, vm); done {
 		return jsonErr
@@ -182,7 +182,7 @@ func (h Handler) Restore(cmd *cobra.Command, args []string) error {
 	}
 
 	// Pin the inspected IDs: re-resolving mutable names here would let a delete+reuse bypass the ownership check above.
-	done, directErr := h.restoreDirect(ctx, cmd, snapInfo.ID, vm.ID, vmCfg, snapBackend, hyper, logger)
+	done, directErr := h.restoreDirect(ctx, cmd, conf, snapInfo.ID, vm.ID, vmCfg, snapBackend, hyper, logger)
 	if done {
 		return directErr
 	}
@@ -200,7 +200,7 @@ func (h Handler) Restore(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("restore: %w", err)
 	}
-	h.reseedAfterResume(ctx, hyper, result, false)
+	h.reseedAfterResume(ctx, conf, hyper, result, false)
 
 	if done, jsonErr := cliutil.MaybeOutputJSON(cmd, result); done {
 		return jsonErr
@@ -245,7 +245,7 @@ func (h Handler) restoreFromDir(ctx context.Context, cmd *cobra.Command, conf *c
 		return err
 	}
 	defer releasePins()
-	return h.runDirectRestore(ctx, cmd, hyper, dcr, vm.ID, vmCfg, dir, cfg.ID,
+	return h.runDirectRestore(ctx, cmd, conf, hyper, dcr, vm.ID, vmCfg, dir, cfg.ID,
 		fmt.Sprintf("dir %s", dir), logger)
 }
 
@@ -303,7 +303,7 @@ func (h Handler) cloneFromSrcDir(ctx context.Context, cmd *cobra.Command, conf *
 		rollbackReserve()
 		return fmt.Errorf("clone VM: %w", cloneErr)
 	}
-	h.reseedAfterResume(ctx, hyper, vm, true)
+	h.reseedAfterResume(ctx, conf, hyper, vm, true)
 
 	if wantJSON {
 		return cliutil.OutputJSON(vm)
@@ -369,7 +369,7 @@ func (h Handler) prepareClone(ctx context.Context, cmd *cobra.Command, conf *con
 	return vmCfg, vmID, rollbackReserve, unlock, netProvider, netSetup, nil
 }
 
-func (h Handler) restoreDirect(ctx context.Context, cmd *cobra.Command, snapRef, vmRef string, vmCfg *types.VMConfig, snapBackend snapshot.Snapshot, hyper hypervisor.Hypervisor, logger *log.Fields) (bool, error) {
+func (h Handler) restoreDirect(ctx context.Context, cmd *cobra.Command, conf *config.Config, snapRef, vmRef string, vmCfg *types.VMConfig, snapBackend snapshot.Snapshot, hyper hypervisor.Hypervisor, logger *log.Fields) (bool, error) {
 	da, ok := snapBackend.(snapshot.Direct)
 	if !ok {
 		return false, nil
@@ -383,11 +383,11 @@ func (h Handler) restoreDirect(ctx context.Context, cmd *cobra.Command, snapRef,
 		return true, fmt.Errorf("open snapshot: %w", err)
 	}
 	defer release()
-	return true, h.runDirectRestore(ctx, cmd, hyper, dcr, vmRef, vmCfg, dataDir, snapCfg.ID,
+	return true, h.runDirectRestore(ctx, cmd, conf, hyper, dcr, vmRef, vmCfg, dataDir, snapCfg.ID,
 		fmt.Sprintf("snapshot %s", snapRef), logger)
 }
 
-func (h Handler) runDirectRestore(ctx context.Context, cmd *cobra.Command, hyper hypervisor.Hypervisor, dcr hypervisor.Direct, vmRef string, vmCfg *types.VMConfig, srcDir, sourceSnapshotID, sourceLabel string, logger *log.Fields) error {
+func (h Handler) runDirectRestore(ctx context.Context, cmd *cobra.Command, conf *config.Config, hyper hypervisor.Hypervisor, dcr hypervisor.Direct, vmRef string, vmCfg *types.VMConfig, srcDir, sourceSnapshotID, sourceLabel string, logger *log.Fields) error {
 	wantJSON := cliutil.WantJSON(cmd)
 	if !wantJSON {
 		logger.Infof(ctx, "restoring VM %s from %s (direct) ...", vmRef, sourceLabel)
@@ -396,7 +396,7 @@ func (h Handler) runDirectRestore(ctx context.Context, cmd *cobra.Command, hyper
 	if err != nil {
 		return fmt.Errorf("restore: %w", err)
 	}
-	h.reseedAfterResume(ctx, hyper, result, false)
+	h.reseedAfterResume(ctx, conf, hyper, result, false)
 	if wantJSON {
 		return cliutil.OutputJSON(result)
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -173,7 +173,7 @@ func (d *Daemon) settle(ctx context.Context) bool {
 
 // gcTick returns the periodic-GC channel and its stop; with GC off (the default) the nil channel keeps the select arm inert.
 func (d *Daemon) gcTick() (<-chan time.Time, func()) {
-	if d.conf.GCInterval <= 0 || d.conf.GC == nil {
+	if d.conf.GCInterval <= 0 {
 		return nil, func() {}
 	}
 	t := time.NewTicker(d.conf.GCInterval)

--- a/hypervisor/baseconfig.go
+++ b/hypervisor/baseconfig.go
@@ -76,7 +76,7 @@ func (c *BaseConfig) LoadAndValidateMeta(dir string) (*SnapshotMeta, error) {
 }
 
 // PreflightRestore runs the shared restore preflight against this backend's managed roots.
-func (c *BaseConfig) PreflightRestore(srcDir string, rec *VMRecord, integrity func(srcDir string, sidecar []*types.StorageConfig) error) error {
+func (c *BaseConfig) PreflightRestore(srcDir string, rec *VMRecord, integrity func(srcDir string, sidecar []*types.StorageConfig) error) (*SnapshotMeta, error) {
 	return PreflightRestore(srcDir, c.RootDir, c.Config.RunDir, rec, integrity)
 }
 

--- a/hypervisor/cloudhypervisor/clone.go
+++ b/hypervisor/cloudhypervisor/clone.go
@@ -35,15 +35,19 @@ func (ch *CloudHypervisor) Clone(ctx context.Context, vmID string, vmCfg *types.
 }
 
 func (ch *CloudHypervisor) cloneAfterExtract(ctx context.Context, vmID string, vmCfg *types.VMConfig, net types.NetSetup, runDir, logDir string, now time.Time, sourceSnapshotID string) (*types.VM, error) {
+	chCfg, err := parseCHConfig(filepath.Join(runDir, configJSONName))
+	if err != nil {
+		return nil, fmt.Errorf("parse CH config: %w", err)
+	}
+	return ch.cloneAfterExtractParsed(ctx, vmID, vmCfg, net, runDir, logDir, now, sourceSnapshotID, chCfg)
+}
+
+// cloneAfterExtractParsed is cloneAfterExtract minus the config.json parse; DirectClone passes the copy step's parse of the verbatim-copied source.
+func (ch *CloudHypervisor) cloneAfterExtractParsed(ctx context.Context, vmID string, vmCfg *types.VMConfig, net types.NetSetup, runDir, logDir string, now time.Time, sourceSnapshotID string, chCfg *chVMConfig) (*types.VM, error) {
 	networkConfigs := net.NetworkConfigs
 	logger := log.WithFunc("cloudhypervisor.cloneAfterExtract")
 
 	chConfigPath := filepath.Join(runDir, configJSONName)
-	chCfg, err := parseCHConfig(chConfigPath)
-	if err != nil {
-		return nil, fmt.Errorf("parse CH config: %w", err)
-	}
-
 	vmCfg.RestoreMode = resolveRestoreMode(ctx, vmCfg.RestoreMode, chCfg.Memory)
 
 	meta, err := ch.conf.LoadAndValidateMeta(runDir)

--- a/hypervisor/cloudhypervisor/direct.go
+++ b/hypervisor/cloudhypervisor/direct.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/cocoonstack/cocoon/hypervisor"
 	"github.com/cocoonstack/cocoon/types"
@@ -12,40 +13,50 @@ import (
 
 // DirectClone clones from a local snapshot dir. Per-type: hardlink memory-range-*, reflink/copy COW, plain copy metadata; cidata is regenerated.
 func (ch *CloudHypervisor) DirectClone(ctx context.Context, vmID string, vmCfg *types.VMConfig, net types.NetSetup, snapshotConfig *types.SnapshotConfig, srcDir string) (*types.VM, error) {
+	// The copy step's parse feeds cloneAfterExtractParsed: config.json is copied verbatim, so re-parsing the runDir copy would decode identical bytes.
+	var srcCfg *chVMConfig
 	return ch.DirectCloneBase(ctx, vmID, vmCfg, net, snapshotConfig, srcDir, func(dstDir, srcDir string) error {
-		return cloneSnapshotFiles(ctx, dstDir, srcDir)
-	}, ch.cloneAfterExtract)
+		var err error
+		srcCfg, err = cloneSnapshotFiles(ctx, dstDir, srcDir)
+		return err
+	}, func(ctx context.Context, vmID string, vmCfg *types.VMConfig, net types.NetSetup, runDir, logDir string, now time.Time, sourceSnapshotID string) (*types.VM, error) {
+		return ch.cloneAfterExtractParsed(ctx, vmID, vmCfg, net, runDir, logDir, now, sourceSnapshotID, srcCfg)
+	})
 }
 
 // DirectRestore restores a VM in place from a local snapshot dir.
 func (ch *CloudHypervisor) DirectRestore(ctx context.Context, vmRef string, vmCfg *types.VMConfig, srcDir, sourceSnapshotID string) (*types.VM, error) {
+	var meta *hypervisor.SnapshotMeta
 	return ch.DirectRestoreSequence(ctx, vmRef, hypervisor.DirectRestoreSpec{
 		VMCfg:            vmCfg,
 		SrcDir:           srcDir,
 		SourceSnapshotID: sourceSnapshotID,
 		Preflight: func(srcDir string, rec *hypervisor.VMRecord) error {
-			return ch.preflightRestore(ctx, srcDir, rec, vmCfg)
+			var err error
+			meta, err = ch.preflightRestore(ctx, srcDir, rec, vmCfg)
+			return err
 		},
 		Kill: ch.killForRestore,
 		Populate: func(rec *hypervisor.VMRecord, srcDir string) error {
 			return hypervisor.PopulateFromSrc(rec.RunDir, srcDir, cleanSnapshotFiles, func(dstDir, srcDir string) error {
-				return cloneSnapshotFiles(ctx, dstDir, srcDir)
+				_, err := cloneSnapshotFiles(ctx, dstDir, srcDir)
+				return err
 			})
 		},
 		AfterExtract: func(ctx context.Context, vmID string, vmCfg *types.VMConfig, rec *hypervisor.VMRecord) (*types.VM, error) {
 			directBoot := hypervisor.IsDirectBoot(rec.BootConfig)
-			return ch.restoreAfterExtract(ctx, vmID, vmCfg, rec, directBoot)
+			return ch.restoreAfterExtract(ctx, vmID, vmCfg, rec, directBoot, meta)
 		},
 	})
 }
 
-func cloneSnapshotFiles(ctx context.Context, dstDir, srcDir string) error {
+func cloneSnapshotFiles(ctx context.Context, dstDir, srcDir string) (*chVMConfig, error) {
 	chCfg, err := parseCHConfig(filepath.Join(srcDir, configJSONName))
 	if err != nil {
-		return fmt.Errorf("parse source config: %w", err)
+		return nil, fmt.Errorf("parse source config: %w", err)
 	}
 	cowFiles := identifyCOWFiles(chCfg)
-	return hypervisor.CloneSnapshotFiles(ctx, dstDir, srcDir, func(name string) hypervisor.SnapshotFileKind {
+	return chCfg, hypervisor.CloneSnapshotFiles(ctx, dstDir, srcDir, func(name string) hypervisor.SnapshotFileKind {
 		switch {
 		case strings.HasPrefix(name, memoryRangeFile):
 			return hypervisor.SnapshotFileMemory

--- a/hypervisor/cloudhypervisor/restore.go
+++ b/hypervisor/cloudhypervisor/restore.go
@@ -17,12 +17,16 @@ import (
 )
 
 func (ch *CloudHypervisor) Restore(ctx context.Context, vmRef string, vmCfg *types.VMConfig, snapshot io.Reader, sourceSnapshotID string) (*types.VM, error) {
+	// Preflight's validated meta feeds AfterExtract: cocoon.json is merged verbatim, so re-reading it would decode identical bytes.
+	var meta *hypervisor.SnapshotMeta
 	return ch.RestoreSequence(ctx, vmRef, hypervisor.RestoreSpec{
 		VMCfg:            vmCfg,
 		Snapshot:         snapshot,
 		SourceSnapshotID: sourceSnapshotID,
 		Preflight: func(srcDir string, rec *hypervisor.VMRecord) error {
-			return ch.preflightRestore(ctx, srcDir, rec, vmCfg)
+			var err error
+			meta, err = ch.preflightRestore(ctx, srcDir, rec, vmCfg)
+			return err
 		},
 		Kill: ch.killForRestore,
 		// Same sweep as DirectRestore's Populate: stale snapshot files from a previous incarnation must not survive the merge.
@@ -31,23 +35,24 @@ func (ch *CloudHypervisor) Restore(ctx context.Context, vmRef string, vmCfg *typ
 		},
 		AfterExtract: func(ctx context.Context, vmID string, vmCfg *types.VMConfig, rec *hypervisor.VMRecord) (*types.VM, error) {
 			directBoot := hypervisor.IsDirectBoot(rec.BootConfig)
-			return ch.restoreAfterExtract(ctx, vmID, vmCfg, rec, directBoot)
+			return ch.restoreAfterExtract(ctx, vmID, vmCfg, rec, directBoot, meta)
 		},
 	})
 }
 
-func (ch *CloudHypervisor) preflightRestore(ctx context.Context, srcDir string, rec *hypervisor.VMRecord, vmCfg *types.VMConfig) error {
+func (ch *CloudHypervisor) preflightRestore(ctx context.Context, srcDir string, rec *hypervisor.VMRecord, vmCfg *types.VMConfig) (*hypervisor.SnapshotMeta, error) {
 	chCfg, err := parseCHConfig(filepath.Join(srcDir, configJSONName))
 	if err != nil {
-		return fmt.Errorf("parse snapshot config: %w", err)
+		return nil, fmt.Errorf("parse snapshot config: %w", err)
 	}
 	vmCfg.RestoreMode = resolveRestoreMode(ctx, vmCfg.RestoreMode, chCfg.Memory)
-	if err := ch.conf.PreflightRestore(srcDir, rec, func(dir string, sidecar []*types.StorageConfig) error {
+	meta, err := ch.conf.PreflightRestore(srcDir, rec, func(dir string, sidecar []*types.StorageConfig) error {
 		return validateSnapshotIntegrityParsed(dir, sidecar, chCfg)
-	}); err != nil {
-		return err
+	})
+	if err != nil {
+		return nil, err
 	}
-	return validateRestoreNICs(chCfg, rec)
+	return meta, validateRestoreNICs(chCfg, rec)
 }
 
 func (ch *CloudHypervisor) killForRestore(ctx context.Context, vmID string, rec *hypervisor.VMRecord) error {
@@ -61,15 +66,11 @@ func (ch *CloudHypervisor) terminateVMM(ctx context.Context, rec *hypervisor.VMR
 	return ch.forceTerminate(ctx, hc, rec.ID, hypervisor.SocketPath(rec.RunDir), pid)
 }
 
-func (ch *CloudHypervisor) restoreAfterExtract(ctx context.Context, vmID string, vmCfg *types.VMConfig, rec *hypervisor.VMRecord, directBoot bool) (_ *types.VM, err error) {
+func (ch *CloudHypervisor) restoreAfterExtract(ctx context.Context, vmID string, vmCfg *types.VMConfig, rec *hypervisor.VMRecord, directBoot bool, meta *hypervisor.SnapshotMeta) (_ *types.VM, err error) {
 	logger := log.WithFunc("cloudhypervisor.restoreAfterExtract")
 
 	chConfigPath := filepath.Join(rec.RunDir, configJSONName)
 	// rec may have trailing cidata absent from the snapshot (cloudimg post-first-boot); slice to sidecar length.
-	meta, metaErr := ch.conf.LoadAndValidateMeta(rec.RunDir)
-	if metaErr != nil {
-		return nil, fmt.Errorf("load snapshot meta: %w", metaErr)
-	}
 	diskCount := len(meta.StorageConfigs)
 	if diskCount > len(rec.StorageConfigs) {
 		return nil, fmt.Errorf("snapshot has %d disks, VM record has %d", diskCount, len(rec.StorageConfigs))

--- a/hypervisor/firecracker/clone.go
+++ b/hypervisor/firecracker/clone.go
@@ -40,11 +40,7 @@ func (p *bindRedirectPlan) files() []*os.File {
 	return files
 }
 
-func (p *bindRedirectPlan) close() {
-	for _, lease := range slices.Backward(p.leases) {
-		_ = lease.Close()
-	}
-}
+func (p *bindRedirectPlan) close() { closeLeases(p.leases) }
 
 func (fc *Firecracker) Clone(ctx context.Context, vmID string, vmCfg *types.VMConfig, net types.NetSetup, snapshotConfig *types.SnapshotConfig, snapshot io.Reader) (*types.VM, error) {
 	return fc.CloneFromStream(ctx, vmID, vmCfg, net, snapshotConfig, snapshot, fc.cloneAfterExtract)
@@ -415,11 +411,7 @@ func managedSourceVMIDs(runRoot string, srcConfigs, dstConfigs []*types.StorageC
 
 func holdManagedSourceVMLeases(ctx context.Context, rootDir, runRoot string, srcConfigs, dstConfigs []*types.StorageConfig) ([]*vmlock.SharedLease, error) {
 	var leases []*vmlock.SharedLease
-	release := func() {
-		for _, lease := range slices.Backward(leases) {
-			_ = lease.Close()
-		}
-	}
+	release := func() { closeLeases(leases) }
 	for _, id := range managedSourceVMIDs(runRoot, srcConfigs, dstConfigs) {
 		lease, err := vmlock.NewSharedLease(ctx, rootDir, id)
 		if err != nil {
@@ -429,6 +421,12 @@ func holdManagedSourceVMLeases(ctx context.Context, rootDir, runRoot string, src
 		leases = append(leases, lease)
 	}
 	return leases, nil
+}
+
+func closeLeases(leases []*vmlock.SharedLease) {
+	for _, lease := range slices.Backward(leases) {
+		_ = lease.Close()
+	}
 }
 
 func buildNetworkOverrides(networkConfigs []*types.NetworkConfig) []fcNetworkOverride {

--- a/hypervisor/firecracker/snapshot.go
+++ b/hypervisor/firecracker/snapshot.go
@@ -54,8 +54,6 @@ func (fc *Firecracker) snapshotSpec(ctx context.Context) hypervisor.SnapshotSpec
 // buildSnapshotMeta rewrites kernel path to vmlinuz so clones get the portable artifact instead of the FC-specific vmlinux cache.
 func buildSnapshotMeta(rec *hypervisor.VMRecord, _ string) (*hypervisor.SnapshotMeta, error) {
 	meta := &hypervisor.SnapshotMeta{
-		CPU:            rec.Config.CPU,
-		Memory:         rec.Config.Memory,
 		StorageConfigs: hypervisor.CloneStorageConfigs(rec.StorageConfigs),
 	}
 	if rec.BootConfig != nil {

--- a/hypervisor/firecracker/start.go
+++ b/hypervisor/firecracker/start.go
@@ -301,9 +301,6 @@ func waitRelayLeaseReady(ready *os.File) error {
 }
 
 func waitRelayLeaseResponse(response *os.File, want byte, phase string) error {
-	if response == nil {
-		return fmt.Errorf("source-lease relay %s response pipe is nil", phase)
-	}
 	result := make(chan error, 1)
 	go func() {
 		var command [1]byte

--- a/hypervisor/firecracker/utils.go
+++ b/hypervisor/firecracker/utils.go
@@ -14,7 +14,8 @@ const pidFileName = "fc.pid"
 var runtimeFiles = []string{hypervisor.APISocketName, pidFileName, hypervisor.ConsoleSockName, hypervisor.VsockSockName}
 
 func (fc *Firecracker) preflightRestore(srcDir string, rec *hypervisor.VMRecord) error {
-	return fc.conf.PreflightRestore(srcDir, rec, snapshotIntegrity)
+	_, err := fc.conf.PreflightRestore(srcDir, rec, snapshotIntegrity)
+	return err
 }
 
 // snapshotIntegrity runs the cross-backend checks + asserts FC vmstate+mem files exist (sidecar is the only disk-shape source for FC).

--- a/hypervisor/repo.go
+++ b/hypervisor/repo.go
@@ -72,7 +72,7 @@ func (b *Backend) updateRelaxed(ctx context.Context, fn func(*vmTx) error) error
 
 func (b *Backend) tx(ctx context.Context, r meta.Reader, w meta.Writer) *vmTx {
 	return &vmTx{
-		NamedTx: meta.NewNamedTx[VMRecord](ctx, b.Meta, b.NS, TableRecords, TableNames, r, w),
+		NamedTx: meta.NewNamedTx[VMRecord](ctx, b.NS, TableRecords, TableNames, r, w),
 		ctx:     ctx,
 		ns:      b.NS,
 		r:       r,

--- a/hypervisor/snapshot.go
+++ b/hypervisor/snapshot.go
@@ -21,9 +21,6 @@ const SnapshotMetaFile = "cocoon.json"
 type SnapshotMeta struct {
 	StorageConfigs []*types.StorageConfig `json:"storage_configs"`
 	BootConfig     *types.BootConfig      `json:"boot_config,omitempty"`
-	// CPU/Memory populated by FC only; CH reads them from config.json on restore.
-	CPU    int   `json:"cpu,omitempty"`
-	Memory int64 `json:"memory,omitempty"`
 }
 
 // RecordSnapshot generates a snapshot ID and records it on the VM's record.

--- a/hypervisor/snapshot.go
+++ b/hypervisor/snapshot.go
@@ -237,15 +237,16 @@ func PopulateFromSrc(runDir, srcDir string, clean func(string) error, clone func
 }
 
 // PreflightRestore: load+validate sidecar, run backend-specific integrity, assert snapshot role sequence is a prefix of rec.
-func PreflightRestore(srcDir, rootDir, runDir string, rec *VMRecord, integrity func(srcDir string, sidecar []*types.StorageConfig) error) error {
+// The validated meta is returned so later restore phases reuse it instead of re-reading the copied-verbatim sidecar.
+func PreflightRestore(srcDir, rootDir, runDir string, rec *VMRecord, integrity func(srcDir string, sidecar []*types.StorageConfig) error) (*SnapshotMeta, error) {
 	meta, err := LoadAndValidateMeta(srcDir, rootDir, runDir)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if err := integrity(srcDir, meta.StorageConfigs); err != nil {
-		return err
+		return nil, err
 	}
-	return ValidateRoleSequence(meta.StorageConfigs, rec.StorageConfigs)
+	return meta, ValidateRoleSequence(meta.StorageConfigs, rec.StorageConfigs)
 }
 
 func CloneStorageConfigs(storageConfigs []*types.StorageConfig) []*types.StorageConfig {

--- a/hypervisor/teardown.go
+++ b/hypervisor/teardown.go
@@ -39,7 +39,7 @@ func (b *Backend) EntryGuardLoad(ctx context.Context, id string) (VMRecord, erro
 }
 
 func (b *Backend) tombstones() *tombstone.Table {
-	return tombstone.NewTable(b.Meta, b.NS)
+	return tombstone.NewTable(b.NS)
 }
 
 // deleteVMProtocol runs the §5 phase protocol for one VM under its held ops

--- a/hypervisor/utils.go
+++ b/hypervisor/utils.go
@@ -31,8 +31,6 @@ const (
 	SnapshotFileCOW
 	// SnapshotFileMeta is small metadata that is plain-copied.
 	SnapshotFileMeta
-	// SnapshotFileSkip means the file should not be cloned.
-	SnapshotFileSkip
 
 	// OpsLockName is the legacy in-runDir lock file name, still guarded in snapshot payloads so old exports can't overwrite a held lock.
 	OpsLockName = "ops.lock"
@@ -380,7 +378,6 @@ func CloneSnapshotFiles(ctx context.Context, dstDir, srcDir string, classify fun
 			if err := CopyFile(dst, src); err != nil {
 				return fmt.Errorf("copy %s: %w", name, err)
 			}
-		case SnapshotFileSkip:
 		}
 	}
 	return copyPairs(ctx, cowPairs, utils.NoSync)

--- a/images/store.go
+++ b/images/store.go
@@ -55,7 +55,7 @@ func (s *Store[E]) applyDiff(ctx context.Context, w meta.Writer, fn func(*Index[
 	if err := fn(idx); err != nil {
 		return err
 	}
-	c := meta.NewCollection[E](s.meta, s.ns, TableRecords)
+	c := meta.NewCollection[E](s.ns, TableRecords)
 	for id := range before {
 		if idx.Images[id] == nil {
 			if err := c.Delete(ctx, w, id); err != nil {

--- a/meta/collection.go
+++ b/meta/collection.go
@@ -8,14 +8,13 @@ import (
 
 // Collection is a typed record set inside one namespace table; reads hand back detached values, persisting a change requires Replace.
 type Collection[R any] struct {
-	store Store
 	ns    string
 	table string
 }
 
-// NewCollection binds a Collection to a (namespace, table) pair on s.
-func NewCollection[R any](s Store, ns, table string) *Collection[R] {
-	return &Collection[R]{store: s, ns: ns, table: table}
+// NewCollection binds a Collection to a (namespace, table) pair.
+func NewCollection[R any](ns, table string) *Collection[R] {
+	return &Collection[R]{ns: ns, table: table}
 }
 
 // Get returns a detached copy of id, or ErrNotFound.

--- a/meta/contracttest/suite.go
+++ b/meta/contracttest/suite.go
@@ -67,7 +67,7 @@ func ForcedRetry(s meta.Store) meta.Store { return &retryStore{Store: s} }
 func testCRUD(t *testing.T, factory Factory) {
 	ctx := t.Context()
 	s := factory(t, []string{nsAlpha})
-	c := meta.NewCollection[record](s, nsAlpha, "records")
+	c := meta.NewCollection[record](nsAlpha, "records")
 
 	update(t, s, nsAlpha, func(w meta.Writer) error {
 		return c.Insert(ctx, w, "a", &record{Name: "one", N: 1})
@@ -105,7 +105,7 @@ func testCRUD(t *testing.T, factory Factory) {
 func testDetached(t *testing.T, factory Factory) {
 	ctx := t.Context()
 	s := factory(t, []string{nsAlpha})
-	c := meta.NewCollection[record](s, nsAlpha, "records")
+	c := meta.NewCollection[record](nsAlpha, "records")
 
 	in := &record{Name: nameOrig, N: 1}
 	update(t, s, nsAlpha, func(w meta.Writer) error { return c.Insert(ctx, w, "a", in) })
@@ -159,8 +159,8 @@ func testDetached(t *testing.T, factory Factory) {
 func testScope(t *testing.T, factory Factory) {
 	ctx := t.Context()
 	s := factory(t, []string{nsAlpha, nsBeta})
-	alpha := meta.NewCollection[record](s, nsAlpha, "records")
-	beta := meta.NewCollection[record](s, nsBeta, "records")
+	alpha := meta.NewCollection[record](nsAlpha, "records")
+	beta := meta.NewCollection[record](nsBeta, "records")
 
 	if err := s.Update(ctx, meta.Scope{Write: nsAlpha}, meta.CommitDurable, func(w meta.Writer) error {
 		_, err := beta.Get(ctx, w, "x")
@@ -195,7 +195,7 @@ func testScope(t *testing.T, factory Factory) {
 func testDurability(t *testing.T, factory Factory) {
 	ctx := t.Context()
 	s := factory(t, []string{nsAlpha})
-	c := meta.NewCollection[record](s, nsAlpha, "records")
+	c := meta.NewCollection[record](nsAlpha, "records")
 
 	if err := s.Update(ctx, meta.Scope{Write: nsAlpha}, meta.CommitRelaxed, func(w meta.Writer) error {
 		return c.Insert(ctx, w, "a", &record{})
@@ -215,7 +215,7 @@ func testDurability(t *testing.T, factory Factory) {
 func testForcedRetry(t *testing.T, factory Factory) {
 	ctx := t.Context()
 	s := ForcedRetry(factory(t, []string{nsAlpha}))
-	c := meta.NewCollection[record](s, nsAlpha, "records")
+	c := meta.NewCollection[record](nsAlpha, "records")
 
 	// The correct pattern: accumulate inside, publish only after nil return.
 	var out []string
@@ -258,7 +258,7 @@ func testForcedRetry(t *testing.T, factory Factory) {
 func testCtxVsHeldWriter(t *testing.T, factory Factory) {
 	ctx := t.Context()
 	s := factory(t, []string{nsAlpha})
-	c := meta.NewCollection[record](s, nsAlpha, "records")
+	c := meta.NewCollection[record](nsAlpha, "records")
 
 	held := make(chan struct{})
 	release := make(chan struct{})
@@ -294,7 +294,7 @@ func testCtxVsHeldWriter(t *testing.T, factory Factory) {
 func testViewIsolation(t *testing.T, factory Factory) {
 	ctx := t.Context()
 	s := factory(t, []string{nsAlpha})
-	c := meta.NewCollection[record](s, nsAlpha, "records")
+	c := meta.NewCollection[record](nsAlpha, "records")
 	update(t, s, nsAlpha, func(w meta.Writer) error { return c.Insert(ctx, w, "a", &record{N: 1}) })
 
 	attempted := make(chan struct{})
@@ -333,8 +333,8 @@ func testViewIsolation(t *testing.T, factory Factory) {
 func testDeadlockFreedom(t *testing.T, factory Factory) {
 	ctx := t.Context()
 	s := factory(t, []string{nsAlpha, nsBeta})
-	alpha := meta.NewCollection[record](s, nsAlpha, "records")
-	beta := meta.NewCollection[record](s, nsBeta, "records")
+	alpha := meta.NewCollection[record](nsAlpha, "records")
+	beta := meta.NewCollection[record](nsBeta, "records")
 	update(t, s, nsAlpha, func(w meta.Writer) error { return alpha.Insert(ctx, w, "x", &record{}) })
 	update(t, s, nsBeta, func(w meta.Writer) error { return beta.Insert(ctx, w, "x", &record{}) })
 
@@ -369,7 +369,7 @@ func testDeadlockFreedom(t *testing.T, factory Factory) {
 func testEvents(t *testing.T, factory Factory) {
 	ctx := t.Context()
 	s := factory(t, []string{nsAlpha})
-	c := meta.NewCollection[record](s, nsAlpha, "records")
+	c := meta.NewCollection[record](nsAlpha, "records")
 
 	ch, release, err := s.Events(ctx)
 	if err != nil {

--- a/meta/json/multiprocess_test.go
+++ b/meta/json/multiprocess_test.go
@@ -36,7 +36,7 @@ func TestMultiProcessCorrectness(t *testing.T) {
 	contracttest.WaitWorkers(t, cmds, "failed")
 
 	s := newStore(t, dir, "alpha")
-	c := meta.NewCollection[map[string]int](s, "alpha", "records")
+	c := meta.NewCollection[map[string]int]("alpha", "records")
 	if recs, err := mustGet(t, s, "alpha", "w0-op0"); err != nil || recs == nil {
 		t.Fatalf("spot check: %v %v", recs, err)
 	}
@@ -67,7 +67,7 @@ func TestMultiProcessWorker(t *testing.T) {
 		t.Fatal(err)
 	}
 	s := newStore(t, dir, "alpha")
-	c := meta.NewCollection[map[string]int](s, "alpha", "records")
+	c := meta.NewCollection[map[string]int]("alpha", "records")
 	ctx := t.Context()
 	for i := range ops {
 		id := fmt.Sprintf("w%s-op%d", worker, i)
@@ -96,7 +96,7 @@ func TestInverseScopeNoDeadlock(t *testing.T) {
 	s := newStore(t, dir, "alpha", "beta")
 	for _, ns := range []string{"alpha", "beta"} {
 		total := 0
-		c := meta.NewCollection[map[string]int](s, ns, "records")
+		c := meta.NewCollection[map[string]int](ns, "records")
 		if err := s.View(t.Context(), []string{ns}, func(r meta.Reader) error {
 			return c.Scan(t.Context(), r, func(string, *map[string]int) error {
 				total++
@@ -121,8 +121,8 @@ func TestInverseScopeWorker(t *testing.T) {
 	write, read, _ := strings.Cut(os.Getenv("META_MP_SCOPE"), ":")
 	s := newStore(t, dir, "alpha", "beta")
 	ctx := t.Context()
-	c := meta.NewCollection[map[string]int](s, write, "records")
-	peer := meta.NewCollection[map[string]int](s, read, "records")
+	c := meta.NewCollection[map[string]int](write, "records")
+	peer := meta.NewCollection[map[string]int](read, "records")
 	for i := range inverseOps {
 		id := fmt.Sprintf("w%s-op%d", worker, i)
 		if err := s.Update(ctx, meta.Scope{Write: write, Read: []string{read}}, meta.CommitDurable, func(w meta.Writer) error {
@@ -192,7 +192,7 @@ func TestAckWorker(t *testing.T) {
 	}
 	s := newStore(t, dir, "alpha")
 	ctx := t.Context()
-	c := meta.NewCollection[map[string]int](s, "alpha", "records")
+	c := meta.NewCollection[map[string]int]("alpha", "records")
 	for i := range 1000 {
 		id := fmt.Sprintf("op%d", i)
 		v := map[string]int{"n": i}
@@ -239,7 +239,7 @@ func TestEventsWriterWorker(t *testing.T) {
 	}
 	s := newStore(t, dir, "alpha")
 	ctx := t.Context()
-	c := meta.NewCollection[map[string]int](s, "alpha", "records")
+	c := meta.NewCollection[map[string]int]("alpha", "records")
 	v := map[string]int{"ext": 1}
 	if err := s.Update(ctx, meta.Scope{Write: "alpha"}, meta.CommitDurable, func(w meta.Writer) error {
 		return c.Insert(ctx, w, "ext", &v)

--- a/meta/json/store_test.go
+++ b/meta/json/store_test.go
@@ -32,7 +32,7 @@ func TestCommitAtomicityUnderCrash(t *testing.T) {
 			ctx := t.Context()
 			dir := t.TempDir()
 			s := newStore(t, dir, "alpha")
-			c := meta.NewCollection[map[string]int](s, "alpha", "records")
+			c := meta.NewCollection[map[string]int]("alpha", "records")
 
 			seed := map[string]int{"v": 1}
 			if err := s.Update(ctx, meta.Scope{Write: "alpha"}, meta.CommitDurable, func(w meta.Writer) error {
@@ -59,7 +59,7 @@ func TestCommitAtomicityUnderCrash(t *testing.T) {
 
 			// Reopen as a fresh process would and require wholly-old or wholly-new.
 			s2 := newStore(t, dir, "alpha")
-			c2 := meta.NewCollection[map[string]int](s2, "alpha", "records")
+			c2 := meta.NewCollection[map[string]int]("alpha", "records")
 			var a, b *map[string]int
 			if err := s2.View(ctx, []string{"alpha"}, func(r meta.Reader) error {
 				var err error
@@ -89,7 +89,7 @@ func TestPrevRecovery(t *testing.T) {
 	ctx := t.Context()
 	dir := t.TempDir()
 	s := newStore(t, dir, "alpha")
-	c := meta.NewCollection[map[string]int](s, "alpha", "records")
+	c := meta.NewCollection[map[string]int]("alpha", "records")
 	path := filepath.Join(dir, "alpha.json")
 
 	for gen := 1; gen <= 2; gen++ {
@@ -108,7 +108,7 @@ func TestPrevRecovery(t *testing.T) {
 	}
 
 	s2 := newStore(t, dir, "alpha")
-	c2 := meta.NewCollection[map[string]int](s2, "alpha", "records")
+	c2 := meta.NewCollection[map[string]int]("alpha", "records")
 	got, err := mustGet(t, s2, "alpha", "a")
 	if err != nil || (*got)["gen"] != 1 {
 		t.Fatalf("recovered generation: %v, %v", got, err)
@@ -162,7 +162,7 @@ func TestExternalProcessEvents(t *testing.T) {
 
 	// A second store over the same files stands in for an external process.
 	s2 := newStore(t, dir, "alpha")
-	c2 := meta.NewCollection[map[string]int](s2, "alpha", "records")
+	c2 := meta.NewCollection[map[string]int]("alpha", "records")
 	v := map[string]int{"v": 1}
 	if err := s2.Update(ctx, meta.Scope{Write: "alpha"}, meta.CommitDurable, func(w meta.Writer) error {
 		return c2.Insert(ctx, w, "a", &v)
@@ -233,7 +233,7 @@ func TestEventsForcedOverflow(t *testing.T) {
 	if err := s.events.watcher.Remove(dir); err != nil {
 		t.Fatalf("remove watch: %v", err)
 	}
-	c := meta.NewCollection[map[string]int](s, "alpha", "records")
+	c := meta.NewCollection[map[string]int]("alpha", "records")
 	v := map[string]int{"v": 1}
 	if err := s.Update(ctx, meta.Scope{Write: "alpha"}, meta.CommitDurable, func(w meta.Writer) error {
 		return c.Insert(ctx, w, "a", &v)
@@ -264,7 +264,7 @@ func TestDurableSyncOrder(t *testing.T) {
 	ctx := t.Context()
 	dir := t.TempDir()
 	s := newStore(t, dir, "alpha")
-	c := meta.NewCollection[map[string]int](s, "alpha", "records")
+	c := meta.NewCollection[map[string]int]("alpha", "records")
 
 	steps = nil
 	v := map[string]int{"n": 1}
@@ -302,7 +302,7 @@ func TestCleanUpdateSkipsCommit(t *testing.T) {
 	ctx := t.Context()
 	dir := t.TempDir()
 	s := newStore(t, dir, "alpha")
-	c := meta.NewCollection[map[string]int](s, "alpha", "records")
+	c := meta.NewCollection[map[string]int]("alpha", "records")
 	v := map[string]int{"n": 1}
 	if err := s.Update(ctx, meta.Scope{Write: "alpha"}, meta.CommitDurable, func(w meta.Writer) error {
 		return c.Insert(ctx, w, "a", &v)
@@ -337,7 +337,7 @@ func TestTrailingDataFallsBackToPrev(t *testing.T) {
 	ctx := t.Context()
 	dir := t.TempDir()
 	s := newStore(t, dir, "alpha")
-	c := meta.NewCollection[map[string]int](s, "alpha", "records")
+	c := meta.NewCollection[map[string]int]("alpha", "records")
 	path := filepath.Join(dir, "alpha.json")
 
 	for gen := 1; gen <= 2; gen++ {
@@ -381,7 +381,7 @@ func (c *crashPoint) hook(step string) error {
 
 func mustGet(t *testing.T, s *Store, ns, id string) (*map[string]int, error) {
 	t.Helper()
-	c := meta.NewCollection[map[string]int](s, ns, "records")
+	c := meta.NewCollection[map[string]int](ns, "records")
 	var rec *map[string]int
 	err := s.View(t.Context(), []string{ns}, func(r meta.Reader) error {
 		var err error

--- a/meta/namedtx.go
+++ b/meta/namedtx.go
@@ -13,17 +13,15 @@ const resolvePrefixMin = 3
 // RecordTx is the id→record map view of one table inside a transaction:
 // Get mirrors map lookup (nil when absent), Put is an upsert.
 type RecordTx[R any] struct {
-	ctx   context.Context
-	ns    string
-	table string
-	r     Reader
-	w     Writer
-	recs  *Collection[R]
+	ctx  context.Context
+	r    Reader
+	w    Writer
+	recs *Collection[R]
 }
 
 // NewRecordTx binds the view to (ns, table); w is nil in read-only transactions.
-func NewRecordTx[R any](ctx context.Context, s Store, ns, table string, r Reader, w Writer) *RecordTx[R] {
-	return &RecordTx[R]{ctx: ctx, ns: ns, table: table, r: r, w: w, recs: NewCollection[R](s, ns, table)}
+func NewRecordTx[R any](ctx context.Context, ns, table string, r Reader, w Writer) *RecordTx[R] {
+	return &RecordTx[R]{ctx: ctx, r: r, w: w, recs: NewCollection[R](ns, table)}
 }
 
 // Get mirrors items[id]: nil when absent.
@@ -69,10 +67,10 @@ type NamedTx[R any] struct {
 
 // NewNamedTx binds the pattern to (ns, recordsTable, namesTable); w is nil in
 // read-only transactions.
-func NewNamedTx[R any](ctx context.Context, s Store, ns, recordsTable, namesTable string, r Reader, w Writer) *NamedTx[R] {
+func NewNamedTx[R any](ctx context.Context, ns, recordsTable, namesTable string, r Reader, w Writer) *NamedTx[R] {
 	return &NamedTx[R]{
-		RecordTx: NewRecordTx[R](ctx, s, ns, recordsTable, r, w),
-		names:    NewCollection[string](s, ns, namesTable),
+		RecordTx: NewRecordTx[R](ctx, ns, recordsTable, r, w),
+		names:    NewCollection[string](ns, namesTable),
 	}
 }
 
@@ -130,7 +128,7 @@ func (x *NamedTx[R]) Resolve(ref string, notFound error) (string, error) {
 	if len(ref) >= resolvePrefixMin {
 		match := ""
 		ambiguous := false
-		if err := x.r.ScanRaw(x.ctx, x.ns, x.table, func(id string, _ json.RawMessage) error {
+		if err := x.r.ScanRaw(x.ctx, x.recs.ns, x.recs.table, func(id string, _ json.RawMessage) error {
 			if strings.HasPrefix(id, ref) {
 				if match != "" {
 					ambiguous = true

--- a/meta/tombstone/tombstone.go
+++ b/meta/tombstone/tombstone.go
@@ -63,9 +63,9 @@ type Table struct {
 	recs *meta.Collection[Record]
 }
 
-// NewTable binds the tombstones table in ns on s.
-func NewTable(s meta.Store, ns string) *Table {
-	return &Table{ns: ns, recs: meta.NewCollection[Record](s, ns, TableName)}
+// NewTable binds the tombstones table in ns.
+func NewTable(ns string) *Table {
+	return &Table{ns: ns, recs: meta.NewCollection[Record](ns, TableName)}
 }
 
 // Get returns id's tombstone, nil when none.

--- a/network/cni/metans.go
+++ b/network/cni/metans.go
@@ -75,5 +75,5 @@ func (c *CNI) deleteRecords(ctx context.Context, ids []string) error {
 }
 
 func (c *CNI) tx(ctx context.Context, r meta.Reader, w meta.Writer) *netTx {
-	return &netTx{RecordTx: meta.NewRecordTx[networkRecord](ctx, c.meta, NamespaceName, TableRecords, r, w)}
+	return &netTx{RecordTx: meta.NewRecordTx[networkRecord](ctx, NamespaceName, TableRecords, r, w)}
 }

--- a/network/cni/teardown.go
+++ b/network/cni/teardown.go
@@ -27,7 +27,7 @@ type netCleanupRecord struct {
 }
 
 func (c *CNI) tombstones() *tombstone.Table {
-	return tombstone.NewTable(c.meta, NamespaceName)
+	return tombstone.NewTable(NamespaceName)
 }
 
 // teardownProtocol runs the delete protocol for one VM's networking under its held VM lock; nil subset means aggregate (all records + the netns).

--- a/snapshot/localfile/localfile.go
+++ b/snapshot/localfile/localfile.go
@@ -117,24 +117,11 @@ func (lf *LocalFile) DataDir(ctx context.Context, ref string) (string, types.Sna
 
 // Create stores a snapshot via placeholder→extract→finalize; a mid-flight crash leaves a pending record for GC.
 func (lf *LocalFile) Create(ctx context.Context, cfg *types.SnapshotConfig, stream io.Reader) (_ string, err error) {
-	if cfg.ID == "" {
-		return "", fmt.Errorf("snapshot ID is required (must be set by caller)")
-	}
-	release, err := lf.acquireBuildLease(cfg.ID)
+	dataDir, done, err := lf.beginBuild(ctx, cfg)
 	if err != nil {
 		return "", err
 	}
-	defer release()
-	dataDir, err := lf.beginCreate(ctx, cfg)
-	if err != nil {
-		return "", err
-	}
-	defer func() {
-		if err != nil {
-			os.RemoveAll(dataDir) //nolint:errcheck,gosec
-			lf.rollbackCreate(ctx, cfg.ID, cfg.Name)
-		}
-	}()
+	defer done(&err)
 
 	if err = utils.EnsureDirs(dataDir); err != nil {
 		return "", err
@@ -161,24 +148,11 @@ func (lf *LocalFile) CreateFromDir(ctx context.Context, cfg *types.SnapshotConfi
 		return "", false, nil
 	}
 
-	if cfg.ID == "" {
-		return "", false, fmt.Errorf("snapshot ID is required (must be set by caller)")
-	}
-	release, err := lf.acquireBuildLease(cfg.ID)
+	dataDir, done, err := lf.beginBuild(ctx, cfg)
 	if err != nil {
 		return "", false, err
 	}
-	defer release()
-	dataDir, err := lf.beginCreate(ctx, cfg)
-	if err != nil {
-		return "", false, err
-	}
-	defer func() {
-		if err != nil {
-			os.RemoveAll(dataDir) //nolint:errcheck,gosec
-			lf.rollbackCreate(ctx, cfg.ID, cfg.Name)
-		}
-	}()
+	defer done(&err)
 
 	// A st_dev match can't rule out EXDEV (bind mounts): roll back and report ok=false so the caller streams via tar.
 	if err = osRename(srcDir, dataDir); err != nil {
@@ -324,6 +298,30 @@ func (lf *LocalFile) deleteOne(ctx context.Context, id string) error {
 	emitSnapStop(ctx, lf.metering, id, hypType)
 	// The lease file stays: flock syncs on the inode, so deleting it would split exclusion for a live waiter.
 	return nil
+}
+
+// beginBuild is the shared Create/CreateFromDir preamble: build lease + pending record; done (deferred with the caller's named error) removes the half-built dir and rolls the record back on failure, then releases the lease.
+func (lf *LocalFile) beginBuild(ctx context.Context, cfg *types.SnapshotConfig) (dataDir string, done func(*error), err error) {
+	if cfg.ID == "" {
+		return "", nil, fmt.Errorf("snapshot ID is required (must be set by caller)")
+	}
+	release, err := lf.acquireBuildLease(cfg.ID)
+	if err != nil {
+		return "", nil, err
+	}
+	dataDir, err = lf.beginCreate(ctx, cfg)
+	if err != nil {
+		release()
+		return "", nil, err
+	}
+	done = func(errp *error) {
+		if *errp != nil {
+			os.RemoveAll(dataDir) //nolint:errcheck,gosec
+			lf.rollbackCreate(ctx, cfg.ID, cfg.Name)
+		}
+		release()
+	}
+	return dataDir, done, nil
 }
 
 func (lf *LocalFile) beginCreate(ctx context.Context, cfg *types.SnapshotConfig) (string, error) {

--- a/snapshot/localfile/metans.go
+++ b/snapshot/localfile/metans.go
@@ -29,5 +29,5 @@ func (lf *LocalFile) update(ctx context.Context, fn func(*snapTx) error) error {
 }
 
 func (lf *LocalFile) tx(ctx context.Context, r meta.Reader, w meta.Writer) *snapTx {
-	return meta.NewNamedTx[snapshot.SnapshotRecord](ctx, lf.meta, NamespaceName, TableRecords, TableNames, r, w)
+	return meta.NewNamedTx[snapshot.SnapshotRecord](ctx, NamespaceName, TableRecords, TableNames, r, w)
 }

--- a/snapshot/localfile/teardown.go
+++ b/snapshot/localfile/teardown.go
@@ -22,7 +22,7 @@ type snapCleanup struct {
 }
 
 func (lf *LocalFile) tombstones() *tombstone.Table {
-	return tombstone.NewTable(lf.meta, NamespaceName)
+	return tombstone.NewTable(NamespaceName)
 }
 
 // deleteSnapshotProtocol runs the phase protocol for one snapshot under its held EXCLUSIVE lease; revalidate (optional) re-checks candidacy inside the lease transaction, and returning false skips without error.


### PR DESCRIPTION
## Problem

Every `vm clone` / `vm restore` ends with a synchronous vsock reseed of the guest CRNG. The dial cannot complete until the resumed guest wakes up and schedules the agent's accept loop, which costs tens of milliseconds — and grows with snapshot age (fresh snapshot ~11ms, 20-minute-old ~27-36ms). On a bare-metal testbed this was 35-50ms of a 55-90ms clone wall: the single largest cost on the clone path, ahead of the CH restore itself.

Warm-pool refill workloads clone long-lived golden snapshots, so they always pay the aged-snapshot path.

## Change

`reseedAfterResume` now re-execs `cocoon vm reseed` as a session-detached child (`Setsid`) instead of dialing inline:

- Same best-effort contract: the reseed lands at the same absolute time post-resume; only the CLI return advances. Spawn failure falls back to the inline path.
- Resolved `--root-dir/--run-dir/--log-dir` travel as explicit flags, so file- or flag-configured parents behave the same as env-configured ones.
- Windows guests and vsock-less VMs keep the existing inline handling (skip + warn).

## Numbers (bare-metal, CH v54.0.0, 2c/1G snapshot, same host back-to-back)

| metric | before | after |
|---|---|---|
| sequential clone, no NIC | 52-65ms | 23-30ms |
| sequential clone, `--bridge` | 66-87ms | 27-36ms |
| burst-16 clone wall | 341-356ms | 150-166ms |

Verified after the change: 16/16 burst clones agent-healthy; hot-swapped NIC up in the guest with a fresh MAC; detached child visible re-parented to init and exiting within 1s; spawn-failure fallback exercised. Dual-GOOS lint clean, tests green on darwin and linux.
