### PR TITLE
review: apply the August asl layout rules

### DIFF
--- a/hypervisor/baseconfig.go
+++ b/hypervisor/baseconfig.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/cocoonstack/cocoon/config"
-	"github.com/cocoonstack/cocoon/types"
 	"github.com/cocoonstack/cocoon/utils"
 )
 
@@ -76,7 +75,7 @@ func (c *BaseConfig) LoadAndValidateMeta(dir string) (*SnapshotMeta, error) {
 }
 
 // PreflightRestore runs the shared restore preflight against this backend's managed roots.
-func (c *BaseConfig) PreflightRestore(srcDir string, rec *VMRecord, integrity func(srcDir string, sidecar []*types.StorageConfig) error) (*SnapshotMeta, error) {
+func (c *BaseConfig) PreflightRestore(srcDir string, rec *VMRecord, integrity IntegrityCheck) (*SnapshotMeta, error) {
 	return PreflightRestore(srcDir, c.RootDir, c.Config.RunDir, rec, integrity)
 }
 

--- a/hypervisor/firecracker/relay.go
+++ b/hypervisor/firecracker/relay.go
@@ -68,6 +68,33 @@ func (b *broadcaster) readLoop() {
 	}
 }
 
+// cloneLeaseControl is the parent's half of the relay lease protocol; a nil control (no leases held) no-ops.
+type cloneLeaseControl struct {
+	commands  *os.File
+	responses *os.File
+}
+
+func (c *cloneLeaseControl) close() {
+	if c == nil {
+		return
+	}
+	closeFile(c.commands)
+	closeFile(c.responses)
+	c.commands = nil
+	c.responses = nil
+}
+
+func (c *cloneLeaseControl) commit() error {
+	if c == nil {
+		return nil
+	}
+	defer c.close()
+	if _, err := c.commands.Write([]byte{relayCommitLeasesCommand}); err != nil {
+		return err
+	}
+	return waitRelayLeaseResponse(c.responses, relayLeaseCommitAck, "commit")
+}
+
 // IsRelayMode returns true when the process was started as a console relay.
 func IsRelayMode() bool {
 	return os.Getenv(relayEnvKey) == "1"

--- a/hypervisor/firecracker/start.go
+++ b/hypervisor/firecracker/start.go
@@ -122,6 +122,11 @@ func (fc *Firecracker) configureVM(ctx context.Context, hc *http.Client, rec *hy
 	return nil
 }
 
+func (fc *Firecracker) launchProcess(ctx context.Context, rec *hypervisor.VMRecord, sockPath, netnsPath string, deferQuota bool) (int, error) {
+	pid, _, err := fc.launchProcessWithLeases(ctx, rec, sockPath, netnsPath, nil, deferQuota)
+	return pid, err
+}
+
 // cloneLeaseControl is the parent's half of the relay lease protocol; a nil control (no leases held) no-ops.
 type cloneLeaseControl struct {
 	commands  *os.File
@@ -147,11 +152,6 @@ func (c *cloneLeaseControl) commit() error {
 		return err
 	}
 	return waitRelayLeaseResponse(c.responses, relayLeaseCommitAck, "commit")
-}
-
-func (fc *Firecracker) launchProcess(ctx context.Context, rec *hypervisor.VMRecord, sockPath, netnsPath string, deferQuota bool) (int, error) {
-	pid, _, err := fc.launchProcessWithLeases(ctx, rec, sockPath, netnsPath, nil, deferQuota)
-	return pid, err
 }
 
 // launchProcessWithLeases keeps inherited source-VM leases in the console relay until the caller confirms clone setup.

--- a/hypervisor/firecracker/start.go
+++ b/hypervisor/firecracker/start.go
@@ -127,33 +127,6 @@ func (fc *Firecracker) launchProcess(ctx context.Context, rec *hypervisor.VMReco
 	return pid, err
 }
 
-// cloneLeaseControl is the parent's half of the relay lease protocol; a nil control (no leases held) no-ops.
-type cloneLeaseControl struct {
-	commands  *os.File
-	responses *os.File
-}
-
-func (c *cloneLeaseControl) close() {
-	if c == nil {
-		return
-	}
-	closeFile(c.commands)
-	closeFile(c.responses)
-	c.commands = nil
-	c.responses = nil
-}
-
-func (c *cloneLeaseControl) commit() error {
-	if c == nil {
-		return nil
-	}
-	defer c.close()
-	if _, err := c.commands.Write([]byte{relayCommitLeasesCommand}); err != nil {
-		return err
-	}
-	return waitRelayLeaseResponse(c.responses, relayLeaseCommitAck, "commit")
-}
-
 // launchProcessWithLeases keeps inherited source-VM leases in the console relay until the caller confirms clone setup.
 func (fc *Firecracker) launchProcessWithLeases(ctx context.Context, rec *hypervisor.VMRecord, sockPath, netnsPath string, leaseFiles []*os.File, deferQuota bool) (int, *cloneLeaseControl, error) {
 	logger := log.WithFunc("firecracker.launchProcessWithLeases")

--- a/hypervisor/snapshot.go
+++ b/hypervisor/snapshot.go
@@ -23,6 +23,9 @@ type SnapshotMeta struct {
 	BootConfig     *types.BootConfig      `json:"boot_config,omitempty"`
 }
 
+// IntegrityCheck verifies the snapshot files under srcDir against the sidecar's storage configs.
+type IntegrityCheck func(srcDir string, sidecar []*types.StorageConfig) error
+
 // RecordSnapshot generates a snapshot ID and records it on the VM's record.
 func (b *Backend) RecordSnapshot(ctx context.Context, vmID string) (string, error) {
 	snapID := utils.GenerateID()
@@ -235,7 +238,7 @@ func PopulateFromSrc(runDir, srcDir string, clean func(string) error, clone func
 }
 
 // PreflightRestore loads and validates the sidecar, runs the backend integrity check and asserts the snapshot role sequence prefixes rec; the validated meta is returned so later phases skip re-reading it.
-func PreflightRestore(srcDir, rootDir, runDir string, rec *VMRecord, integrity func(srcDir string, sidecar []*types.StorageConfig) error) (*SnapshotMeta, error) {
+func PreflightRestore(srcDir, rootDir, runDir string, rec *VMRecord, integrity IntegrityCheck) (*SnapshotMeta, error) {
 	meta, err := LoadAndValidateMeta(srcDir, rootDir, runDir)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
`asl` (CMGS/asl at dc48996) now mechanizes more of the layout rules of the code-style standard; this branch clears every finding it reports on this repository.

- `hypervisor/baseconfig.go`, `hypervisor/snapshot.go`: the integrity callback `func(srcDir string, sidecar []*types.StorageConfig) error` was spelled in both `PreflightRestore` signatures → named `hypervisor.IntegrityCheck` (functypedup)
- `hypervisor/firecracker/start.go`, `hypervisor/firecracker/relay.go`: the `cloneLeaseControl` block sat inside the `Firecracker` method set, splitting the launch sequence (methodinterleave). It is the parent's half of the relay lease protocol, so it moves beside the child's half in `relay.go`; `start.go` keeps its original method order.

Gates: `asl ./...` clean on darwin and linux; `go build` and `go vet` on both GOOS; `go test ./hypervisor/...`; `make lint` (golangci-lint v2.12.2) 0 issues on both GOOS.
