### PR TITLE
vm: derive host CPU capacity from online cores, not process affinity

### DIFF
--- a/hypervisor/cloudhypervisor/args.go
+++ b/hypervisor/cloudhypervisor/args.go
@@ -3,7 +3,6 @@ package cloudhypervisor
 import (
 	"fmt"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 
@@ -43,10 +42,8 @@ func buildVMConfig(rec *hypervisor.VMRecord, consoleSockPath string, allowed []i
 	cpu := rec.Config.CPU
 	mem := rec.Config.Memory
 
-	maxVCPUs := runtime.NumCPU()
-
 	cfg := &chVMConfig{
-		CPUs:     chCPUs{BootVCPUs: cpu, MaxVCPUs: maxVCPUs, KVMHyperV: rec.Config.Windows},
+		CPUs:     chCPUs{BootVCPUs: cpu, MaxVCPUs: hypervisor.HostCPUCount(), KVMHyperV: rec.Config.Windows},
 		Memory:   chMemory{Size: mem, HugePages: rec.Config.HugePages, Shared: rec.Config.SharedMemory},
 		RNG:      chRNG{Src: "/dev/urandom"},
 		Watchdog: true,

--- a/hypervisor/utils.go
+++ b/hypervisor/utils.go
@@ -18,6 +18,7 @@ import (
 	"github.com/projecteru2/core/log"
 	"github.com/vishvananda/netns"
 
+	"github.com/cocoonstack/cocoon/cgroup"
 	"github.com/cocoonstack/cocoon/lock/flock"
 	"github.com/cocoonstack/cocoon/lock/vmlock"
 	"github.com/cocoonstack/cocoon/types"
@@ -48,6 +49,8 @@ const (
 
 	// socketReadyPollInterval is the WaitForSocket poll cadence — VMM socket usually appears within a few ms after process start.
 	socketReadyPollInterval = 1 * time.Millisecond
+
+	onlineCPUsPath = "/sys/devices/system/cpu/online"
 )
 
 // SnapshotFileKind classifies a snapshot file for CloneSnapshotFiles.
@@ -269,8 +272,22 @@ func MergeDirInto(src, dst string) error {
 	return nil
 }
 
+// HostCPUCount returns the host's online CPU count; runtime.NumCPU reports the process affinity mask, which undersizes guests when the control plane is core-pinned.
+func HostCPUCount() int {
+	data, err := os.ReadFile(onlineCPUsPath)
+	if err != nil {
+		return runtime.NumCPU()
+	}
+	cpus, err := cgroup.ParseCPUList(strings.TrimSpace(string(data)))
+	if err != nil || len(cpus) == 0 {
+		return runtime.NumCPU()
+	}
+	return len(cpus)
+}
+
+// ValidateHostCPU rejects vCPU counts beyond the host's online cores.
 func ValidateHostCPU(cpu int) error {
-	maxCPU := runtime.NumCPU()
+	maxCPU := HostCPUCount()
 	if cpu > maxCPU {
 		return fmt.Errorf("requested %d vCPUs exceeds host cores (%d)", cpu, maxCPU)
 	}

--- a/hypervisor/utils_test.go
+++ b/hypervisor/utils_test.go
@@ -3,12 +3,22 @@ package hypervisor
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
 
 	"github.com/cocoonstack/cocoon/types"
 )
+
+// Under a pinned test process (taskset) NumCPU shrinks to the affinity mask while HostCPUCount must keep reporting the machine.
+func TestHostCPUCount(t *testing.T) {
+	got := HostCPUCount()
+	t.Logf("HostCPUCount=%d runtime.NumCPU=%d", got, runtime.NumCPU())
+	if got < runtime.NumCPU() {
+		t.Fatalf("HostCPUCount() = %d, below runtime.NumCPU() = %d", got, runtime.NumCPU())
+	}
+}
 
 func TestValidateSnapshotIntegrity(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
Fixes #189.

`runtime.NumCPU()` returns the size of the calling process's CPU affinity mask, not the machine's core count. A control plane pinned to a reserved core (`systemd-run -p AllowedCPUs=383 cocoon vm clone ...` — the shape a `cgroup_cpus` fence deployment invites) therefore:

- hard-rejected every multi-vCPU create/clone/restore: `requested 2 vCPUs exceeds host cores (1)`
- silently collapsed CH's hotplug ceiling to `--cpus max=1` for every VM it launched

`HostCPUCount()` reads `/sys/devices/system/cpu/online` (affinity-independent, parsed with the existing `cgroup.ParseCPUList`) and falls back to `runtime.NumCPU()` where the file is unavailable (darwin). Both guest-facing sites — `ValidateHostCPU` and `buildVMConfig` — now use it. The process-concurrency sites (`pool_size` default, sqlite reader pool, `PoolSizeOrDefault`) intentionally keep `runtime.NumCPU`: affinity is the correct sizing for the process's own workers.

The fence width is deliberately not a ceiling: vCPU overcommit against the fence is legitimate (many VMs already sum past it), so the validation keeps its original meaning — reject configs that exceed the machine.

Hot-path cost: one small sysfs read per create/clone/restore/launch, dwarfed by the fork/exec and snapshot I/O around it; no caching, so CPU hotplug is always seen fresh.

Verification on a 384-core linux/amd64 host:

```
--- unpinned:
    utils_test.go:17: HostCPUCount=384 runtime.NumCPU=384
--- PASS: TestHostCPUCount (0.00s)
--- taskset -c 0:
    utils_test.go:17: HostCPUCount=384 runtime.NumCPU=1
--- PASS: TestHostCPUCount (0.00s)
```

The pinned row is exactly the #189 failure shape: the old code compared against 1, the new code sees the machine.

Gates: `make lint` (both GOOS) 0 issues, `asl ./...` (both GOOS) clean, `go test ./...` 34 packages ok.
