### PR TITLE
perf(bridge): attach and configure a TAP in one netlink message

### DIFF
--- a/network/bridge/bridge_linux.go
+++ b/network/bridge/bridge_linux.go
@@ -112,36 +112,14 @@ func (b *Bridge) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, sp
 			}
 		}
 		queues := network.ResolveQueues(spec.Queues, vmCfg.CPU)
-		if cErr := network.CreateTAP(name, queues); cErr != nil {
+		tapIndex, cErr := network.CreateTAP(name, queues)
+		if cErr != nil {
 			return nil, cErr
 		}
 		added = append(added, spec.Index)
 
-		tap, lErr := netlink.LinkByName(name)
-		if lErr != nil {
-			return nil, fmt.Errorf("find tap %s: %w", name, lErr)
-		}
-
-		if mErr := netlink.LinkSetMaster(tap, br); mErr != nil {
-			return nil, fmt.Errorf("add %s to %s: %w", name, b.bridgeDev, mErr)
-		}
-
-		// Best-effort tuning, but leave a trace: a silently failed MTU sync
-		// surfaces later as a connectivity symptom with no trail back here.
-		if lErr := netlink.LinkSetLearning(tap, false); lErr != nil {
-			logger.Debugf(ctx, "disable learning on %s: %v", name, lErr)
-		}
-		if mtu := br.Attrs().MTU; mtu > 0 {
-			if mErr := netlink.LinkSetMTU(tap, mtu); mErr != nil {
-				logger.Debugf(ctx, "sync mtu %d to %s: %v", mtu, name, mErr)
-			}
-		}
-		if tErr := network.TuneTAP(tap); tErr != nil {
-			logger.Debugf(ctx, "tune tap %s: %v", name, tErr)
-		}
-
-		if uErr := netlink.LinkSetUp(tap); uErr != nil {
-			return nil, fmt.Errorf("set %s up: %w", name, uErr)
+		if aErr := network.AttachBridgeUp(tapIndex, b.bridgeIdx, br.Attrs().MTU); aErr != nil {
+			return nil, aErr
 		}
 
 		configs = append(configs, &types.NetworkConfig{

--- a/network/bridge/bridge_linux.go
+++ b/network/bridge/bridge_linux.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/projecteru2/core/log"
 	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink/nl"
+	"golang.org/x/sys/unix"
 
 	"github.com/cocoonstack/cocoon/config"
 	"github.com/cocoonstack/cocoon/gc"
@@ -118,7 +120,7 @@ func (b *Bridge) Add(ctx context.Context, vmID string, vmCfg *types.VMConfig, sp
 		}
 		added = append(added, spec.Index)
 
-		if aErr := network.AttachBridgeUp(tapIndex, b.bridgeIdx, br.Attrs().MTU); aErr != nil {
+		if aErr := attachBridgeUp(tapIndex, b.bridgeIdx, br.Attrs().MTU); aErr != nil {
 			return nil, aErr
 		}
 
@@ -177,6 +179,26 @@ func CleanupTAPs(vmIDs []string) []string {
 		cleaned = append(cleaned, vmID)
 	}
 	return cleaned
+}
+
+// attachBridgeUp enslaves a TAP to the bridge, applies MTU/txqlen/GRO tuning and brings it up in one RTM_SETLINK, paying the node-wide rtnl lock once.
+func attachBridgeUp(tapIndex, bridgeIndex, mtu int) error {
+	req := nl.NewNetlinkRequest(unix.RTM_SETLINK, unix.NLM_F_ACK)
+	msg := nl.NewIfInfomsg(unix.AF_UNSPEC)
+	msg.Index = int32(tapIndex) //nolint:gosec // kernel-issued ifindex fits int32
+	msg.Flags = unix.IFF_UP
+	msg.Change = unix.IFF_UP
+	req.AddData(msg)
+	req.AddData(nl.NewRtAttr(unix.IFLA_MASTER, nl.Uint32Attr(uint32(bridgeIndex)))) //nolint:gosec // kernel-issued ifindex fits uint32
+	req.AddData(nl.NewRtAttr(unix.IFLA_TXQLEN, nl.Uint32Attr(network.TAPTxQueueLen)))
+	req.AddData(nl.NewRtAttr(unix.IFLA_GRO_MAX_SIZE, nl.Uint32Attr(network.GROMaxSize)))
+	if mtu > 0 {
+		req.AddData(nl.NewRtAttr(unix.IFLA_MTU, nl.Uint32Attr(uint32(mtu)))) //nolint:gosec // guarded > 0; kernel MTU fits uint32
+	}
+	if _, err := req.Execute(unix.NETLINK_ROUTE, 0); err != nil {
+		return fmt.Errorf("attach tap %d to bridge %d: %w", tapIndex, bridgeIndex, err)
+	}
+	return nil
 }
 
 func tearDownTAPs(vmID string, indices []int, bestEffort bool) error {

--- a/network/cni/lifecycle_linux.go
+++ b/network/cni/lifecycle_linux.go
@@ -148,7 +148,7 @@ func tcRedirectInNS(ifName, tapName string, queues int, overrideMAC string) (str
 		}
 	}
 
-	if tapErr := network.CreateTAP(tapName, queues); tapErr != nil {
+	if _, tapErr := network.CreateTAP(tapName, queues); tapErr != nil {
 		return "", tapErr
 	}
 	tapLink, err := netlink.LinkByName(tapName)

--- a/network/tap_linux.go
+++ b/network/tap_linux.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -35,11 +36,14 @@ func CreateTAP(name string, numQueues int) (int, error) {
 	if err := netlink.LinkAdd(tap); err != nil {
 		return 0, fmt.Errorf("add tap %s: %w", name, err)
 	}
+	// netlink's post-TUNSETIFF index lookup drops its error; on a zero index drop persistence so the device dies with the fds instead of outliving the failure.
+	index := tap.Attrs().Index
+	if index == 0 {
+		_ = unix.IoctlSetInt(int(tap.Fds[0].Fd()), unix.TUNSETPERSIST, 0)
+	}
 	for _, fd := range tap.Fds {
 		_ = fd.Close()
 	}
-	// netlink's post-TUNSETIFF index lookup drops its error, so 0 can land here.
-	index := tap.Attrs().Index
 	if index == 0 {
 		return 0, fmt.Errorf("resolve index of tap %s", name)
 	}

--- a/network/tap_linux.go
+++ b/network/tap_linux.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 
 	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink/nl"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -16,8 +18,9 @@ const (
 	groMaxSize = 65536
 )
 
-// CreateTAP adds a multi-queue TAP sized for numQueues virtio-net queues, then closes the kernel fds (CH/QEMU reopen it by name).
-func CreateTAP(name string, numQueues int) error {
+// CreateTAP adds a multi-queue TAP sized for numQueues virtio-net queues and returns its index, then closes the kernel fds (CH/QEMU reopen it by name).
+// TUNSETIFF carries no index, so netlink resolves one after the ioctl and swallows a failure to; an unresolved index must not reach a caller as valid.
+func CreateTAP(name string, numQueues int) (int, error) {
 	// queue_pairs = num_queues / 2 (TX+RX pair); multi-queue needs >1 and must match the VMM's IFF_MULTI_QUEUE expectation.
 	queuePairs := max(1, numQueues/2) //nolint:mnd
 	flags := netlink.TUNTAP_VNET_HDR | netlink.TUNTAP_NO_PI
@@ -33,10 +36,35 @@ func CreateTAP(name string, numQueues int) error {
 		Flags:     flags,
 	}
 	if err := netlink.LinkAdd(tap); err != nil {
-		return fmt.Errorf("add tap %s: %w", name, err)
+		return 0, fmt.Errorf("add tap %s: %w", name, err)
 	}
 	for _, fd := range tap.Fds {
 		_ = fd.Close()
+	}
+	index := tap.Attrs().Index
+	if index == 0 {
+		return 0, fmt.Errorf("resolve index of tap %s", name)
+	}
+	return index, nil
+}
+
+// AttachBridgeUp enslaves a TAP to a bridge, applies the queue and GRO tuning and brings it up, in a single RTM_SETLINK.
+// Every netlink write serializes on the kernel's node-wide rtnl lock, so on a dense fill the op count, not the work, is the cost.
+func AttachBridgeUp(tapIndex, bridgeIndex, mtu int) error {
+	req := nl.NewNetlinkRequest(unix.RTM_SETLINK, unix.NLM_F_ACK)
+	msg := nl.NewIfInfomsg(unix.AF_UNSPEC)
+	msg.Index = int32(tapIndex)
+	msg.Flags = unix.IFF_UP
+	msg.Change = unix.IFF_UP
+	req.AddData(msg)
+	req.AddData(nl.NewRtAttr(unix.IFLA_MASTER, nl.Uint32Attr(uint32(bridgeIndex))))
+	req.AddData(nl.NewRtAttr(unix.IFLA_TXQLEN, nl.Uint32Attr(tapTxQueueLen)))
+	req.AddData(nl.NewRtAttr(unix.IFLA_GRO_MAX_SIZE, nl.Uint32Attr(groMaxSize)))
+	if mtu > 0 {
+		req.AddData(nl.NewRtAttr(unix.IFLA_MTU, nl.Uint32Attr(uint32(mtu))))
+	}
+	if _, err := req.Execute(unix.NETLINK_ROUTE, 0); err != nil {
+		return fmt.Errorf("attach tap %d to bridge %d: %w", tapIndex, bridgeIndex, err)
 	}
 	return nil
 }

--- a/network/tap_linux.go
+++ b/network/tap_linux.go
@@ -6,20 +6,17 @@ import (
 	"fmt"
 
 	"github.com/vishvananda/netlink"
-	"github.com/vishvananda/netlink/nl"
-	"golang.org/x/sys/unix"
 )
 
 const (
-	// tapTxQueueLen absorbs traffic bursts (especially UDP) without dropping; the kernel default of 1000 is too small for VM workloads.
-	tapTxQueueLen = 10000
+	// TAPTxQueueLen absorbs traffic bursts (especially UDP) without dropping; the kernel default of 1000 is too small for VM workloads.
+	TAPTxQueueLen = 10000
 
-	// groMaxSize matches the maximum virtio-net segment size so the kernel aggregates inbound packets before CH reads them.
-	groMaxSize = 65536
+	// GROMaxSize matches the maximum virtio-net segment size so the kernel aggregates inbound packets before CH reads them.
+	GROMaxSize = 65536
 )
 
 // CreateTAP adds a multi-queue TAP sized for numQueues virtio-net queues and returns its index, then closes the kernel fds (CH/QEMU reopen it by name).
-// TUNSETIFF carries no index, so netlink resolves one after the ioctl and swallows a failure to; an unresolved index must not reach a caller as valid.
 func CreateTAP(name string, numQueues int) (int, error) {
 	// queue_pairs = num_queues / 2 (TX+RX pair); multi-queue needs >1 and must match the VMM's IFF_MULTI_QUEUE expectation.
 	queuePairs := max(1, numQueues/2) //nolint:mnd
@@ -41,6 +38,7 @@ func CreateTAP(name string, numQueues int) (int, error) {
 	for _, fd := range tap.Fds {
 		_ = fd.Close()
 	}
+	// netlink's post-TUNSETIFF index lookup drops its error, so 0 can land here.
 	index := tap.Attrs().Index
 	if index == 0 {
 		return 0, fmt.Errorf("resolve index of tap %s", name)
@@ -48,31 +46,10 @@ func CreateTAP(name string, numQueues int) (int, error) {
 	return index, nil
 }
 
-// AttachBridgeUp enslaves a TAP to a bridge, applies the queue and GRO tuning and brings it up, in a single RTM_SETLINK.
-// Every netlink write serializes on the kernel's node-wide rtnl lock, so on a dense fill the op count, not the work, is the cost.
-func AttachBridgeUp(tapIndex, bridgeIndex, mtu int) error {
-	req := nl.NewNetlinkRequest(unix.RTM_SETLINK, unix.NLM_F_ACK)
-	msg := nl.NewIfInfomsg(unix.AF_UNSPEC)
-	msg.Index = int32(tapIndex)
-	msg.Flags = unix.IFF_UP
-	msg.Change = unix.IFF_UP
-	req.AddData(msg)
-	req.AddData(nl.NewRtAttr(unix.IFLA_MASTER, nl.Uint32Attr(uint32(bridgeIndex))))
-	req.AddData(nl.NewRtAttr(unix.IFLA_TXQLEN, nl.Uint32Attr(tapTxQueueLen)))
-	req.AddData(nl.NewRtAttr(unix.IFLA_GRO_MAX_SIZE, nl.Uint32Attr(groMaxSize)))
-	if mtu > 0 {
-		req.AddData(nl.NewRtAttr(unix.IFLA_MTU, nl.Uint32Attr(uint32(mtu))))
-	}
-	if _, err := req.Execute(unix.NETLINK_ROUTE, 0); err != nil {
-		return fmt.Errorf("attach tap %d to bridge %d: %w", tapIndex, bridgeIndex, err)
-	}
-	return nil
-}
-
 // TuneTAP applies best-effort performance tuning to a TAP device.
 func TuneTAP(link netlink.Link) error {
-	if err := netlink.LinkSetTxQLen(link, tapTxQueueLen); err != nil {
+	if err := netlink.LinkSetTxQLen(link, TAPTxQueueLen); err != nil {
 		return err
 	}
-	return netlink.LinkSetGROMaxSize(link, groMaxSize)
+	return netlink.LinkSetGROMaxSize(link, GROMaxSize)
 }


### PR DESCRIPTION
`Bridge.Add` issued **eight netlink calls per NIC** — `LinkAdd`, `LinkByName`, master, learning, MTU, txqlen, GRO, up. Seven of them take the kernel's node-wide `rtnl` lock, so on a dense warm-pool fill the lock, not the work, sets the ceiling.

This collapses the sequence to **two ops**: `CreateTAP` returns the index, and one `RTM_SETLINK` carries `IFLA_MASTER` + `IFLA_MTU` + `IFLA_TXQLEN` + `IFLA_GRO_MAX_SIZE` + `IFF_UP` together — the `ip link set X up master br` idiom that iproute2 has always used.

## Why `learning=false` goes with it

Nothing in this repo or in sandbox ever installed a static FDB entry, so disabling learning left the bridge FDB permanently empty and **every frame — unicast included — flooded to all ports**. That bought no isolation and cost N-fold datapath amplification: on a bridge carrying a thousand taps, ordinary DHCP traffic was enough to drive the host into a broadcast storm.

Clones already get a fresh MAC from `hotSwapNets` before resume, so learning cannot flap a shared address between ports. Verified after the change: a non-permanent FDB entry appears per guest, and guest-bound unicast stops flooding.

One caveat: an FC clone cannot swap its guest MAC before resume, so an FC bridge clone shares the source's MAC until the operator applies the CLI's repair hints. With learning on that shared MAC flaps the FDB between ports; with learning off the clone simply received *all* of the source's traffic via flooding — the pair was never a functioning config either way (both answer ARP for the same MAC-keyed DHCP lease), so this PR changes how that window fails, not whether it works.

## Measurements

A 384-core host, 512 MiB guests, one bridge, warm-pool fill driven by sandboxd.

| what | before | after |
|---|---|---|
| netlink ops per NIC | 8 | 2 |
| bridge attach, isolated, W=64 | 32.9/s | 244.7/s |
| end-to-end fill, 256 VMs, quiet console | 26.2/s | 28.0/s |
| end-to-end fill, 256 VMs, RC 192 | 38.2/s | 40.6/s |

The end-to-end win is **~7%**, not the 7x the isolated op suggests: the fill is dominated by other `rtnl` consumers this PR cannot touch — TUNSETIFF device registration, the VMM's own tap open (another TUNSETIFF per queue fd), linkwatch carrier batches, IPv6 addrconf per port-up. Fitting `X(W) = W/(P + W·S)` across six concurrency points puts the serialized component at ~16.8 ms/VM for the bridge lane against ~5.4 ms/VM for the no-NIC lane; this PR removes a few ms of it. The change is worth landing for the op-count reduction and the flooding fix, not as a fix for the lane's throughput gap.

## One caveat worth knowing before you land it

On a host that still logs to a console at default loglevel, this change is a **regression**, not a win: collapsing the ops drives more bridge-port state transitions per attach (2.2 → 4.0 `entered … state` lines), and each such line is written synchronously to the console while `rtnl` is held. On a host with two registered consoles that measured ~14 ms per line, which is more than the netlink calls this saves — a 256-VM fill went 23.3 s → 30.1 s. With the console quiet the same fill is 9.8 s → 9.1 s.

So the bridge lane wants `console_loglevel < 6` in its deployment contract. That is a host setting, not something this PR can carry.

## Behaviour and safety

- `do_setlink` applies MTU **before** enslaving, so a jumbo bridge no longer dips the port's MTU on the way in — strictly better than the old enslave-then-set order.
- Up-before-enslave is safe: a fresh TAP has no carrier until the VMM opens it, so the port cannot enter forwarding early.
- A mid-message failure (e.g. `EXFULL` at a bridge's 1024-port limit) leaves an up-but-unattached TAP; `Add`'s deferred `tearDownTAPs` is state-insensitive and already cleans that.
- netlink resolves a tuntap index with a `GETLINK` after `TUNSETIFF` and **drops the error**, so `CreateTAP` could hand back index 0. Now guarded.
- The CNI lane is untouched apart from the new `CreateTAP` signature.

## Verification

`go vet` clean on `GOOS=linux` and `GOOS=darwin`; `make fmt-check` clean. On hardware: TAP comes up with the right master/state/MTU/txqlen/GRO, guest gets its DHCP address, reaches the internet and resolves DNS, and removing the VM leaves the bridge with zero ports. The numbers above come from full 256- and 1000-VM fills.

Not covered by unit tests — the touched paths are Linux-gated and the package has no netlink test harness.

