### PR TITLE
docs: point release download links at v0.5.8

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -23,10 +23,10 @@ Download pre-built binaries from [GitHub Releases](https://github.com/cocoonstac
 
 ```bash
 # Linux amd64
-curl -fsSL -o cocoon.tar.gz https://github.com/cocoonstack/cocoon/releases/download/v0.5.5/cocoon_0.5.5_Linux_x86_64.tar.gz
+curl -fsSL -o cocoon.tar.gz https://github.com/cocoonstack/cocoon/releases/download/v0.5.8/cocoon_0.5.8_Linux_x86_64.tar.gz
 
 # Linux arm64
-curl -fsSL -o cocoon.tar.gz https://github.com/cocoonstack/cocoon/releases/download/v0.5.5/cocoon_0.5.5_Linux_arm64.tar.gz
+curl -fsSL -o cocoon.tar.gz https://github.com/cocoonstack/cocoon/releases/download/v0.5.8/cocoon_0.5.8_Linux_arm64.tar.gz
 
 tar -xzf cocoon.tar.gz
 install -m 0755 cocoon /usr/local/bin/


### PR DESCRIPTION
install.md's pre-built binary links pinned v0.5.5; bumped to v0.5.8 ahead of the release. The rest of the docs were audited against the four merges (#173/#175/#176/#177) and are already current — cli.md's reconcile-stale-create section, gc.md's lock/lease-proof wording, and daemon.md's ownerless-create row all landed with their PRs.