### PR TITLE
cgroup: explain a rejected cpuset fence write instead of surfacing bare ENOSPC

### DIFF
--- a/cgroup/cgroup.go
+++ b/cgroup/cgroup.go
@@ -272,7 +272,7 @@ func reconcileFence(parentDir, fence string) error {
 	current, err := readControl(parentDir, cpusetName)
 	if fence == "" {
 		if err == nil && current != "" {
-			return writeControl(parentDir, cpusetName, "\n")
+			return explainFenceWrite(parentDir, current, fence, writeControl(parentDir, cpusetName, "\n"))
 		}
 		return nil
 	}
@@ -288,7 +288,7 @@ func reconcileFence(parentDir, fence string) error {
 	if err := checkScopePlacements(parentDir, fence); err != nil {
 		return err
 	}
-	return writeControl(parentDir, cpusetName, fence)
+	return explainFenceWrite(parentDir, current, fence, writeControl(parentDir, cpusetName, fence))
 }
 
 // placeScope applies a per-VM placement; the kernel silently degrades ungrantable requests to the parent set, so the subset check is cocoon's.
@@ -353,6 +353,18 @@ func checkScopePlacements(parentDir, fence string) error {
 		}
 	}
 	return nil
+}
+
+// explainFenceWrite names the live VMs behind a rejected fence write: the kernel refuses to re-home populated cgroups and reports only ENOSPC, which reads as an unrelated disk-full error.
+func explainFenceWrite(parentDir, current, fence string, err error) error {
+	if err == nil {
+		return nil
+	}
+	ids, listErr := ListScopeVMIDs(parentDir)
+	if listErr != nil || len(ids) == 0 {
+		return err
+	}
+	return fmt.Errorf("cgroup_cpus %q -> %q rejected with %d VM(s) running; the fence is machine-wide, drain them first: %w", current, fence, len(ids), err)
 }
 
 func forEachLevel(rel string, fn func(dir string) error) error {

--- a/cgroup/cgroup_test.go
+++ b/cgroup/cgroup_test.go
@@ -1,6 +1,7 @@
 package cgroup
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"slices"
@@ -207,6 +208,29 @@ func TestReconcileFenceCanonicalEquality(t *testing.T) {
 	// No cpuset.cpus.effective fixture exists: reaching checkSubset would fail, so success proves the parsed-set gate short-circuited.
 	if err := reconcileFence(parent, "0-3,4-7"); err != nil {
 		t.Errorf("canonically-equal fence rewrote: %v", err)
+	}
+}
+
+func TestExplainFenceWriteNamesLiveVMs(t *testing.T) {
+	parent := t.TempDir()
+	enospc := errors.New("no space left on device")
+
+	if got := explainFenceWrite(parent, "0-14", "", enospc); got != enospc {
+		t.Errorf("no live scope: got %v, want the error unchanged", got)
+	}
+	if got := explainFenceWrite(parent, "0-14", "", nil); got != nil {
+		t.Errorf("successful write: got %v, want nil", got)
+	}
+
+	if err := os.Mkdir(ScopeDir(parent, "X"), 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	got := explainFenceWrite(parent, "0-14", "", enospc)
+	if !errors.Is(got, enospc) {
+		t.Fatalf("wrapped error dropped the cause: %v", got)
+	}
+	if !strings.Contains(got.Error(), "1 VM(s) running") {
+		t.Errorf("message does not name the live VMs: %v", got)
 	}
 }
 


### PR DESCRIPTION
Changing `cgroup_cpus` while VM scopes are live makes the kernel reject the `cpuset.cpus` write with `ENOSPC`. What the operator sees is:

```
Error: clone VM: launch CH: prepare cgroup scope:
       write /sys/fs/cgroup/cocoon.slice/cpuset.cpus: no space left on device
```

That points at the disk, not at the fence. Hit while benchmarking a 120-VM Windows fleet; it cost about half an hour to trace, and the first hypothesis was a cocoon bug rather than an operator error.

`checkScopePlacements` does not catch this: it only inspects scopes that carry an *explicit* `cpuset.cpus`, and skips inheriting ones — which are the common case, since most fleets never set a per-VM placement. The clear-fence branch (`fence == ""`) had no check at all, and that is the path that failed.

This wraps the write error with the current fence, the requested one, and the number of running VMs:

```
cgroup_cpus "0-24" -> "" rejected with 29 VM(s) running;
the fence is machine-wide, drain them first: ... no space left on device
```

Deliberately an annotation rather than a pre-flight refusal: narrowing the fence *did* succeed on a live fleet in the same session, so refusing every change while scopes exist would regress a path that works today. The wrap only fires when the kernel has already said no.

`make lint` clean on both `GOOS`, `asl ./...` clean on both, `go test ./cgroup/...` green.
